### PR TITLE
Resolve wrong mapping of setMetadata property to JSON key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scrap
 .env
 src/run.ts
 .vscode
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinecone-database/pinecone",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinecone-database/pinecone",
-      "version": "0.0.11",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinecone-database/pinecone",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinecone-database/pinecone",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "dist/index.js",
   "repository": {
     "type": "git",

--- a/src/pinecone-generated-ts-fetch/models/UpdateRequest.ts
+++ b/src/pinecone-generated-ts-fetch/models/UpdateRequest.ts
@@ -80,8 +80,8 @@ export function UpdateRequestFromJSONTyped(json: any, ignoreDiscriminator: boole
         
         'id': json['id'],
         'values': !exists(json, 'values') ? undefined : json['values'],
-        'sparseValues': !exists(json, 'sparseValues') ? undefined : SparseValuesFromJSON(json['sparseValues']),
-        'setMetadata': !exists(json, 'setMetadata') ? undefined : json['setMetadata'],
+        'sparseValues': !exists(json, 'sparse_values') ? undefined : SparseValuesFromJSON(json['sparse_values']),
+        'setMetadata': !exists(json, 'set_metadata') ? undefined : json['set_metadata'],
         'namespace': !exists(json, 'namespace') ? undefined : json['namespace'],
     };
 }

--- a/src/pinecone-generated-ts-fetch/models/UpdateRequest.ts
+++ b/src/pinecone-generated-ts-fetch/models/UpdateRequest.ts
@@ -97,8 +97,8 @@ export function UpdateRequestToJSON(value?: UpdateRequest | null): any {
         
         'id': value.id,
         'values': value.values,
-        'sparseValues': SparseValuesToJSON(value.sparseValues),
-        'setMetadata': value.setMetadata,
+        'sparse_values': SparseValuesToJSON(value.sparseValues),
+        'set_metadata': value.setMetadata,
         'namespace': value.namespace,
     };
 }


### PR DESCRIPTION
Resolves incorrect JSON mapping of sparseValues and setMetadata update parameters to raw Pinecone API json object.

This new mapping mirrors the mapping currently in use by the Pinecone-Python-Client here: https://github.com/pinecone-io/pinecone-python-client/blob/0186064d2c563c3bac41b9b86699cd5133e18411/pinecone/core/client/model/update_request.py#L113