### PR TITLE
Remove `dist/` directory before every build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist/ && tsc",
     "format": "prettier --write .",
     "repl": "npm run build && node utils/replInit.ts",
     "test:legacy": "jest --runInBand --detectOpenHandles tests/legacy-integration/",


### PR DESCRIPTION
## Problem

In the past, the `dist/` directory was never cleaned up after the initial build. So if you change the structure of your modules at any time during development, you can get unpredictable behavior. 

In my specific case, during development I initially implemented some error classes in a `src/errors.ts` file, built the project with `npm run build` which resulted in compilation output written to `dist/errors.js`.  Then later as the number of error classes grew I decided to refactor and create an errors submodule with exports declared from `src/errors/index.ts`. After the refactor, a `dist/errors/index.js` got added to the dist output. But since the top-level `dist/errors.js` file was hanging around from an earlier build, that made it impossible for javascript to see items in the `dist/errors/index.js` file when importing things via `require('./errors')`. This caused the symptom I experienced, of some exports being inexplicably missing.

The fact this was possible is just another reason it's so important we recently implemented a process to release from CI where these transient development states can never exist and get erroneously packaged into the published module.

## Solution

Pretty self-explanatory. Delete `dist/` to clean before rebuilding the project.

## Type of Change

- [x] Infrastructure change (CI configs, etc)
