### PR TITLE
[v1] Add metadataConfig to index typescript type

### DIFF
--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -15,7 +15,11 @@ const CreateIndexOptionsSchema = Type.Object({
   pods: Type.Optional(positiveInteger),
   replicas: Type.Optional(positiveInteger),
   podType: Type.Optional(nonemptyString),
-  metadataConfig: Type.Optional(Type.Object({})),
+  metadataConfig: Type.Optional(
+    Type.Object({
+      indexed: Type.Array(nonemptyString),
+    })
+  ),
   sourceCollection: Type.Optional(nonemptyString),
 });
 


### PR DESCRIPTION
## Problem

metadataConfig type is vague

## Solution

Add more detail, so those using typescript will see the object is expected to have an `'indexed'` field.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
