### PR TITLE
Ship nightly developer builds using @next tag

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Pinecone CI
+name: Pull Request
 
 on:
   pull_request: {}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,33 @@
+name: 'Release: @next nightly dev build'
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  version-and-release:
+    name: Release dev build to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+              
+      - name: 'Bump version, do not commit'
+        shell: bash
+        run: |
+          currentVersion=$(jq -r '.version' package.json)
+          timestamp=$(date +%Y%m%d%H%M%S)
+          devVersion="$currentVersion-dev.$timestamp"
+          jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
+          jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
+          jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
+
+      - name: 'Publish to npm'
+        run: npm publish --tag next --dry-run
+        shell: bash
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-              
+
       - name: 'Bump version, do not commit'
         shell: bash
         run: |
@@ -30,4 +30,4 @@ jobs:
         run: npm publish --tag next --dry-run
         shell: bash
         env:
-            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-      
+
       - name: Version and publish to npm
         id: npm-release
         uses: ./.github/actions/npm-release

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,4 +1,4 @@
-name: Release to NPM
+name: 'Release: @latest production build'
 
 on:
   workflow_dispatch:
@@ -33,12 +33,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Show debug info
-        run: |
-          echo "Release type: ${{ github.event.inputs.releaseType }}"
-          git status
+      
       - name: Version and publish to npm
         id: npm-release
         uses: ./.github/actions/npm-release

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "build": "tsc",
     "format": "prettier --write .",
-    "test": "jest --runInBand --detectOpenHandles",
-    "prepublishOnly": "git push --follow-tags"
+    "test": "jest --runInBand --detectOpenHandles"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
## Problem

We need a way to easily share and consume unreleased work in progress. This will support testing and documentation efforts.

## Solution

- Create a new release workflow that runs nightly and publishes a timestamped build under the `@next` tag. Testers should be able to access the latest work in progress by installing `npm install @pinecone-database/pinecone@next`. 
- Those who install without specifying the `@next` tag will continue to get the `@latest` tag, which is attached by default in our normal release workflow and requested by default in a normal install.

I had to write a few lines of my own code to create the timestamped build numbers. The `npm version` command has some limited support for versioning prereleases, but it's setup in a way that assumes long-lived git branches that doesn't really match our situation.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

I tested the script lines doing the version change to package.json and package-lock.json on my local machine.