### PR TITLE
feat: only call process if it exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,9 @@ class PineconeClient {
     let response
     try {
       // Workaround for Jest TLSWRAP issue
-      await process.nextTick(() => { });
+      if (typeof process === 'object') {
+        await process.nextTick(() => { });
+      }
       response = await fetch(whoami, request);
       if (response.status !== 200) {
         const error = await response.text();


### PR DESCRIPTION
## Problem

The Pinecone client library doesn't work in Cloudflare Workers without `node_compat = true`, which isn't ideal for users. The only reason this is the case is the call to `process.nextTick()` here: https://github.com/pinecone-io/pinecone-ts-client/blob/77ec3aea0a6da2cfccf129f68f1b986e4aad1bc5/src/index.ts#LL108C21-L108C29%60

https://gist.github.com/elithrar/d425ef2e91cc795d36864f39deeaec75

## Solution

This allows the library to run natively in Cloudflare Workers: `process.nextTick()` is only called if `process` exists within the environment.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

No test should be needed.
