### PR TITLE
[v1] Implement collection operations

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,10 @@ import {
   createIndex,
   deleteIndex,
   configureIndex,
+  listCollections,
+  createCollection,
+  describeCollection,
+  deleteCollection
 } from './control';
 import { buildValidator } from './validator';
 import { Static, Type } from '@sinclair/typebox';
@@ -147,6 +151,66 @@ export class Client {
   configureIndex: ReturnType<typeof configureIndex>;
 
   /**
+   * Create a new collection from an existing index
+   * 
+   * @example
+   * ```js
+   * const indexList = await client.listIndexes()
+   * await client.createCollection({
+   *  name: 'my-collection',
+   *  source: indexList[0]
+   * })
+   * ```
+   * 
+   * 
+   * @param options - The collection configuration.
+   * @param options.name - The name of the collection. Must be unique within the project and contain alphanumeric and hyphen characters. The name must start and end with alphanumeric characters.
+   * @param options.source - The name of the index to use as the source for the collection.
+   * @returns a promise that resolves when the request to create the collection is completed.
+  */
+  createCollection: ReturnType<typeof createCollection>;
+
+  /**
+   * List all collections in a project
+   * 
+   * @example
+   * ```js
+   * await client.listCollections()
+   * ```
+   * 
+   * @returns A promise that resolves to an array of collection objects.
+  */
+  listCollections: ReturnType<typeof listCollections>;
+  
+  /** 
+   * Delete a collection by collection name
+   * 
+   * @example
+   * ```
+   * const collectionList = await client.listCollections()
+   * const collectionName = collectionList[0]
+   * await client.deleteCollection(collectionName)
+   * ```
+   * 
+   * @param collectionName - The name of the collection to delete.
+   * @returns A promise that resolves when the request to delete the collection is completed.
+   */
+  deleteCollection: ReturnType<typeof deleteCollection>;
+
+  /**
+   * Describe a collection
+   * 
+   * @example
+   * ```js
+   * await client.describeCollection('my-collection')
+   * ```
+   * 
+   * @param collectionName - The name of the collection to describe.
+   * @returns A promise that resolves to a collection object with type {@link CollectionDescription}.
+  */
+  describeCollection: ReturnType<typeof describeCollection>;
+
+  /**
    * Creates a new Pinecone client. Most users will not need to call this directly, but rather use the `Pinecone` {@link Pinecone.createClient} method which aggregates information from multiple configuration sources.
    *
    * @example
@@ -179,6 +243,11 @@ export class Client {
     this.createIndex = createIndex(api);
     this.deleteIndex = deleteIndex(api);
     this.configureIndex = configureIndex(api);
+    
+    this.createCollection = createCollection(api);
+    this.listCollections = listCollections(api);
+    this.describeCollection = describeCollection(api);
+    this.deleteCollection = deleteCollection(api);
   }
 
   /** @internal */

--- a/src/client.ts
+++ b/src/client.ts
@@ -152,7 +152,7 @@ export class Client {
 
   /**
    * Create a new collection from an existing index
-   * 
+   *
    * @example
    * ```js
    * const indexList = await client.listIndexes()
@@ -161,37 +161,37 @@ export class Client {
    *  source: indexList[0]
    * })
    * ```
-   * 
-   * 
+   *
+   *
    * @param options - The collection configuration.
    * @param options.name - The name of the collection. Must be unique within the project and contain alphanumeric and hyphen characters. The name must start and end with alphanumeric characters.
    * @param options.source - The name of the index to use as the source for the collection.
    * @returns a promise that resolves when the request to create the collection is completed.
-  */
+   */
   createCollection: ReturnType<typeof createCollection>;
 
   /**
    * List all collections in a project
-   * 
+   *
    * @example
    * ```js
    * await client.listCollections()
    * ```
-   * 
+   *
    * @returns A promise that resolves to an array of collection objects.
-  */
+   */
   listCollections: ReturnType<typeof listCollections>;
-  
-  /** 
+
+  /**
    * Delete a collection by collection name
-   * 
+   *
    * @example
    * ```
    * const collectionList = await client.listCollections()
    * const collectionName = collectionList[0]
    * await client.deleteCollection(collectionName)
    * ```
-   * 
+   *
    * @param collectionName - The name of the collection to delete.
    * @returns A promise that resolves when the request to delete the collection is completed.
    */
@@ -199,15 +199,15 @@ export class Client {
 
   /**
    * Describe a collection
-   * 
+   *
    * @example
    * ```js
    * await client.describeCollection('my-collection')
    * ```
-   * 
+   *
    * @param collectionName - The name of the collection to describe.
    * @returns A promise that resolves to a collection object with type {@link CollectionDescription}.
-  */
+   */
   describeCollection: ReturnType<typeof describeCollection>;
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
   listCollections,
   createCollection,
   describeCollection,
-  deleteCollection
+  deleteCollection,
 } from './control';
 import { buildValidator } from './validator';
 import { Static, Type } from '@sinclair/typebox';
@@ -243,7 +243,7 @@ export class Client {
     this.createIndex = createIndex(api);
     this.deleteIndex = deleteIndex(api);
     this.configureIndex = configureIndex(api);
-    
+
     this.createCollection = createCollection(api);
     this.listCollections = listCollections(api);
     this.describeCollection = describeCollection(api);

--- a/src/control/__tests__/createCollection.test.ts
+++ b/src/control/__tests__/createCollection.test.ts
@@ -20,9 +20,6 @@ const setOpenAPIResponse = (fakeCreateCollectionResponse) => {
     listIndexes: fakeListIndexes,
   } as IndexOperationsApi;
 
-  jest.mock('../../pinecone-generated-ts-fetch', () => ({
-    IndexOperationsApi: IOA,
-  }));
   return IOA;
 };
 

--- a/src/control/__tests__/createCollection.test.ts
+++ b/src/control/__tests__/createCollection.test.ts
@@ -1,0 +1,219 @@
+import { createCollection } from '../createCollection';
+import {
+  PineconeArgumentError,
+  PineconeBadRequestError,
+  PineconeInternalServerError,
+  PineconeNotFoundError,
+} from '../../errors';
+import { IndexOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type { CreateCollectionOperationRequest as CCOR } from '../../pinecone-generated-ts-fetch';
+
+const setOpenAPIResponse = (fakeCreateCollectionResponse) => {
+  const fakeCreateCollection: (req: CCOR) => Promise<string> = jest
+    .fn()
+    .mockImplementation(fakeCreateCollectionResponse);
+  const fakeListIndexes: () => Promise<string[]> = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(['foo', 'bar']));
+  const IOA = {
+    createCollection: fakeCreateCollection,
+    listIndexes: fakeListIndexes,
+  } as IndexOperationsApi;
+
+  jest.mock('../../pinecone-generated-ts-fetch', () => ({
+    IndexOperationsApi: IOA,
+  }));
+  return IOA;
+};
+
+describe('createCollection', () => {
+  describe('argument validations', () => {
+    test('throws if no arguments are provided', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        // @ts-ignore
+        await createCollection(IOA)();
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        'Argument to createCollection has a problem. The argument must be object.'
+      );
+    });
+
+    test('throws if argument is not an object', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        // @ts-ignore
+        await createCollection(IOA)('not an object');
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        'Argument to createCollection has a problem. The argument must be object.'
+      );
+    });
+
+    test('throws if empty object', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        // @ts-ignore
+        await createCollection(IOA)({});
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createCollection has a problem. The argument must have required property 'name'. The argument must have required property 'source'."
+      );
+    });
+
+    test('throws if name is not provided', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        await createCollection(IOA)({
+          name: '',
+          source: 'index-name',
+        });
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createCollection has a problem. The property 'name' must not be blank."
+      );
+    });
+
+    test('throws if name is not a string', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        // @ts-ignore
+        await createCollection(IOA)({ name: 1, source: 'index-name' });
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createCollection has a problem. The property 'name' must be string."
+      );
+    });
+
+    test('throws if source is not provided', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        // @ts-ignore
+        await createCollection(IOA)({ name: 'collection-name' });
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createCollection has a problem. The argument must have required property 'source'."
+      );
+    });
+
+    test('throws if source is not a string', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        // @ts-ignore
+        await createCollection(IOA)({ name: 'foo', source: 12 });
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createCollection has a problem. The property 'source' must be string."
+      );
+    });
+
+    test('throws if source is blank', async () => {
+      const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+      const toThrow = async () => {
+        await createCollection(IOA)({
+          name: 'collection-name',
+          source: '',
+        });
+      };
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "Argument to createCollection has a problem. The property 'source' must not be blank."
+      );
+    });
+  });
+
+  test('calls the openapi create collection endpoint', async () => {
+    const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+    const returned = await createCollection(IOA)({
+      name: 'collection-name',
+      source: 'index-name',
+    });
+
+    expect(returned).toBe(void 0);
+    expect(IOA.createCollection).toHaveBeenCalledWith({
+      createCollectionRequest: {
+        name: 'collection-name',
+        source: 'index-name',
+      },
+    });
+  });
+
+  describe('http error mapping', () => {
+    test('when 500 occurs', async () => {
+      const IOA = setOpenAPIResponse(() =>
+        Promise.reject({
+          response: {
+            status: 500,
+            text: () => 'backend error message',
+          },
+        })
+      );
+
+      const toThrow = async () => {
+        await createCollection(IOA)({
+          name: 'collection-name',
+          source: 'index-name',
+        });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeInternalServerError);
+    });
+
+    test('when 400 occurs, displays server message', async () => {
+      const IOA = setOpenAPIResponse(() =>
+        Promise.reject({
+          response: {
+            status: 400,
+            text: () => 'backend error message',
+          },
+        })
+      );
+      const toThrow = async () => {
+        await createCollection(IOA)({
+          name: 'collection-name',
+          source: 'index-name',
+        });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeBadRequestError);
+      await expect(toThrow).rejects.toThrow('backend error message');
+    });
+
+    test('when 404 occurs, show available indexes', async () => {
+      const IOA = setOpenAPIResponse(() =>
+        Promise.reject({
+          response: {
+            status: 404,
+            text: () => 'not found',
+          },
+        })
+      );
+      const toThrow = async () => {
+        await createCollection(IOA)({
+          name: 'collection-name',
+          source: 'index-name',
+        });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeNotFoundError);
+      await expect(toThrow).rejects.toThrow(
+        "Index 'index-name' does not exist. Valid index names: ['foo', 'bar']"
+      );
+    });
+  });
+});

--- a/src/control/__tests__/deleteCollection.index.ts
+++ b/src/control/__tests__/deleteCollection.index.ts
@@ -1,0 +1,129 @@
+import { deleteCollection } from '../deleteCollection';
+import {
+  PineconeArgumentError,
+  PineconeInternalServerError,
+  PineconeNotFoundError,
+} from '../../errors';
+import { IndexOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type { DeleteCollectionRequest as DCR } from '../../pinecone-generated-ts-fetch';
+
+const setupMocks = (
+  deleteResponse,
+  listCollectionResponse = () => Promise.resolve([''])
+) => {
+  const fakeDeleteCollection: (req: DCR) => Promise<string> = jest
+    .fn()
+    .mockImplementation(deleteResponse);
+  const fakeListCollections: () => Promise<string[]> = jest
+    .fn()
+    .mockImplementation(listCollectionResponse);
+  const IOA = {
+    deleteCollection: fakeDeleteCollection,
+    listCollections: fakeListCollections,
+  };
+  jest.mock('../../pinecone-generated-ts-fetch', () => ({
+    IndexOperationsApi: IOA,
+  }));
+  return IOA as IndexOperationsApi;
+};
+
+describe('deleteCollection', () => {
+  describe('argument validation', () => {
+    test('should throw if collection name is not provided', async () => {
+      const IOA = setupMocks(() => Promise.resolve(''));
+      // @ts-ignore
+      const expectToThrow = async () => await deleteCollection(IOA)();
+
+      expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(expectToThrow).rejects.toThrowError(
+        'Argument to deleteCollection has a problem. The argument must be string.'
+      );
+    });
+
+    test('should throw if collection name is not a string', async () => {
+      const IOA = setupMocks(() => Promise.resolve(''));
+      // @ts-ignore
+      const expectToThrow = async () => await deleteCollection(IOA)({});
+
+      expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(expectToThrow).rejects.toThrowError(
+        'Argument to deleteCollection has a problem. The argument must be string.'
+      );
+    });
+
+    test('should throw if collection name is empty string', async () => {
+      const IOA = setupMocks(() => Promise.resolve(''));
+      // @ts-ignore
+      const expectToThrow = async () => await deleteCollection(IOA)('');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(expectToThrow).rejects.toThrowError(
+        'Argument to deleteCollection has a problem. The argument must not be blank.'
+      );
+    });
+  });
+
+  describe('uses http error mapper', () => {
+    test('it should map errors with the http error mapper (500)', async () => {
+      const IOA = setupMocks(() =>
+        Promise.reject({ response: { status: 500 } })
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await deleteCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeInternalServerError);
+    });
+  });
+
+  describe('custom error mapping', () => {
+    test('not found (404), fetches and shows available collection names', async () => {
+      const IOA = setupMocks(
+        () => Promise.reject({ response: { status: 404 } }),
+        () => Promise.resolve(['foo', 'bar'])
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await deleteCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
+      expect(expectToThrow).rejects.toThrowError(
+        `Collection 'collection-name' does not exist. Valid collection names: ['foo', 'bar']`
+      );
+    });
+
+    test('not found (404), fetches and shows available collection names (empty list)', async () => {
+      const IOA = setupMocks(
+        () => Promise.reject({ response: { status: 404 } }),
+        () => Promise.resolve([])
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await deleteCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
+      expect(expectToThrow).rejects.toThrowError(
+        `Collection 'collection-name' does not exist. Valid collection names: []`
+      );
+    });
+
+    test('not found (404), error while fetching collection list', async () => {
+      const IOA = setupMocks(
+        () => Promise.reject({ response: { status: 404 } }),
+        () => Promise.reject('error')
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await deleteCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
+      expect(expectToThrow).rejects.toThrowError(
+        `Collection 'collection-name' does not exist.`
+      );
+    });
+  });
+});

--- a/src/control/__tests__/describeCollection.test.ts
+++ b/src/control/__tests__/describeCollection.test.ts
@@ -75,6 +75,29 @@ describe('describeCollection', () => {
     });
   });
 
+  describe('happy path', () => {
+    test('it should return the collection meta', async () => {
+      const IOA = setupMocks(
+        () =>
+          Promise.resolve({
+            name: 'collection-name',
+            size: 3085509,
+            status: 'Ready',
+          }),
+        () => Promise.resolve([])
+      );
+
+      // @ts-ignore
+      const response = await describeCollection(IOA)('collection-name');
+
+      expect(response).toEqual({
+        name: 'collection-name',
+        size: 3085509,
+        status: 'Ready',
+      });
+    });
+  });
+
   describe('uses http error mapper', () => {
     test('it should map errors with the http error mapper (500)', async () => {
       const IOA = setupMocks(

--- a/src/control/__tests__/describeCollection.test.ts
+++ b/src/control/__tests__/describeCollection.test.ts
@@ -24,9 +24,6 @@ const setupMocks = (
     describeCollection: fakeDescribeCollection,
     listCollections: fakeListCollections,
   };
-  jest.mock('../../pinecone-generated-ts-fetch', () => ({
-    IndexOperationsApi: IOA,
-  }));
   return IOA as IndexOperationsApi;
 };
 

--- a/src/control/__tests__/describeCollection.test.ts
+++ b/src/control/__tests__/describeCollection.test.ts
@@ -1,0 +1,142 @@
+import { describeCollection } from '../describeCollection';
+import {
+  PineconeArgumentError,
+  PineconeInternalServerError,
+  PineconeNotFoundError,
+} from '../../errors';
+import { IndexOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type {
+  DescribeCollectionRequest as DCR,
+  CollectionMeta,
+} from '../../pinecone-generated-ts-fetch';
+
+const setupMocks = (
+  describeResponse,
+  listCollectionResponse: () => Promise<Array<string>>
+) => {
+  const fakeDescribeCollection: (req: DCR) => Promise<CollectionMeta> = jest
+    .fn()
+    .mockImplementation(describeResponse);
+  const fakeListCollections: () => Promise<Array<string>> = jest
+    .fn()
+    .mockImplementation(listCollectionResponse);
+  const IOA = {
+    describeCollection: fakeDescribeCollection,
+    listCollections: fakeListCollections,
+  };
+  jest.mock('../../pinecone-generated-ts-fetch', () => ({
+    IndexOperationsApi: IOA,
+  }));
+  return IOA as IndexOperationsApi;
+};
+
+describe('describeCollection', () => {
+  describe('argument validation', () => {
+    test('should throw if collection name is not provided', async () => {
+      const IOA = setupMocks(
+        () => Promise.resolve(''),
+        () => Promise.resolve([])
+      );
+      // @ts-ignore
+      const expectToThrow = async () => await describeCollection(IOA)();
+
+      expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(expectToThrow).rejects.toThrowError(
+        'Argument to describeCollection has a problem. The argument must be string.'
+      );
+    });
+
+    test('should throw if collection name is not a string', async () => {
+      const IOA = setupMocks(
+        () => Promise.resolve(''),
+        () => Promise.resolve([])
+      );
+      // @ts-ignore
+      const expectToThrow = async () => await describeCollection(IOA)({});
+
+      expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(expectToThrow).rejects.toThrowError(
+        'Argument to describeCollection has a problem. The argument must be string.'
+      );
+    });
+
+    test('should throw if collection name is empty string', async () => {
+      const IOA = setupMocks(
+        () => Promise.resolve(''),
+        () => Promise.resolve([])
+      );
+      // @ts-ignore
+      const expectToThrow = async () => await describeCollection(IOA)('');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(expectToThrow).rejects.toThrowError(
+        'Argument to describeCollection has a problem. The argument must not be blank.'
+      );
+    });
+  });
+
+  describe('uses http error mapper', () => {
+    test('it should map errors with the http error mapper (500)', async () => {
+      const IOA = setupMocks(
+        () => Promise.reject({ response: { status: 500 } }),
+        () => Promise.resolve([])
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await describeCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeInternalServerError);
+    });
+  });
+
+  describe('custom error mapping', () => {
+    test('not found (404), fetches and shows available collection names', async () => {
+      const IOA = setupMocks(
+        () => Promise.reject({ response: { status: 404 } }),
+        () => Promise.resolve(['foo', 'bar'])
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await describeCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
+      expect(expectToThrow).rejects.toThrowError(
+        `Collection 'collection-name' does not exist. Valid collection names: ['foo', 'bar']`
+      );
+    });
+
+    test('not found (404), fetches and shows available collection names (empty list)', async () => {
+      const IOA = setupMocks(
+        () => Promise.reject({ response: { status: 404 } }),
+        () => Promise.resolve([])
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await describeCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
+      expect(expectToThrow).rejects.toThrowError(
+        `Collection 'collection-name' does not exist. Valid collection names: []`
+      );
+    });
+
+    test('not found (404), error while fetching collection list', async () => {
+      const IOA = setupMocks(
+        () => Promise.reject({ response: { status: 404 } }),
+        () => Promise.reject('error')
+      );
+
+      // @ts-ignore
+      const expectToThrow = async () =>
+        await describeCollection(IOA)('collection-name');
+
+      expect(expectToThrow).rejects.toThrowError(PineconeNotFoundError);
+      expect(expectToThrow).rejects.toThrowError(
+        `Collection 'collection-name' does not exist.`
+      );
+    });
+  });
+});

--- a/src/control/__tests__/describeIndex.test.ts
+++ b/src/control/__tests__/describeIndex.test.ts
@@ -28,9 +28,6 @@ describe('describeIndex', () => {
         .fn()
         .mockImplementation(() => Promise.resolve(responseData)),
     };
-    jest.mock('../../pinecone-generated-ts-fetch', () => ({
-      IndexOperationsApi: IOA,
-    }));
 
     // @ts-ignore
     const returned = await describeIndex(IOA)('index-name');
@@ -55,9 +52,6 @@ describe('describeIndex', () => {
           .fn()
           .mockImplementation(() => Promise.resolve(responseData)),
       };
-      jest.mock('../../pinecone-generated-ts-fetch', () => ({
-        IndexOperationsApi: IOA,
-      }));
 
       // @ts-ignore
       const expectToThrow = async () => await describeIndex(IOA)();
@@ -74,9 +68,6 @@ describe('describeIndex', () => {
           .fn()
           .mockImplementation(() => Promise.resolve(responseData)),
       };
-      jest.mock('../../pinecone-generated-ts-fetch', () => ({
-        IndexOperationsApi: IOA,
-      }));
 
       // @ts-ignore
       const expectToThrow = async () => await describeIndex(IOA)({});
@@ -93,9 +84,6 @@ describe('describeIndex', () => {
           .fn()
           .mockImplementation(() => Promise.resolve(responseData)),
       };
-      jest.mock('../../pinecone-generated-ts-fetch', () => ({
-        IndexOperationsApi: IOA,
-      }));
 
       // @ts-ignore
       const expectToThrow = async () => await describeIndex(IOA)('');
@@ -116,9 +104,6 @@ describe('describeIndex', () => {
             Promise.reject({ response: { status: 500 } })
           ),
       };
-      jest.mock('../../pinecone-generated-ts-fetch', () => ({
-        IndexOperationsApi: IOA,
-      }));
 
       // @ts-ignore
       const expectToThrow = async () => await describeIndex(IOA)('index-name');
@@ -139,9 +124,6 @@ describe('describeIndex', () => {
           .fn()
           .mockImplementation(() => Promise.resolve(['foo', 'bar'])),
       };
-      jest.mock('../../pinecone-generated-ts-fetch', () => ({
-        IndexOperationsApi: IOA,
-      }));
 
       // @ts-ignore
       const expectToThrow = async () => await describeIndex(IOA)('index-name');
@@ -161,9 +143,6 @@ describe('describeIndex', () => {
           ),
         listIndexes: jest.fn().mockImplementation(() => Promise.resolve([])),
       };
-      jest.mock('../../pinecone-generated-ts-fetch', () => ({
-        IndexOperationsApi: IOA,
-      }));
 
       // @ts-ignore
       const expectToThrow = async () => await describeIndex(IOA)('index-name');
@@ -185,9 +164,6 @@ describe('describeIndex', () => {
           .fn()
           .mockImplementation(() => Promise.reject('error')),
       };
-      jest.mock('../../pinecone-generated-ts-fetch', () => ({
-        IndexOperationsApi: IOA,
-      }));
 
       // @ts-ignore
       const expectToThrow = async () => await describeIndex(IOA)('index-name');

--- a/src/control/__tests__/listCollections.test.ts
+++ b/src/control/__tests__/listCollections.test.ts
@@ -1,0 +1,58 @@
+import { listCollections } from '../listCollections';
+import {
+  PineconeInternalServerError,
+  PineconeAuthorizationError,
+} from '../../errors';
+
+describe('listCollections', () => {
+  test('should return a list of collections', async () => {
+    const IOA = {
+      listCollections: jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(['collection-name', 'collection-name-2'])
+        ),
+    };
+
+    // @ts-ignore
+    const returned = await listCollections(IOA)();
+
+    expect(returned).toEqual(['collection-name', 'collection-name-2']);
+  });
+
+  test('it should map errors with the http error mapper (500)', async () => {
+    const IOA = {
+      listCollections: jest.fn().mockImplementation(() =>
+        Promise.reject({
+          response: {
+            status: 500,
+            text: async () => 'Internal Server Error',
+          },
+        })
+      ),
+    };
+
+    // @ts-ignore
+    const expectToThrow = async () => await listCollections(IOA)();
+
+    expect(expectToThrow).rejects.toThrowError(PineconeInternalServerError);
+  });
+
+  test('it should map errors with the http error mapper (401)', async () => {
+    const IOA = {
+      listCollections: jest.fn().mockImplementation(() =>
+        Promise.reject({
+          response: {
+            status: 401,
+            text: async () => 'Unauthorized',
+          },
+        })
+      ),
+    };
+
+    // @ts-ignore
+    const expectToThrow = async () => await listCollections(IOA)();
+
+    expect(expectToThrow).rejects.toThrowError(PineconeAuthorizationError);
+  });
+});

--- a/src/control/createCollection.ts
+++ b/src/control/createCollection.ts
@@ -1,0 +1,39 @@
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+import { mapHttpStatusError } from '../errors';
+import { builOptionConfigValidator } from '../validator';
+
+import { Static, Type } from '@sinclair/typebox';
+
+const nonemptyString = Type.String({ minLength: 1 });
+
+const CreateCollectionOptionsSchema = Type.Object({
+  name: nonemptyString,
+  source: nonemptyString
+});
+
+export type CreateCollectionOptions = Static<typeof CreateCollectionOptionsSchema>;
+
+export const createCollection = (api: IndexOperationsApi) => {
+  const validator = builOptionConfigValidator(
+    CreateCollectionOptionsSchema,
+    'createCollection'
+  );
+
+  return async (options: CreateCollectionOptions): Promise<void> => {
+    validator(options);
+
+    try {
+      await api.createCollection({ createCollectionRequest: options });
+      return;
+    } catch (e) {
+      const createCollectionError = e as ResponseError;
+      const message = await createCollectionError.response.text();
+      throw mapHttpStatusError({
+        status: createCollectionError.response.status,
+        url: createCollectionError.response.url,
+        message: message,
+      });
+    }
+  };
+};

--- a/src/control/deleteCollection.ts
+++ b/src/control/deleteCollection.ts
@@ -1,0 +1,42 @@
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+import { mapHttpStatusError } from '../errors';
+import { builOptionConfigValidator } from '../validator';
+import { Static, Type } from '@sinclair/typebox';
+import { validIndexMessage } from './utils';
+
+const DeleteCollectionIndex = Type.String({ minLength: 1 });
+export type CollectionName = Static<typeof DeleteCollectionIndex>;
+
+export const deleteCollection = (api: IndexOperationsApi) => {
+  const validator = builOptionConfigValidator(
+    DeleteCollectionIndex,
+    'deleteCollection'
+  );
+
+  return async (collectionName: CollectionName): Promise<void> => {
+    validator(collectionName);
+
+    try {
+      await api.deleteCollection({ collectionName: collectionName });
+      return;
+    } catch (e) {
+      const deleteError = e as ResponseError;
+      const requestInfo = {
+        status: deleteError.response.status,
+      };
+
+      let toThrow;
+      if (requestInfo.status === 404) {
+        const message = await validIndexMessage(api, collectionName, requestInfo);
+        toThrow = mapHttpStatusError({ ...requestInfo, message });
+      } else {
+        // 500? 401? This logical branch is not generally expected. Let
+        // the http error mapper handle it, but we can't write a
+        // message because we don't know what went wrong.
+        toThrow = mapHttpStatusError(requestInfo);
+      }
+      throw toThrow;
+    }
+  };
+};

--- a/src/control/deleteCollection.ts
+++ b/src/control/deleteCollection.ts
@@ -3,7 +3,7 @@ import type { ResponseError } from '../pinecone-generated-ts-fetch';
 import { mapHttpStatusError } from '../errors';
 import { builOptionConfigValidator } from '../validator';
 import { Static, Type } from '@sinclair/typebox';
-import { validIndexMessage } from './utils';
+import { validCollectionMessage } from './utils';
 
 const DeleteCollectionIndex = Type.String({ minLength: 1 });
 export type CollectionName = Static<typeof DeleteCollectionIndex>;
@@ -28,7 +28,11 @@ export const deleteCollection = (api: IndexOperationsApi) => {
 
       let toThrow;
       if (requestInfo.status === 404) {
-        const message = await validIndexMessage(api, collectionName, requestInfo);
+        const message = await validCollectionMessage(
+          api,
+          collectionName,
+          requestInfo
+        );
         toThrow = mapHttpStatusError({ ...requestInfo, message });
       } else {
         // 500? 401? This logical branch is not generally expected. Let

--- a/src/control/describeCollection.ts
+++ b/src/control/describeCollection.ts
@@ -2,7 +2,7 @@ import { Static, Type } from '@sinclair/typebox';
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { builOptionConfigValidator } from '../validator';
 import { mapHttpStatusError } from '../errors';
-import { validIndexMessage } from './utils';
+import { validCollectionMessage } from './utils';
 import type {
   ResponseError,
   CollectionMeta as CollectionDescription,
@@ -15,7 +15,7 @@ import type {
 // string. To avoid this confusing case, we require lenth > 1.
 const DescribeCollectionSchema = Type.String({ minLength: 1 });
 
-export type CollectionName = Static<typeof DescribeCollectionSchema>;;
+export type CollectionName = Static<typeof DescribeCollectionSchema>;
 
 export const describeCollection = (api: IndexOperationsApi) => {
   const validator = builOptionConfigValidator(
@@ -47,15 +47,12 @@ export const describeCollection = (api: IndexOperationsApi) => {
       };
 
       let toThrow;
-    //   if (requestInfo.status === 404) {
-        // const message = await validIndexMessage(api, name, requestInfo);
-        // toThrow = mapHttpStatusError({ ...requestInfo, message });
-    //   } else {
-        // 500? 401? This logical branch is not generally expected. Let
-        // the http error mapper handle it, but we can't write a
-        // message because we don't know what went wrong.
+      if (requestInfo.status === 404) {
+        const message = await validCollectionMessage(api, name, requestInfo);
+        toThrow = mapHttpStatusError({ ...requestInfo, message });
+      } else {
         toThrow = mapHttpStatusError(requestInfo);
-    //   }
+      }
       throw toThrow;
     }
   };

--- a/src/control/describeCollection.ts
+++ b/src/control/describeCollection.ts
@@ -1,0 +1,62 @@
+import { Static, Type } from '@sinclair/typebox';
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import { builOptionConfigValidator } from '../validator';
+import { mapHttpStatusError } from '../errors';
+import { validIndexMessage } from './utils';
+import type {
+  ResponseError,
+  CollectionMeta as CollectionDescription,
+} from '../pinecone-generated-ts-fetch';
+
+// If user passes the empty string for collection name, the generated
+// OpenAPI client will call /databases/ which is the list
+// collection endpoint. This returns 200 instead of 404, but obviously
+// no descriptive information is returned for an collection named empty
+// string. To avoid this confusing case, we require lenth > 1.
+const DescribeCollectionSchema = Type.String({ minLength: 1 });
+
+export type CollectionName = Static<typeof DescribeCollectionSchema>;;
+
+export const describeCollection = (api: IndexOperationsApi) => {
+  const validator = builOptionConfigValidator(
+    DescribeCollectionSchema,
+    'describeCollection'
+  );
+
+  const removeDeprecatedFields = (result: any) => {
+    if (result.database) {
+      for (const key of Object.keys(result.database)) {
+        if (result.database[key] === undefined) {
+          delete result.database[key];
+        }
+      }
+    }
+  };
+
+  return async (name: CollectionName): Promise<CollectionDescription> => {
+    validator(name);
+
+    try {
+      const result = await api.describeCollection({ collectionName: name });
+      removeDeprecatedFields(result);
+      return result;
+    } catch (e) {
+      const describeError = e as ResponseError;
+      const requestInfo = {
+        status: describeError.response.status,
+      };
+
+      let toThrow;
+    //   if (requestInfo.status === 404) {
+        // const message = await validIndexMessage(api, name, requestInfo);
+        // toThrow = mapHttpStatusError({ ...requestInfo, message });
+    //   } else {
+        // 500? 401? This logical branch is not generally expected. Let
+        // the http error mapper handle it, but we can't write a
+        // message because we don't know what went wrong.
+        toThrow = mapHttpStatusError(requestInfo);
+    //   }
+      throw toThrow;
+    }
+  };
+};

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -12,7 +12,7 @@ export type { ConfigureIndexOptions } from './configureIndex';
 
 // Collection Operations
 export { createCollection } from './createCollection';
-export { describeCollection }from './describeCollection';
+export { describeCollection } from './describeCollection';
 export { listCollections } from './listCollections';
 export { deleteCollection } from './deleteCollection';
 

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -1,9 +1,19 @@
+// Index Operations
 export { describeIndex } from './describeIndex';
-export type { IndexName } from './describeIndex';
 export { listIndexes } from './listIndexes';
-export { IndexList } from './listIndexes';
 export { createIndex } from './createIndex';
-export type { CreateIndexOptions } from './createIndex';
 export { deleteIndex } from './deleteIndex';
 export { configureIndex } from './configureIndex';
+
+export type { CreateIndexOptions } from './createIndex';
+export type { IndexName } from './describeIndex';
+export type { IndexList } from './listIndexes';
 export type { ConfigureIndexOptions } from './configureIndex';
+
+// Collection Operations
+export { createCollection } from './createCollection';
+export { describeCollection }from './describeCollection';
+export { listCollections } from './listCollections';
+export { deleteCollection } from './deleteCollection';
+
+export type { CollectionName, CollectionList } from './listCollections';

--- a/src/control/listCollections.ts
+++ b/src/control/listCollections.ts
@@ -1,0 +1,21 @@
+import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import { mapHttpStatusError } from '../errors';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+
+export type CollectionName = string;
+export type CollectionList = CollectionName[];
+
+export const listCollections = (api: IndexOperationsApi) => {
+  return async (): Promise<CollectionList> => {
+    try {
+      return await api.listCollections();
+    } catch (e) {
+      const listCollectionsError = e as ResponseError;
+      throw mapHttpStatusError({
+        status: listCollectionsError.response.status,
+        url: listCollectionsError.response.url,
+        message: await listCollectionsError.response.text(),
+      });
+    }
+  };
+};

--- a/src/control/utils.ts
+++ b/src/control/utils.ts
@@ -22,3 +22,24 @@ export const validIndexMessage = async (
     });
   }
 };
+
+export const validCollectionMessage = async (
+  api: IndexOperationsApi,
+  name: string,
+  requestInfo: FailedRequestInfo
+) => {
+  try {
+    const validNames = await api.listCollections();
+    return `Collection '${name}' does not exist. Valid collection names: [${validNames
+      .map((n) => `'${n}'`)
+      .join(', ')}]`;
+  } catch (e) {
+    // Expect to end up here only if a second error occurs while fetching valid collection names.
+    // We can show the error from the failed call to describeIndex, but without listing
+    // index names.
+    throw mapHttpStatusError({
+      ...requestInfo,
+      message: `Collection '${name}' does not exist.`,
+    });
+  }
+};


### PR DESCRIPTION
## Problem

Similar to recent PRs #66 and #67, this PR is adding new functionality to the revamped node client. Specifically:

- `createCollection`
- `describeCollection`
- `listCollections`
- `deleteCollection`

## Solution

More or less followed the approach used in #66 and #67 to provide simpler arguments, runtime argument validation, and improved error handling.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

- Added new unit tests covering these commands.
- Manual testing with `npm run repl`

### Creating a collection

#### Validating arguments
```
> await client.createCollection()
Uncaught:
PineconeArgumentError: Argument to createCollection has a problem. The argument must be object.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:56:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:4:12)
    at Client.createCollection (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:51:40)
> await client.createCollection({})
Uncaught:
PineconeArgumentError: Argument to createCollection has a problem. The argument must have required property 'name'. The argument must have required property 'source'.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:56:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:4:12)
    at Client.createCollection (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:51:40)
> await client.createCollection({ name: 'baz-collection', source: 'baz' })
Uncaught PineconeBadRequestError: source database baz does not exist
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:88:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:33:23)
```

#### bad request

```
> await client.createCollection({ name: 'my-collection', source: 'asdf' })
Uncaught PineconeBadRequestError: source database asdf does not exist
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:88:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/createCollection.js:33:23)
```



#### happy path
```
> await client.listIndexes()
[ 'bar', 'foofoo', 'jen-numpy-test' ]
> await client.createCollection({ name: 'bar-collection', source: 'bar' })
undefined
```

### describeCollection

#### Validations

```
> await client.describeCollection()
Uncaught:
PineconeArgumentError: Argument to describeCollection has a problem. The argument must be string.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:45:15
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:36:13
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:78:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:44:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:25:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:19:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:15:12)
    at Client.describeCollection (/Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:73:37)
```

#### bad request
```
> await client.describeCollection('asdf')
Uncaught:
PineconeNotFoundError: Collection 'asdf' does not exist. Valid collection names: []
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:131:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:98:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/describeCollection.js:44:23)
````

#### happy path

```
> await client.describeCollection('bar-collection')
{ name: 'bar-collection', size: undefined, status: 'Initializing' }
> await client.describeCollection('bar-collection')
{ name: 'bar-collection', size: 3088261, status: 'Ready' }
```

### listCollection

```
> await client.listCollections()
[ 'bar-collection' ]
```

### deleteCollection

```
> await client.deleteCollection('foo-collection')
Uncaught:
PineconeNotFoundError: Collection 'foo-collection' does not exist. Valid collection names: ['bar-collection']
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:131:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteCollection.js:82:63
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/deleteCollection.js:44:23)
> await client.deleteCollection('bar-collection')
undefined
> await client.listCollections()
[]
>
```

