### PR TITLE
[v1] Implement `createIndex` and `deleteIndex`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 src/pinecone-generated-ts-fetch
+src/v0

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -8,7 +8,7 @@ describe('Client', () => {
           // @ts-ignore
           new Client();
         }).toThrow(
-          'Configuration passed to Client constructor had a problem: must be object. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io'
+          'Configuration passed to Client constructor had a problem. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io'
         );
       });
 
@@ -17,7 +17,7 @@ describe('Client', () => {
           // @ts-ignore
           new Client({ apiKey: 'test-key' });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem: must have required property 'environment'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The argument must have required property 'environment'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
 
         expect(() => {
@@ -26,7 +26,7 @@ describe('Client', () => {
             environment: 'test-environment',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem: must have required property 'apiKey'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The argument must have required property 'apiKey'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
       });
 
@@ -38,7 +38,7 @@ describe('Client', () => {
             apiKey: 'test-key',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem: the field 'environment' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The property 'environment' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
 
         expect(() => {
@@ -48,7 +48,7 @@ describe('Client', () => {
             apiKey: '',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem: the field 'apiKey' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The property 'apiKey' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
       });
     });
@@ -64,7 +64,7 @@ describe('Client', () => {
             unknownProp: 'banana',
           } as any);
         }).toThrow(
-          'Configuration passed to Client constructor had a problem: must NOT have additional properties. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io'
+          'Configuration passed to Client constructor had a problem. The argument must NOT have additional properties. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io'
         );
       });
     });

--- a/src/control/__tests__/createIndex.test.ts
+++ b/src/control/__tests__/createIndex.test.ts
@@ -1,0 +1,23 @@
+import { createIndex } from '../createIndex';
+import { IndexOperationsApi } from '../../pinecone-generated-ts-fetch';
+
+describe('createIndex', () => {
+  let IOA: IndexOperationsApi;
+  beforeEach(() => {
+    // @ts-ignore
+    IOA = { createIndex: jest.fn() };
+    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+      IndexOperationsApi: IOA,
+    }));
+  });
+
+  test('calls the create endpoint', async () => {
+    const returned = await createIndex(IOA)({
+      name: 'index-name',
+      dimension: 10,
+    });
+
+    expect(returned).toBe(void 0);
+    expect(IOA.createIndex).toHaveBeenCalled();
+  });
+});

--- a/src/control/__tests__/createIndex.validation.test.ts
+++ b/src/control/__tests__/createIndex.validation.test.ts
@@ -1,0 +1,246 @@
+// @ts-nocheck
+
+// Disabling typescript in this file because the entire point is to catch
+// cases where library callers (who may not be using typescript) pass
+// incorrect argument values.
+
+import { createIndex } from '../createIndex';
+import { PineconeArgumentError } from '../../errors';
+import { IndexOperationsApi } from '../../pinecone-generated-ts-fetch';
+
+describe('createIndex argument validations', () => {
+  let IOA: IndexOperationsApi;
+  beforeEach(() => {
+    IOA = { createIndex: jest.fn() };
+    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+      IndexOperationsApi: IOA,
+    }));
+  });
+
+  describe('required configurations', () => {
+    test('should throw if index name is not provided', async () => {
+      const toThrow = async () => await createIndex(IOA)();
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        'Argument to createIndex has a problem. The argument must be object.'
+      );
+    });
+
+    test('should throw if index name is not a string', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({ name: 12, dimension: 10 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'name' must be string."
+      );
+    });
+
+    test('should throw if index name is empty string', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({ name: '', dimension: 10 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'name' must not be blank."
+      );
+    });
+
+    test('should throw if dimension is not provided', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({ name: 'index-name' });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The argument must have required property 'dimension'."
+      );
+    });
+
+    test('should throw if dimension is not a number', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({ name: 'index-name', dimension: '10' });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'dimension' must be integer."
+      );
+    });
+
+    test('should throw if dimension is float', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({ name: 'index-name', dimension: 10.5 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'dimension' must be integer."
+      );
+    });
+
+    test('should throw if dimension is not a positive integer', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({ name: 'index-name', dimension: -10 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'dimension' must be >= 1."
+      );
+    });
+  });
+
+  describe('optional configurations', () => {
+    test('metric: should throw if not a string', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          metric: 10,
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'metric' must be string."
+      );
+    });
+
+    test('metric: should throw if blank string', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          metric: '',
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'metric' must not be blank."
+      );
+    });
+
+    test('replicas: should throw if not an integer', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          replicas: '10',
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'replicas' must be integer."
+      );
+    });
+
+    test('replicas: should throw if not a positive integer', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          replicas: -10,
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'replicas' must be >= 1."
+      );
+    });
+
+    test('podType: should throw if not a string', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          podType: 10,
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'podType' must be string."
+      );
+    });
+
+    test('podType: should throw if not a valid pod type', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          podType: '',
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'podType' must not be blank."
+      );
+    });
+
+    test('pods: should throw if not an integer', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          pods: '10',
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'pods' must be integer."
+      );
+    });
+
+    test('pods: should throw if not a positive integer', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          pods: -10,
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'pods' must be >= 1."
+      );
+    });
+
+    test('metadataConfig: should throw if not an object', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          metadataConfig: '{}',
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'metadataConfig' must be object."
+      );
+    });
+
+    test('sourceCollection: should throw if not a string', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          sourceCollection: 10,
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'sourceCollection' must be string."
+      );
+    });
+
+    test('sourceCollection: should throw if blank string', async () => {
+      const toThrow = async () =>
+        await createIndex(IOA)({
+          name: 'index-name',
+          dimension: 10,
+          sourceCollection: '',
+        });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createIndex has a problem. The property 'sourceCollection' must not be blank."
+      );
+    });
+  });
+});

--- a/src/control/__tests__/deleteIndex.test.ts
+++ b/src/control/__tests__/deleteIndex.test.ts
@@ -1,108 +1,60 @@
-import { describeIndex } from '../describeIndex';
+import { deleteIndex } from '../deleteIndex';
 import {
   PineconeArgumentError,
   PineconeInternalServerError,
   PineconeNotFoundError,
 } from '../../errors';
 
-describe('describeIndex', () => {
-  const responseData = Object.freeze({
-    database: {
-      name: 'test-index',
-      dimensions: undefined,
-      indexType: undefined,
-      metric: 'cosine',
-      pods: 1,
-      replicas: 1,
-      shards: 1,
-      podType: 'p1.x1',
-      indexConfig: undefined,
-      metadataConfig: undefined,
-    },
-    status: { ready: true, state: 'Ready' },
-  });
-
-  test('should remove undefined fields from response', async () => {
-    const IOA = {
-      describeIndex: jest
-        .fn()
-        .mockImplementation(() => Promise.resolve(responseData)),
-    };
-    jest.mock('../../pinecone-generated-ts-fetch', () => ({
-      IndexOperationsApi: IOA,
-    }));
-
-    // @ts-ignore
-    const returned = await describeIndex(IOA)('index-name');
-
-    expect(returned).toEqual({
-      database: {
-        name: 'test-index',
-        metric: 'cosine',
-        pods: 1,
-        replicas: 1,
-        shards: 1,
-        podType: 'p1.x1',
-      },
-      status: { ready: true, state: 'Ready' },
-    });
-  });
-
+describe('deleteIndex', () => {
   describe('argument validation', () => {
     test('should throw if index name is not provided', async () => {
       const IOA = {
-        describeIndex: jest
-          .fn()
-          .mockImplementation(() => Promise.resolve(responseData)),
+        deleteIndex: jest.fn().mockImplementation(() => Promise.resolve('')),
       };
       jest.mock('../../pinecone-generated-ts-fetch', () => ({
         IndexOperationsApi: IOA,
       }));
 
       // @ts-ignore
-      const expectToThrow = async () => await describeIndex(IOA)();
+      const expectToThrow = async () => await deleteIndex(IOA)();
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeIndex has a problem. The argument must be string.'
+        'Argument to deleteIndex has a problem. The argument must be string.'
       );
     });
 
     test('should throw if index name is not a string', async () => {
       const IOA = {
-        describeIndex: jest
-          .fn()
-          .mockImplementation(() => Promise.resolve(responseData)),
+        deleteIndex: jest.fn().mockImplementation(() => Promise.resolve('')),
       };
       jest.mock('../../pinecone-generated-ts-fetch', () => ({
         IndexOperationsApi: IOA,
       }));
 
       // @ts-ignore
-      const expectToThrow = async () => await describeIndex(IOA)({});
+      const expectToThrow = async () => await deleteIndex(IOA)({});
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeIndex has a problem. The argument must be string.'
+        'Argument to deleteIndex has a problem. The argument must be string.'
       );
     });
 
     test('should throw if index name is empty string', async () => {
       const IOA = {
-        describeIndex: jest
-          .fn()
-          .mockImplementation(() => Promise.resolve(responseData)),
+        deleteIndex: jest.fn().mockImplementation(() => Promise.resolve('')),
       };
       jest.mock('../../pinecone-generated-ts-fetch', () => ({
         IndexOperationsApi: IOA,
       }));
 
       // @ts-ignore
-      const expectToThrow = async () => await describeIndex(IOA)('');
+      const expectToThrow = async () => await deleteIndex(IOA)('');
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeIndex has a problem. The argument must not be blank.'
+        'Argument to deleteIndex has a problem. The argument must not be blank.'
       );
     });
   });
@@ -110,7 +62,7 @@ describe('describeIndex', () => {
   describe('uses http error mapper', () => {
     test('it should map errors with the http error mapper (500)', async () => {
       const IOA = {
-        describeIndex: jest
+        deleteIndex: jest
           .fn()
           .mockImplementation(() =>
             Promise.reject({ response: { status: 500 } })
@@ -121,7 +73,7 @@ describe('describeIndex', () => {
       }));
 
       // @ts-ignore
-      const expectToThrow = async () => await describeIndex(IOA)('index-name');
+      const expectToThrow = async () => await deleteIndex(IOA)('index-name');
 
       expect(expectToThrow).rejects.toThrowError(PineconeInternalServerError);
     });
@@ -130,7 +82,7 @@ describe('describeIndex', () => {
   describe('custom error mapping', () => {
     test('not found (404), fetches and shows available index names', async () => {
       const IOA = {
-        describeIndex: jest
+        deleteIndex: jest
           .fn()
           .mockImplementation(() =>
             Promise.reject({ response: { status: 404 } })
@@ -144,7 +96,7 @@ describe('describeIndex', () => {
       }));
 
       // @ts-ignore
-      const expectToThrow = async () => await describeIndex(IOA)('index-name');
+      const expectToThrow = async () => await deleteIndex(IOA)('index-name');
 
       expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
       expect(expectToThrow).rejects.toThrowError(
@@ -154,7 +106,7 @@ describe('describeIndex', () => {
 
     test('not found (404), fetches and shows available index names (empty list)', async () => {
       const IOA = {
-        describeIndex: jest
+        deleteIndex: jest
           .fn()
           .mockImplementation(() =>
             Promise.reject({ response: { status: 404 } })
@@ -166,7 +118,7 @@ describe('describeIndex', () => {
       }));
 
       // @ts-ignore
-      const expectToThrow = async () => await describeIndex(IOA)('index-name');
+      const expectToThrow = async () => await deleteIndex(IOA)('index-name');
 
       expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
       expect(expectToThrow).rejects.toThrowError(
@@ -176,7 +128,7 @@ describe('describeIndex', () => {
 
     test('not found (404), error while fetching index list', async () => {
       const IOA = {
-        describeIndex: jest
+        deleteIndex: jest
           .fn()
           .mockImplementation(() =>
             Promise.reject({ response: { status: 404 } })
@@ -190,7 +142,7 @@ describe('describeIndex', () => {
       }));
 
       // @ts-ignore
-      const expectToThrow = async () => await describeIndex(IOA)('index-name');
+      const expectToThrow = async () => await deleteIndex(IOA)('index-name');
 
       expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
       expect(expectToThrow).rejects.toThrowError(

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -1,0 +1,46 @@
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+import { mapHttpStatusError } from '../errors';
+import { builOptionConfigValidator } from '../validator';
+
+import { Static, Type } from '@sinclair/typebox';
+
+const nonemptyString = Type.String({ minLength: 1 });
+const positiveInteger = Type.Integer({ minimum: 1 });
+
+const CreateIndexOptionsSchema = Type.Object({
+  name: nonemptyString,
+  dimension: positiveInteger,
+  metric: Type.Optional(nonemptyString),
+  pods: Type.Optional(positiveInteger),
+  replicas: Type.Optional(positiveInteger),
+  podType: Type.Optional(nonemptyString),
+  metadataConfig: Type.Optional(Type.Object({})),
+  sourceCollection: Type.Optional(nonemptyString),
+});
+
+export type CreateIndexOptions = Static<typeof CreateIndexOptionsSchema>;
+
+export const createIndex = (api: IndexOperationsApi) => {
+  const validator = builOptionConfigValidator(
+    CreateIndexOptionsSchema,
+    'createIndex'
+  );
+
+  return async (options: CreateIndexOptions): Promise<void> => {
+    validator(options);
+
+    try {
+      await api.createIndex({ createRequest: options });
+      return;
+    } catch (e) {
+      const createIndexError = e as ResponseError;
+      const message = await createIndexError.response.text();
+      throw mapHttpStatusError({
+        status: createIndexError.response.status,
+        url: createIndexError.response.url,
+        message: message,
+      });
+    }
+  };
+};

--- a/src/control/deleteIndex.ts
+++ b/src/control/deleteIndex.ts
@@ -1,0 +1,42 @@
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+import { mapHttpStatusError } from '../errors';
+import { builOptionConfigValidator } from '../validator';
+import { Static, Type } from '@sinclair/typebox';
+import { validIndexMessage } from './utils';
+
+const DescribeIndexSchema = Type.String({ minLength: 1 });
+export type IndexName = Static<typeof DescribeIndexSchema>;
+
+export const deleteIndex = (api: IndexOperationsApi) => {
+  const validator = builOptionConfigValidator(
+    DescribeIndexSchema,
+    'deleteIndex'
+  );
+
+  return async (indexName: IndexName): Promise<void> => {
+    validator(indexName);
+
+    try {
+      await api.deleteIndex({ indexName: indexName });
+      return;
+    } catch (e) {
+      const deleteError = e as ResponseError;
+      const requestInfo = {
+        status: deleteError.response.status,
+      };
+
+      let toThrow;
+      if (requestInfo.status === 404) {
+        const message = await validIndexMessage(api, indexName, requestInfo);
+        toThrow = mapHttpStatusError({ ...requestInfo, message });
+      } else {
+        // 500? 401? This logical branch is not generally expected. Let
+        // the http error mapper handle it, but we can't write a
+        // message because we don't know what went wrong.
+        toThrow = mapHttpStatusError(requestInfo);
+      }
+      throw toThrow;
+    }
+  };
+};

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -2,3 +2,6 @@ export { describeIndex } from './describeIndex';
 export type { IndexName } from './describeIndex';
 export { listIndexes } from './listIndexes';
 export { IndexList } from './listIndexes';
+export { createIndex } from './createIndex';
+export type { CreateIndexOptions } from './createIndex';
+export { deleteIndex } from './deleteIndex';

--- a/src/control/utils.ts
+++ b/src/control/utils.ts
@@ -1,0 +1,24 @@
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { FailedRequestInfo } from '../errors';
+import { mapHttpStatusError } from '../errors';
+
+export const validIndexMessage = async (
+  api: IndexOperationsApi,
+  name: string,
+  requestInfo: FailedRequestInfo
+) => {
+  try {
+    const validNames = await api.listIndexes();
+    return `Index '${name}' does not exist. Valid index names: [${validNames
+      .map((n) => `'${n}'`)
+      .join(', ')}]`;
+  } catch (e) {
+    // Expect to end up here only if a second error occurs while fetching valid index names.
+    // We can show the error from the failed call to describeIndex, but without listing
+    // index names.
+    throw mapHttpStatusError({
+      ...requestInfo,
+      message: `Index '${name}' does not exist.`,
+    });
+  }
+};

--- a/src/errors/http.ts
+++ b/src/errors/http.ts
@@ -9,6 +9,14 @@ export type FailedRequestInfo = {
 
 const CONFIG_HELP = `You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io`;
 
+export class PineconeBadRequestError extends BasePineconeError {
+  constructor(failedRequest: FailedRequestInfo) {
+    const { message } = failedRequest;
+    super(message);
+    this.name = 'PineconeBadRequestError';
+  }
+}
+
 export class PineconeAuthorizationError extends BasePineconeError {
   constructor(failedRequest: FailedRequestInfo) {
     const { url } = failedRequest;
@@ -87,6 +95,8 @@ export class PineconeUnmappedHttpError extends BasePineconeError {
 
 export const mapHttpStatusError = (failedRequestInfo: FailedRequestInfo) => {
   switch (failedRequestInfo.status) {
+    case 400:
+      return new PineconeBadRequestError(failedRequestInfo);
     case 401:
       return new PineconeAuthorizationError(failedRequestInfo);
     case 404:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { Pinecone, type ClientConfigurationInit } from './pinecone';
 export { Client, type ClientConfiguration } from './client';
 export * as Errors from './errors';
-export type { IndexName, IndexList } from './control';
+export type { IndexName, IndexList, CreateIndexOptions } from './control';
 
 // Legacy exports for backwards compatibility
 export { PineconeClient } from './v0';

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -22,12 +22,16 @@ export const buildValidator = (
         })
         .map((error) => {
           if (error.instancePath) {
-            return `the field '${error.instancePath.slice(1)}' ${
+            return `the property '${error.instancePath.slice(1)}' ${
               error.message
             }`;
           } else {
-            return `${error.message}`;
+            return `the argument ${error.message}`;
           }
+        })
+        .map((error) => {
+          // Turn errors into sentences
+          return error.charAt(0).toUpperCase() + error.slice(1) + '.';
         })
         .filter((message): message is string => message !== undefined);
       onError(errorsList);
@@ -36,14 +40,11 @@ export const buildValidator = (
   };
 };
 
-export const buildDataPlaneOperationsValidator = (
-  schema: any,
-  methodName: string
-) => {
+export const builOptionConfigValidator = (schema: any, methodName: string) => {
   return buildValidator(schema, (errorsList) => {
-    const message = errorsList.join('\n');
+    const message = errorsList.join(' ');
     throw new PineconeArgumentError(
-      `Argument to ${methodName} ${message || ''}`
+      `Argument to ${methodName} has a problem. ${message || ''}`
     );
   });
 };


### PR DESCRIPTION
## Problem

Need to implement `createIndex` and `deleteIndex` on the new client accessed from `const client = await Pinecone.createClient()`. The old client, `const legacy = await new PineconeClient(); legacy.init()`, should continue to work exactly as before.

These methods have the following changes from their legacy counterparts:

- [x] **Simpler arguments**. 
    - For createIndex, argument has been simplified from `{ createRequest: { name: 'foo', dimension: 256 } }` to `{ name: 'foo', dimension: 256 }`. 
    - For deleteIndex, argument has been simplified from `{ indexName: 'foo' }` to `'foo'`
- [x] **Cleaned up return values.** No longer return empty string `''` on success. The point of the `createIndex` and `deleteIndex` methods are their side-effects (creating/deleting an index), not fetching and displaying data. So there's no need to return anything here.
- [x] **Concise and actionable error messages.** Client-side argument validation informs the user when they have passed argument values with incorrect type.
    - Old: `PineconeError: PineconeClient: Error calling deleteIndex: RequiredError: Required parameter requestParameters.indexName was null or undefined when calling deleteIndex.`
    - New:  `PineconeNotFoundError: Index 'baz' does not exist. Valid index names: ['foo', 'jen-numpy-test']`
- [x] When needed, details about server-side validation errors (e.g. invalid index name) are shown when `PineconeBadRequestError` is thrown.
- [x] Proper stacktraces 
- [x] Argument types exported


## Solution

This diff mostly follows the approach used in PR #66 to add new methods to the client. Some small changes were made to validation methods to improve error messaging which resulted in a lot of minor changes to assertions about error messages created in earlier commits.

- The `buildValidator` in `validator.ts` now passes errors as complete sentences to the onError callback. In some cases this results in slightly longer error messages, but makes it much easier to integrate these errors into larger messages.
- Moved some logic I wanted to reuse about building richer error messages with the list of available indexes out of `control/describeIndex.ts` and into a `control/utils.ts` where it could also be accessed from `control/deleteIndex.ts`. There's some structural similarity between these two client methods because they are both trying to act on a single index by name.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

- Unit tests added included in PR, integration test suite to come in future diff
- Manual tests using `npm run repl`

### createIndex

#### createIndex: Happy path

```
> await client.createIndex({ name: 'foo', dimension: 10 })
undefined
> await client.listIndexes()
[ 'foo', 'jen-numpy-test' ]
> await client.describeIndex('foo')
{
  database: {
    name: 'foo',
    metric: 'cosine',
    pods: 1,
    replicas: 1,
    shards: 1,
    podType: 'p1.x1'
  },
  status: { ready: false, state: 'Initializing' }
}
```

#### createIndex: Argument validation
```
> await client.createIndex()
Uncaught:
PineconeArgumentError: Argument to createIndex has a problem. The argument must be object.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:62:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:4:12)
    at Client.createIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:57:40)
> await client.createIndex({})
Uncaught:
PineconeArgumentError: Argument to createIndex has a problem. The argument must have required property 'name'. The argument must have required property 'dimension'.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:62:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:4:12)
    at Client.createIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:57:40)
> await client.createIndex({ name: 0, dimension: 0})
Uncaught:
PineconeArgumentError: Argument to createIndex has a problem. The property 'name' must be string. The property 'dimension' must be >= 1.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:62:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:4:12)
    at Client.createIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:57:40)
```

#### createIndex: Accepts and passes optional configuration values
```
> await client.createIndex({ name: 'bar', dimension: 10, metric: 'dotproduct', pods: 2, podType: 'p1.x2'})
undefined
> await client.describeIndex('bar')
{
  database: {
    name: 'bar',
    metric: 'dotproduct',
    pods: 2,
    replicas: 1,
    shards: 2,
    podType: 'p1.x2'
  },
  status: { ready: false, state: 'Initializing' }
}
```

#### createIndex: When validations performed on the backend fail
```
> await client.createIndex({ name: 'foo-', dimension: 10 })
Uncaught:
PineconeBadRequestError: Invalid value: "foo-": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:76:59
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:33:23)
> await client.createIndex({ name: 'quux', dimension: 10, podType: 'unknown-pod-type' })
Uncaught:
PineconeBadRequestError: Unsupported value: "unknown-pod-type": supported values: "c1", "c1.x1", "c1.x2", "c1.x4", "c1.x8", "c1.x16", "c1.x32", "p1", "p1.x1", "p1.x2", "p1.x4", "p1.x8", "p2", "p2.x1", "p2.x2", "p2.x4", "p2.x8", "s1", "s1.x1", "s1.x2", "s1.x4", "s1.x8", "s1h", "s1h.x1", "s1h.x2", "s1h.x4", "s1h.x8", "s2", "s2.x1", "s2.x2", "s2.x4", "s2.x8"
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:76:59
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createIndex.js:33:23)
```

### deleteIndex

#### deleteIndex: happy path

```
> await client.listIndexes()
[ 'foo', 'jen-numpy-test' ]
> await client.deleteIndex('foo')
undefined
> await client.listIndexes()
[ 'jen-numpy-test' ]
```

#### deleteIndex: validations

```
> await client.deleteIndex()
Uncaught:
PineconeArgumentError: Argument to deleteIndex has a problem. The argument must be string.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:63:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:44:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:25:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:19:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:15:12)
    at Client.deleteIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:58:42)
```

#### deleteIndex: When requests fail (e.g. 404)

```
> await client.deleteIndex('quux')
Uncaught:
PineconeNotFoundError: Index 'quux' does not exist. Valid index names: ['foo', 'jen-numpy-test']
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:131:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:82:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteIndex.js:44:23)
```

