### PR TITLE
[v1] Implement `configureIndex`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import {
   listIndexes,
   createIndex,
   deleteIndex,
+  configureIndex,
 } from './control';
 import { buildValidator } from './validator';
 import { Static, Type } from '@sinclair/typebox';
@@ -31,6 +32,7 @@ export class Client {
   listIndexes: ReturnType<typeof listIndexes>;
   createIndex: ReturnType<typeof createIndex>;
   deleteIndex: ReturnType<typeof deleteIndex>;
+  configureIndex: ReturnType<typeof configureIndex>;
 
   constructor(options: ClientConfiguration) {
     this._validateConfig(options);
@@ -49,6 +51,7 @@ export class Client {
     this.listIndexes = listIndexes(api);
     this.createIndex = createIndex(api);
     this.deleteIndex = deleteIndex(api);
+    this.configureIndex = configureIndex(api);
   }
 
   _validateConfig(options: ClientConfiguration) {

--- a/src/control/__tests__/configureIndex.test.ts
+++ b/src/control/__tests__/configureIndex.test.ts
@@ -1,0 +1,107 @@
+import { configureIndex } from '../configureIndex';
+import {
+  PineconeBadRequestError,
+  PineconeInternalServerError,
+  PineconeNotFoundError,
+} from '../../errors';
+
+describe('configureIndex', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    const IOA = { configureIndex: jest.fn() };
+    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+      IndexOperationsApi: IOA,
+    }));
+  });
+
+  test('calls the openapi configure endpoint', async () => {
+    const returned = await configureIndex(IOA)('index-name', { replicas: 10 });
+
+    expect(returned).toBe(void 0);
+    expect(IOA.configureIndex).toHaveBeenCalledWith({
+      indexName: 'index-name',
+      patchRequest: { replicas: 10 },
+    });
+  });
+
+  describe('http error mapping', () => {
+    test('when 500 occurs', async () => {
+      const IOA = {
+        configureIndex: jest.fn().mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 500,
+              text: () => 'backend error message',
+            },
+          })
+        ),
+      };
+
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        IndexOperationsApi: IOA,
+      }));
+
+      const toThrow = async () => {
+        // @ts-ignore
+        await configureIndex(IOA)('index-name', { replicas: 10 });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeInternalServerError);
+    });
+
+    test('when 400 occurs, displays server message', async () => {
+      const IOA = {
+        configureIndex: jest.fn().mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 400,
+              text: () => 'backend error message',
+            },
+          })
+        ),
+      };
+
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        IndexOperationsApi: IOA,
+      }));
+
+      const toThrow = async () => {
+        // @ts-ignore
+        await configureIndex(IOA)('index-name', { replicas: 10 });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeBadRequestError);
+      await expect(toThrow).rejects.toThrow('backend error message');
+    });
+
+    test('when 404 occurs, show available indexes', async () => {
+      const IOA = {
+        configureIndex: jest.fn().mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 404,
+              text: () => 'backend error message',
+            },
+          })
+        ),
+        listIndexes: jest
+          .fn()
+          .mockImplementation(() => Promise.resolve(['foo', 'bar'])),
+      };
+
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        IndexOperationsApi: IOA,
+      }));
+
+      const toThrow = async () => {
+        // @ts-ignore
+        await configureIndex(IOA)('index-name', { replicas: 10 });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeNotFoundError);
+      await expect(toThrow).rejects.toThrow(
+        "Index 'index-name' does not exist. Valid index names: ['foo', 'bar']"
+      );
+    });
+  });
+});

--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+
+// Disabling typescript in this file because the entire point is to catch
+// cases where library callers (who may not be using typescript) pass
+// incorrect argument values.
+
+import { configureIndex } from '../configureIndex';
+import { PineconeArgumentError } from '../../errors';
+import { IndexOperationsApi } from '../../pinecone-generated-ts-fetch';
+
+describe('configureIndex argument validations', () => {
+  let IOA: IndexOperationsApi;
+  beforeEach(() => {
+    IOA = { configureIndex: jest.fn() };
+    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+      IndexOperationsApi: IOA,
+    }));
+  });
+
+  describe('required configurations', () => {
+    test('should throw if index name is not provided', async () => {
+      const toThrow = async () => await configureIndex(IOA)();
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        'Argument to configureIndex has a problem. The argument must be string.'
+      );
+    });
+
+    test('should throw if index name is not a string', async () => {
+      const toThrow = async () =>
+        await configureIndex(IOA)(1, { replicas: 10 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        'Argument to configureIndex has a problem. The argument must be string.'
+      );
+    });
+
+    test('should throw if index name is empty string', async () => {
+      const toThrow = async () =>
+        await configureIndex(IOA)('', { replicas: 2 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        'Argument to configureIndex has a problem. The argument must not be blank.'
+      );
+    });
+
+    test('should throw if a patch config is not provided', async () => {
+      const toThrow = async () => await configureIndex(IOA)('index-name', {});
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+      );
+    });
+
+    test('should throw if replicas is not a number', async () => {
+      const toThrow = async () =>
+        await configureIndex(IOA)('index-name', { replicas: '10' });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+      );
+    });
+
+    test('should throw if podType is not a string', async () => {
+      const toThrow = async () =>
+        await configureIndex(IOA)('index-name', { podType: 10.5 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+      );
+    });
+
+    test('should throw if replicas is not a positive integer', async () => {
+      const toThrow = async () =>
+        await configureIndex(IOA)('index-name', { replicas: 0 });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+      );
+    });
+  });
+});

--- a/src/control/configureIndex.ts
+++ b/src/control/configureIndex.ts
@@ -1,0 +1,86 @@
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+import { PineconeArgumentError, mapHttpStatusError } from '../errors';
+import { builOptionConfigValidator } from '../validator';
+import type { IndexName } from './deleteIndex';
+import { validIndexMessage } from './utils';
+
+import { Static, Type } from '@sinclair/typebox';
+
+const nonemptyString = Type.String({ minLength: 1 });
+const positiveInteger = Type.Integer({ minimum: 1 });
+
+const ConfigureIndexOptionsSchema = Type.Union([
+  Type.Object({
+    replicas: positiveInteger,
+  }),
+  Type.Object({
+    podType: nonemptyString,
+  }),
+]);
+
+export type ConfigureIndexOptions = Static<typeof ConfigureIndexOptionsSchema>;
+
+export const configureIndex = (api: IndexOperationsApi) => {
+  const indexNameValidator = builOptionConfigValidator(
+    nonemptyString,
+    'configureIndex'
+  );
+  const patchRequestValidator = builOptionConfigValidator(
+    ConfigureIndexOptionsSchema,
+    'configureIndex'
+  );
+
+  return async (
+    name: IndexName,
+    options: ConfigureIndexOptions
+  ): Promise<void> => {
+    indexNameValidator(name);
+
+    try {
+      patchRequestValidator(options);
+    } catch (e) {
+      if (e instanceof PineconeArgumentError && e.message.includes('anyOf')) {
+        const updateableProperties = ['replicas', 'podType'];
+        const propertyNames = updateableProperties
+          .map((p) => `'${p}'`)
+          .join(', ');
+        const msg = `At least one mutable property must be specified from list [${propertyNames}]. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index`;
+        throw new PineconeArgumentError(msg);
+      } else {
+        throw e;
+      }
+    }
+
+    try {
+      await api.configureIndex({ indexName: name, patchRequest: options });
+      return;
+    } catch (e) {
+      const configureIndexError = e as ResponseError;
+      const message = await configureIndexError.response.text();
+
+      const requestInfo = {
+        status: configureIndexError.response.status,
+        url: configureIndexError.response.url,
+        message,
+      };
+
+      let toThrow;
+      if (requestInfo.status === 404) {
+        const message = await validIndexMessage(api, name, requestInfo);
+        toThrow = mapHttpStatusError({ status: requestInfo.status, message });
+      } else {
+        // 500? 401? This logical branch is not generally expected. Let
+        // the http error mapper handle it, but we can't write a
+        // message because we don't know what went wrong.
+        const requestInfo = {
+          status: configureIndexError.response.status,
+          url: configureIndexError.response.url,
+          message,
+        };
+        toThrow = mapHttpStatusError(requestInfo);
+      }
+      throw toThrow;
+    }
+  };
+};

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -5,3 +5,5 @@ export { IndexList } from './listIndexes';
 export { createIndex } from './createIndex';
 export type { CreateIndexOptions } from './createIndex';
 export { deleteIndex } from './deleteIndex';
+export { configureIndex } from './configureIndex';
+export type { ConfigureIndexOptions } from './configureIndex';

--- a/src/errors/http.ts
+++ b/src/errors/http.ts
@@ -81,14 +81,14 @@ export class PineconeNotImplementedError extends BasePineconeError {
 
 export class PineconeUnmappedHttpError extends BasePineconeError {
   constructor(failedRequest: FailedRequestInfo) {
-    const { url, status, body } = failedRequest;
+    const { url, status, body, message } = failedRequest;
     const intro = url
       ? `An unexpected error occured while calling the ${url} endpoint. `
       : '';
     const statusMsg = status ? `Status: ${status}. ` : '';
     const bodyMsg = body ? `Body: ${body}` : '';
 
-    super([intro, statusMsg, bodyMsg].join(' ').trim());
+    super([intro, message, statusMsg, bodyMsg].join(' ').trim());
     this.name = 'PineconeUnmappedHttpError';
   }
 }


### PR DESCRIPTION
## Problem

Implementing `configureIndex` for the new client. Like similar PRs for other actions, this PR adds:

- New `configureIndex` method on the client created with `const client = await Pinecone.createClient()`
- Simplified arguments
- Runtime argument validation
- Errors with informative messages and stack traces
- Exported types for arguments and return types

## Solution

Leverage existing error mapping, validation, etc to implement new method.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

- Added unit tests for validation and error messages
- Manual testing with `npm run repl`

### Happy path

```
> await client.describeIndex('bar')
{
  database: {
    name: 'bar',
    metric: 'cosine',
    pods: 2,
    replicas: 2,
    shards: 1,
    podType: 'p1.x1',
    metadataConfig: { indexed: [Array] }
  },
  status: { ready: true, state: 'Ready' }
}
> await client.configureIndex('bar', { replicas: 3, podType: 'p1.x2' })
undefined
> await client.describeIndex('bar')
{
  database: {
    name: 'bar',
    metric: 'cosine',
    pods: 3,
    replicas: 3,
    shards: 1,
    podType: 'p1.x2',
    metadataConfig: { indexed: [Array] }
  },
  status: { ready: true, state: 'ScalingUpPodSize' }
}
```

### Validation failures

```
> await client.configureIndex({ replicas: 2 })
Uncaught:
PineconeArgumentError: Argument to configureIndex has a problem. The argument must be string.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:62:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:4:12)
    at Client.configureIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:57:46)
>
> await client.configureIndex('', { replicas: 2 })
Uncaught:
PineconeArgumentError: Argument to configureIndex has a problem. The argument must not be blank.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:62:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:4:12)
    at Client.configureIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:57:46)
> await client.configureIndex('bar', { replica: 1 })
Uncaught:
PineconeArgumentError: At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:73:35
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:4:12)
    at Client.configureIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:57:46)
    at REPL97:1:46
> await client.configureIndex('bar', { replicas: 0 })
Uncaught:
PineconeArgumentError: At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:73:35
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:4:12)
    at Client.configureIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:57:46)
    at REPL98:1:46
```

### Backend errors

#### Index not found

```
> await client.configureIndex('foo', { replicas: 2})
Uncaught:
PineconeNotFoundError: Index 'foo' does not exist. Valid index names: ['bar', 'jen-numpy-test']
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:131:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:102:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
```

#### Can't downgrade pod type

```
> await client.describeIndex('bar')
{
  database: {
    name: 'bar',
    metric: 'cosine',
    pods: 2,
    replicas: 2,
    shards: 1,
    podType: 'p1.x2',
    metadataConfig: { indexed: [Array] }
  },
  status: { ready: true, state: 'Ready' }
}
> await client.configureIndex('bar', { podType: 'p1.x1' })
Uncaught PineconeBadRequestError: scaling down pod type is not supported
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:110:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
```

#### Changing base pod type 

```
> await client.configureIndex('bar', { podType: 'asdf' })
Uncaught PineconeBadRequestError: updating base pod type is not supported
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:110:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
```

#### Quota error

```
> await client.configureIndex('bar', { replicas: 10 })
Uncaught:
PineconeBadRequestError: The index exceeds the project quota of 5 pods by 6 pods. Upgrade your account or change the project settings to increase the quota.
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:110:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
```