### PR TITLE
Add typedoc and inline documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/run.ts
 .vscode
 .DS_Store
 scratch
+docs/

--- a/README.future.md
+++ b/README.future.md
@@ -18,16 +18,83 @@ const client = await Pinecone.createClient({
 
 It also can find information specified in the environment variables `PINECONE_API_KEY` and `PINECONE_ENVIRONMENT`.
 
-## Data Plane
+## Control Plane
+
+### Create an index
+
+The minimum required configuration to create an index is the index name and dimension. The dimension you choose should match the output of the model used to produce your embeddings.
+
+```
+await client.createIndex({ name: 'my-index', dimension: 128 })
+```
+
+In a more expansive example, you can specify the metric, number of pods, number of replicas, and pod type.
+
+```
+await client.createIndex({
+ name: 'my-index',
+ dimension: 128,
+ metric: 'cosine',
+ pods: 1,
+ replicas: 2,
+ podType: 'p1.x1'
+})
+```
+
+By default all metadata fields are indexed when vectors are upserted with metadata, but if you want to improve performance you can specify the specific fields you want to index. This example is showing a few hypothetical metadata fields, but the values you'd use depend on what metadata you plan to store in Pinecone alongside your vectors.
+
+```
+await client.createIndex({ name: 'my-index', dimension: 128, metadataConfig: { 'indexed' : ['productName', 'productDescription'] }})
+```
+
+### Describe an index
+
+After you've created an index, you can view its configuration.
+
+```
+const config = await client.describeIndex('my-index')
+// {
+//   database: {
+//     name: 'my-index',
+//     metric: 'cosine',
+//     pods: 1,
+//     replicas: 1,
+//     shards: 1,
+//     podType: 'p1.x1'
+//   },
+//   status: { ready: false, state: 'Ready' }
+// }
+```
 
 ### List indexes
 
 ```
-client.listIndexes()
+const indexList = await client.listIndexes()
+// ['my-index']
 ```
 
-### Describe index
+### Delete an index
 
 ```
-client.describeIndex('my-index-name')
+await client.deleteIndex('my-index')
+```
+
+### Configure an index
+
+You can adjust the number of replicas or scale to a larger pod size (specified with `podType`). See [Pod types and sizes](https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes). You cannot downgrade pod size or change the base pod type.
+
+```
+await client.configureIndex('my-index', { replicas: 3, podType: 'p1.x2' })
+const config = await client.describeIndex('my-index')
+// {
+//   database: {
+//     name: 'my-index',
+//     metric: 'cosine',
+//     pods: 3,
+//     replicas: 3,
+//     shards: 1,
+//     podType: 'p1.x2'
+//   },
+//   status: { ready: false, state: 'ScalingUpPodType' }
+// }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "prettier": "^2.8.8",
         "ts-jest": "^29.0.5",
         "ts-node": "^10.9.1",
+        "typedoc": "^0.24.8",
         "typescript": "^4.9.4",
         "unique-names-generator": "^4.7.1"
       },
@@ -348,9 +349,10 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.7",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
+      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1650,6 +1652,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -4266,6 +4274,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "dev": true,
@@ -4330,6 +4344,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -4355,6 +4375,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/merge-stream": {
@@ -4985,6 +5017,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+      "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -5440,6 +5484,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.2.tgz",
+      "integrity": "sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "dev": true,
@@ -5538,6 +5627,18 @@
       "version": "1.9.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf dist/ && tsc",
+    "docs:build": "typedoc",
     "format": "prettier --write .",
     "lint": "eslint src/ --ext .ts",
     "repl": "npm run build && node utils/replInit.ts",
@@ -36,6 +37,7 @@
     "prettier": "^2.8.8",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
+    "typedoc": "^0.24.8",
     "typescript": "^4.9.4",
     "unique-names-generator": "^4.7.1"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,7 @@ const ClientConfigurationSchema = Type.Object(
   {
     environment: Type.String({ minLength: 1 }),
     apiKey: Type.String({ minLength: 1 }),
-    projectId: Type.String({ minLength: 1 }),
+    projectId: Type.Optional(Type.String({ minLength: 1 })),
   },
   { additionalProperties: false }
 );

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,22 +18,149 @@ const ClientConfigurationSchema = Type.Object(
   {
     environment: Type.String({ minLength: 1 }),
     apiKey: Type.String({ minLength: 1 }),
-    projectId: Type.Optional(Type.String({ minLength: 1 })),
+    projectId: Type.String({ minLength: 1 }),
   },
   { additionalProperties: false }
 );
 
 export type ClientConfiguration = Static<typeof ClientConfigurationSchema>;
 
+/** Class representing a Pinecone client */
 export class Client {
+  /** @hidden */
   private config: ClientConfiguration;
 
+  /**
+   * Describe a Pinecone index
+   *
+   * @example
+   * ```js
+   * const indexConfig = await client.describeIndex('my-index')
+   * console.log(indexConfig)
+   * // {
+   * //    database: {
+   * //      name: 'my-index',
+   * //      metric: 'cosine',
+   * //      pods: 2,
+   * //      replicas: 2,
+   * //      shards: 1,
+   * //      podType: 'p1.x2',
+   * //      metadataConfig: { indexed: [Array] }
+   * //    },
+   * //    status: { ready: true, state: 'Ready' }
+   * // }
+   * ```
+   *
+   * @param indexName - The name of the index to describe.
+   * @returns A promise that resolves to {@link IndexMeta}
+   */
   describeIndex: ReturnType<typeof describeIndex>;
+
+  /**
+   * List all Pinecone indexes
+   * @example
+   * ```js
+   * const indexes = await client.listIndexes()
+   * console.log(indexes)
+   * // [ 'my-index', 'my-other-index' ]
+   * ```
+   *
+   * @returns A promise that resolves to an array of index names
+   */
   listIndexes: ReturnType<typeof listIndexes>;
+
+  /**
+   * Creates a new index.
+   *
+   * @example
+   * The minimum required configuration to create an index is the index name and dimension.
+   * ```js
+   * await client.createIndex({ name: 'my-index', dimension: 128 })
+   * ```
+   * @example
+   * In a more expansive example, you can specify the metric, number of pods, number of replicas, and pod type.
+   * ```js
+   * await client.createIndex({
+   *  name: 'my-index',
+   *  dimension: 128,
+   *  metric: 'cosine',
+   *  pods: 1,
+   *  replicas: 2,
+   *  podType: 'p1.x1'
+   * })
+   * ```
+   *
+   * @example
+   * By default all metadata fields are indexed when vectors are upserted with metadata, but if you want to improve performance you can specify the specific fields you want to index. This example is showing a few hypothetical metadata fields, but the values you'd use depend on what metadata you plan to store in Pinecone alongside your vectors.
+   * ```js
+   * await client.createIndex({ name: 'my-index', dimension: 128, metadataConfig: { 'indexed' : ['productName', 'productDescription'] }})
+   * ```
+   *
+   * @param options - The index configuration.
+   * @param options.name - The name of the index. Must be unique within the project and contain alphanumeric and hyphen characters. The name must start and end with alphanumeric characters.
+   * @param options.dimension - The dimension of the index. Must be a positive integer. The number you choose here will depend on the model you are using. For example, if you are using a model that outputs 128-dimensional vectors, you should set the dimension to 128.
+   * @param options.metric - The metric of the index. The default metric is `'cosine'`. Supported metrics include `'cosine'`, `'dotproduct'`, and `'euclidean'`. To learn more about these options, see [Distance metrics](https://docs.pinecone.io/docs/indexes#distance-metrics)
+   * @param options.pods - The number of pods in the index. The default number of pods is 1.
+   * @param options.replicas - The number of replicas in the index. The default number of replicas is 1.
+   * @param options.podType - The type of pod in the index. This string should combine a base pod type (`s1`, `p1`, or `p2`) with a size (`x1`, `x2`, `x4`, or `x8`) into a string such as `p1.x1` or `s1.x4`. The default pod type is `p1.x1`. For more information on these, see this guide on [pod types and sizes](https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes)
+   * @param options.metadataConfig - Configuration for the behavior of Pinecone's internal metadata index. By default, all metadata is indexed; when a `metadataConfig` object is present, only metadata fields specified are indexed.
+   * @param options.metadataConfig.indexed - An array of metadata fields to index. If this array is empty, no metadata is indexed. If this array is not present, all metadata is indexed.
+   * @param options.sourceCollection - If creating an index from a collection, you can specify the name of the collection here.
+   * @see [Distance metrics](https://docs.pinecone.io/docs/indexes#distance-metrics)
+   * @see [Pod types and sizes](https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes)
+   * @throws {@link PineconeArgumentError} when invalid arguments are provided.
+   *
+   * @returns A promise that resolves when the request to create the index is completed. Note that the index is not immediately ready to use. You can use the `describeIndex` function to check the status of the index.
+   */
   createIndex: ReturnType<typeof createIndex>;
+
+  /**
+   * Deletes an index
+   *
+   * @example
+   * ```js
+   * await client.deleteIndex('my-index')
+   * ```
+   *
+   * @param indexName - The name of the index to delete.
+   * @returns A promise that resolves when the request to delete the index is completed.
+   * @throws {@link PineconeArgumentError} when invalid arguments are provided
+   */
   deleteIndex: ReturnType<typeof deleteIndex>;
+
+  /**
+   * Configure an index
+   *
+   * Use this method to update configuration on an existing index. You can update the number of pods, replicas, and pod type. You can also update the metadata configuration.
+   *
+   * @example
+   * ```js
+   * await client.configureIndex('my-index', { replicas: 2, podType: 'p1.x2' })
+   * ```
+   *
+   * @param indexName - The name of the index to configure.
+   * @param options - The configuration properties you would like to update
+   * @param options.replicas - The number of replicas in the index. The default number of replicas is 1.
+   * @param options.podType - The type of pod in the index. This string should combine a base pod type (`s1`, `p1`, or `p2`) with a size (`x1`, `x2`, `x4`, or `x8`) into a string such as `p1.x1` or `s1.x4`. The default pod type is `p1.x1`. For more information on these, see this guide on [pod types and sizes](https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes)
+   * @param options.metadataConfig - Configuration for the behavior of Pinecone's internal metadata index. By default, all metadata is indexed; when a `metadataConfig` object is present, only metadata fields specified are indexed.
+   */
   configureIndex: ReturnType<typeof configureIndex>;
 
+  /**
+   * Creates a new Pinecone client. Most users will not need to call this directly, but rather use the `Pinecone` {@link Pinecone.createClient} method which aggregates information from multiple configuration sources.
+   *
+   * @example
+   * ```
+   * import { Client } from '@pinecone-database/pinecone`
+   * const client = new Client({ apiKey: 'my-api-key', environment: 'us-west1-gcp', projectId: 'my-project-id' })
+   * ```
+   *
+   * @constructor
+   * @param options - The configuration options for the client.
+   * @param options.apiKey - The API key for your Pinecone project. You can find this in the [Pinecone console](https://app.pinecone.io).
+   * @param options.environment - The environment for your Pinecone project. You can find this in the [Pinecone console](https://app.pinecone.io).
+   * @param options.projectId - The project ID for your Pinecone project is determined by  calling the whoami endpoint using your API key and environment as parameters. Users will usually not do this themselves, but rather use the {@link Pincecone} `createClient` method.
+   */
   constructor(options: ClientConfiguration) {
     this._validateConfig(options);
 
@@ -54,6 +181,7 @@ export class Client {
     this.configureIndex = configureIndex(api);
   }
 
+  /** @internal */
   _validateConfig(options: ClientConfiguration) {
     buildValidator(ClientConfigurationSchema, (errorsList) => {
       const messageParts: Array<string> = [];
@@ -80,6 +208,9 @@ export class Client {
     })(options);
   }
 
+  /**
+   * @returns The configuration object that was passed to the Client constructor.
+   */
   getConfig() {
     return this.config;
   }

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -13,7 +13,57 @@ export type ClientConfigurationInit = {
   projectId?: string;
 };
 
+/**
+ * This utility class is used to help configure a Pinecone {@link Client} by aggregating
+ * configuration from environment variables and method params. Most usage will center on the `createClient`
+ * static method.
+ *
+ * @example
+ * ```
+ * import { Pinecone } from '@pinecone-database/pinecone';
+ * const client = await Pinecone.createClient();
+ * ```
+ */
 export class Pinecone {
+  /**
+   * This is the primary way to create a new client instance.
+   *
+   * @example
+   * If you would like to configure the client via environment variables, you can invoke this method with no arguments:
+   * ```typescript
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = await Pinecone.createClient();
+   * ```
+   *
+   * When no arguments are provided, the client will attempt to read configuration from the following environment variables:
+   * - `PINECONE_ENVIRONMENT`
+   * - `PINECONE_API_KEY`
+   * - `PINECONE_PROJECT_ID` (optional)
+   *
+   * If a project ID is not provided, the client will fetch it from the Pinecone API.
+   *
+   * @example
+   * If you would like to configure the client via arguments, you can invoke this method with a {@link ClientConfigurationInit} object:
+   * ```typescript
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = await Pinecone.createClient({
+   *   apiKey: 'my-api-key',
+   *   environment: 'us-west1-gcp'
+   * });
+   * ```
+   *
+   * This can be useful if your application needs to interact with indexes from multiple projects and relying on environment variables would create a conflict.
+   *
+   * Whether you are configuring via environment variables or arguments, the client will throw an error if it is unable to read the required configuration.
+   *
+   * @param options - A {@link ClientConfigurationInit} object containing the configuration for the client.
+   * @param options.apiKey - The API key to use for authentication.
+   * @param options.environment - The environment to use for the client.
+   * @param options.projectId - The project ID to use for the client. If not provided, the project ID will be fetched from the Pinecone API.
+   * @throws {@link PineconeConfigurationError} if the client is unable to find the required configuration from either parameters or environment variables.
+   * @returns A new {@link Client} instance.
+   */
   static async createClient(
     options?: ClientConfigurationInit
   ): Promise<Client> {
@@ -31,6 +81,17 @@ export class Pinecone {
     }
   }
 
+  /**
+   * @internal
+   * This method is used by {@link Pinecone.createClient} to read configuration from environment variables.
+   *
+   * It looks for the following environment variables:
+   * - `PINECONE_ENVIRONMENT`
+   * - `PINECONE_API_KEY`
+   * - `PINECONE_PROJECT_ID`
+   *
+   * @returns A {@link ClientConfigurationInit} object populated with values found in environment variables.
+   */
   static _readEnvironmentConfig(): ClientConfigurationInit {
     if (!process || !process.env) {
       throw new PineconeEnvironmentVarsNotSupportedError(
@@ -137,6 +198,7 @@ export class Pinecone {
     return json.project_name;
   }
 
+  /** @hidden */
   static _buildWhoamiRequest(
     environment: string,
     apiKey: string

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -117,6 +117,11 @@ function attachHandler(instance: VectorOperationsApi): VectorOperationsApi {
 
 interface PineconeClient extends IndexOperationsApi {}
 
+/**
+ * @deprecated in v1.0.0
+ * 
+ * Use {@link Client} instead, which is most easily initialized with the `Pinecone`{@link Pinecone.createClient} static method.
+ */
 class PineconeClient {
   apiKey: string | null = null;
   projectName: string | null = null;

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  // Comments are supported, like tsconfig.json
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}


### PR DESCRIPTION
## Problem

We need a way to create inline documentation in our source code.

## Solution

- Use [typedoc](https://typedoc.org/guides/overview/) as a devDependency. This project takes heavy inspiration from the much older jsdoc project but is compatible with typescript.
- Add initial docs about client methods landed to master
- Add `@deprecated` attribute to old client.

## Type of Change

- [x] Docs

## Test Plan

Describe specific steps for validating this change.
