### PR TITLE
[v1] Add upsert and fetch to new client

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -17,7 +17,7 @@ describe('Client', () => {
           // @ts-ignore
           new Client({ apiKey: 'test-key' });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The argument must have required property 'environment'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The argument must have required property 'environment'. The argument must have required property 'projectId'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
 
         expect(() => {
@@ -26,7 +26,7 @@ describe('Client', () => {
             environment: 'test-environment',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The argument must have required property 'apiKey'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The argument must have required property 'apiKey'. The argument must have required property 'projectId'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
       });
 
@@ -35,10 +35,11 @@ describe('Client', () => {
           // @ts-ignore
           new Client({
             environment: '',
+            projectId: '',
             apiKey: 'test-key',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The property 'environment' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The property 'environment' must not be blank. The property 'projectId' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
 
         expect(() => {
@@ -48,7 +49,7 @@ describe('Client', () => {
             apiKey: '',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The property 'apiKey' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "Configuration passed to Client constructor had a problem. The argument must have required property 'projectId'. The property 'apiKey' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
         );
       });
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,7 @@ import {
   describeCollection,
   deleteCollection,
 } from './control';
+import { Index } from './data';
 import { buildValidator } from './validator';
 import { Static, Type } from '@sinclair/typebox';
 
@@ -22,7 +23,7 @@ const ClientConfigurationSchema = Type.Object(
   {
     environment: Type.String({ minLength: 1 }),
     apiKey: Type.String({ minLength: 1 }),
-    projectId: Type.Optional(Type.String({ minLength: 1 })),
+    projectId: Type.String({ minLength: 1 }),
   },
   { additionalProperties: false }
 );
@@ -282,5 +283,14 @@ export class Client {
    */
   getConfig() {
     return this.config;
+  }
+
+  index(indexName: string) {
+    return new Index(indexName, this.config);
+  }
+
+  // Alias method to match the Python SDK capitalization
+  Index(indexName: string) {
+    return this.index(indexName);
   }
 }

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -39,7 +39,8 @@ export const createIndex = (api: IndexOperationsApi) => {
       return;
     } catch (e) {
       const createIndexError = e as ResponseError;
-      const message = await createIndexError.response.text();
+      const messageJSON = await createIndexError.response.text();
+      const message = JSON.parse(messageJSON).message;
       throw mapHttpStatusError({
         status: createIndexError.response.status,
         url: createIndexError.response.url,

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -1,6 +1,6 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { ResponseError } from '../pinecone-generated-ts-fetch';
-import { mapHttpStatusError } from '../errors';
+import { mapHttpStatusError, extractMessage } from '../errors';
 import { builOptionConfigValidator } from '../validator';
 
 import { Static, Type } from '@sinclair/typebox';
@@ -39,8 +39,7 @@ export const createIndex = (api: IndexOperationsApi) => {
       return;
     } catch (e) {
       const createIndexError = e as ResponseError;
-      const messageJSON = await createIndexError.response.text();
-      const message = JSON.parse(messageJSON).message;
+      const message = await extractMessage(createIndexError);
       throw mapHttpStatusError({
         status: createIndexError.response.status,
         url: createIndexError.response.url,

--- a/src/data/__tests__/fetch.test.ts
+++ b/src/data/__tests__/fetch.test.ts
@@ -27,7 +27,7 @@ describe('fetch', () => {
     const fetchFn = fetch(VOA, 'namespace');
     const returned = await fetchFn(['1', '2']);
 
-    expect(returned).toEqual({"vectors": []});
+    expect(returned).toEqual({ vectors: [] });
     expect(VOA.fetch).toHaveBeenCalledWith({
       ids: ['1', '2'],
       namespace: 'namespace',

--- a/src/data/__tests__/fetch.test.ts
+++ b/src/data/__tests__/fetch.test.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../pinecone-generated-ts-fetch';
 
 describe('fetch', () => {
-  test('calls the openapi fetch endpoint', async () => {
+  test('calls the openapi fetch endpoint, passing target namespace', async () => {
     const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> = jest
       .fn()
       .mockImplementation(() =>
@@ -27,12 +27,10 @@ describe('fetch', () => {
     const fetchFn = fetch(VOA, 'namespace');
     const returned = await fetchFn(['1', '2']);
 
-    expect(returned).toBe(void 0);
+    expect(returned).toEqual({"vectors": []});
     expect(VOA.fetch).toHaveBeenCalledWith({
-      fetchRequest: {
-        ids: ['1', '2'],
-        namespace: 'namespace',
-      },
+      ids: ['1', '2'],
+      namespace: 'namespace',
     });
   });
 

--- a/src/data/__tests__/fetch.test.ts
+++ b/src/data/__tests__/fetch.test.ts
@@ -2,17 +2,22 @@ import { fetch } from '../fetch';
 import {
   PineconeBadRequestError,
   PineconeInternalServerError,
-  PineconeNotFoundError,
 } from '../../errors';
 import { VectorOperationsApi } from '../../pinecone-generated-ts-fetch';
-import type { FetchRequest, FetchResponse } from '../../pinecone-generated-ts-fetch';
+import type {
+  FetchRequest,
+  FetchResponse,
+} from '../../pinecone-generated-ts-fetch';
 
 describe('fetch', () => {
   test('calls the openapi fetch endpoint', async () => {
-    const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> =
-      jest.fn().mockImplementation(() => Promise.resolve({
-        vectors: [],
-      }));
+    const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({
+          vectors: [],
+        })
+      );
     const VOA = { fetch: fakeFetch } as VectorOperationsApi;
 
     jest.mock('../../pinecone-generated-ts-fetch', () => ({
@@ -27,14 +32,15 @@ describe('fetch', () => {
       fetchRequest: {
         ids: ['1', '2'],
         namespace: 'namespace',
-      }
+      },
     });
   });
 
   describe('http error mapping', () => {
     test('when 500 occurs', async () => {
-      const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> =
-        jest.fn().mockImplementation(() =>
+      const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> = jest
+        .fn()
+        .mockImplementation(() =>
           Promise.reject({
             response: {
               status: 500,
@@ -58,8 +64,9 @@ describe('fetch', () => {
     });
 
     test('when 400 occurs, displays server message', async () => {
-      const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> =
-        jest.fn().mockImplementation(() =>
+      const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> = jest
+        .fn()
+        .mockImplementation(() =>
           Promise.reject({
             response: {
               status: 400,

--- a/src/data/__tests__/fetch.test.ts
+++ b/src/data/__tests__/fetch.test.ts
@@ -1,0 +1,87 @@
+import { fetch } from '../fetch';
+import {
+  PineconeBadRequestError,
+  PineconeInternalServerError,
+  PineconeNotFoundError,
+} from '../../errors';
+import { VectorOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type { FetchRequest, FetchResponse } from '../../pinecone-generated-ts-fetch';
+
+describe('fetch', () => {
+  test('calls the openapi fetch endpoint', async () => {
+    const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> =
+      jest.fn().mockImplementation(() => Promise.resolve({
+        vectors: [],
+      }));
+    const VOA = { fetch: fakeFetch } as VectorOperationsApi;
+
+    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+      VectorOperationsApi: VOA,
+    }));
+
+    const fetchFn = fetch(VOA, 'namespace');
+    const returned = await fetchFn(['1', '2']);
+
+    expect(returned).toBe(void 0);
+    expect(VOA.fetch).toHaveBeenCalledWith({
+      fetchRequest: {
+        ids: ['1', '2'],
+        namespace: 'namespace',
+      }
+    });
+  });
+
+  describe('http error mapping', () => {
+    test('when 500 occurs', async () => {
+      const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> =
+        jest.fn().mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 500,
+              text: () => 'backend error message',
+            },
+          })
+        );
+      const VOA = {
+        fetch: fakeFetch,
+      } as VectorOperationsApi;
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        VectorOperationsApi: VOA,
+      }));
+
+      const toThrow = async () => {
+        const fetchFn = fetch(VOA, 'namespace');
+        await fetchFn(['1']);
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeInternalServerError);
+    });
+
+    test('when 400 occurs, displays server message', async () => {
+      const fakeFetch: (req: FetchRequest) => Promise<FetchResponse> =
+        jest.fn().mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 400,
+              text: () => 'backend error message',
+            },
+          })
+        );
+      const VOA = {
+        fetch: fakeFetch,
+      } as VectorOperationsApi;
+
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        VectorOperationsApi: VOA,
+      }));
+
+      const toThrow = async () => {
+        const fetchFn = fetch(VOA, 'namespace');
+        await fetchFn(['1']);
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeBadRequestError);
+      await expect(toThrow).rejects.toThrow('backend error message');
+    });
+  });
+});

--- a/src/data/__tests__/upsert.test.ts
+++ b/src/data/__tests__/upsert.test.ts
@@ -2,10 +2,12 @@ import { upsert } from '../upsert';
 import {
   PineconeBadRequestError,
   PineconeInternalServerError,
-  PineconeNotFoundError,
 } from '../../errors';
 import { VectorOperationsApi } from '../../pinecone-generated-ts-fetch';
-import type { UpsertOperationRequest, UpsertResponse } from '../../pinecone-generated-ts-fetch';
+import type {
+  UpsertOperationRequest,
+  UpsertResponse,
+} from '../../pinecone-generated-ts-fetch';
 
 describe('upsert', () => {
   test('calls the openapi upsert endpoint', async () => {
@@ -25,21 +27,22 @@ describe('upsert', () => {
       upsertRequest: {
         namespace: 'namespace',
         vectors: [{ id: '1', values: [1, 2, 3] }],
-      }
+      },
     });
   });
 
   describe('http error mapping', () => {
     test('when 500 occurs', async () => {
-      const fakeUpsert: (req: UpsertOperationRequest) => Promise<UpsertResponse> =
-        jest.fn().mockImplementation(() =>
-          Promise.reject({
-            response: {
-              status: 500,
-              text: () => 'backend error message',
-            },
-          })
-        );
+      const fakeUpsert: (
+        req: UpsertOperationRequest
+      ) => Promise<UpsertResponse> = jest.fn().mockImplementation(() =>
+        Promise.reject({
+          response: {
+            status: 500,
+            text: () => 'backend error message',
+          },
+        })
+      );
       const VOA = {
         upsert: fakeUpsert,
       } as VectorOperationsApi;
@@ -56,15 +59,16 @@ describe('upsert', () => {
     });
 
     test('when 400 occurs, displays server message', async () => {
-      const fakeUpsert: (req: UpsertOperationRequest) => Promise<UpsertResponse> =
-        jest.fn().mockImplementation(() =>
-          Promise.reject({
-            response: {
-              status: 400,
-              text: () => 'backend error message',
-            },
-          })
-        );
+      const fakeUpsert: (
+        req: UpsertOperationRequest
+      ) => Promise<UpsertResponse> = jest.fn().mockImplementation(() =>
+        Promise.reject({
+          response: {
+            status: 400,
+            text: () => 'backend error message',
+          },
+        })
+      );
       const VOA = {
         upsert: fakeUpsert,
       } as VectorOperationsApi;

--- a/src/data/__tests__/upsert.test.ts
+++ b/src/data/__tests__/upsert.test.ts
@@ -1,0 +1,85 @@
+import { upsert } from '../upsert';
+import {
+  PineconeBadRequestError,
+  PineconeInternalServerError,
+  PineconeNotFoundError,
+} from '../../errors';
+import { VectorOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type { UpsertOperationRequest, UpsertResponse } from '../../pinecone-generated-ts-fetch';
+
+describe('upsert', () => {
+  test('calls the openapi upsert endpoint', async () => {
+    const fakeUpsert: (req: UpsertOperationRequest) => Promise<UpsertResponse> =
+      jest.fn();
+    const VOA = { upsert: fakeUpsert } as VectorOperationsApi;
+
+    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+      VectorOperationsApi: VOA,
+    }));
+
+    const upsertFn = upsert(VOA, 'namespace');
+    const returned = await upsertFn([{ id: '1', values: [1, 2, 3] }]);
+
+    expect(returned).toBe(void 0);
+    expect(VOA.upsert).toHaveBeenCalledWith({
+      upsertRequest: {
+        namespace: 'namespace',
+        vectors: [{ id: '1', values: [1, 2, 3] }],
+      }
+    });
+  });
+
+  describe('http error mapping', () => {
+    test('when 500 occurs', async () => {
+      const fakeUpsert: (req: UpsertOperationRequest) => Promise<UpsertResponse> =
+        jest.fn().mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 500,
+              text: () => 'backend error message',
+            },
+          })
+        );
+      const VOA = {
+        upsert: fakeUpsert,
+      } as VectorOperationsApi;
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        VectorOperationsApi: VOA,
+      }));
+
+      const toThrow = async () => {
+        const upsertFn = upsert(VOA, 'namespace');
+        await upsertFn([]);
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeInternalServerError);
+    });
+
+    test('when 400 occurs, displays server message', async () => {
+      const fakeUpsert: (req: UpsertOperationRequest) => Promise<UpsertResponse> =
+        jest.fn().mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 400,
+              text: () => 'backend error message',
+            },
+          })
+        );
+      const VOA = {
+        upsert: fakeUpsert,
+      } as VectorOperationsApi;
+
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        VectorOperationsApi: VOA,
+      }));
+
+      const toThrow = async () => {
+        const upsertFn = upsert(VOA, 'namespace');
+        await upsertFn([]);
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeBadRequestError);
+      await expect(toThrow).rejects.toThrow('backend error message');
+    });
+  });
+});

--- a/src/data/fetch.ts
+++ b/src/data/fetch.ts
@@ -1,5 +1,8 @@
-import { FetchError, VectorOperationsApi } from '../pinecone-generated-ts-fetch';
-import type { ResponseError, FetchResponse } from '../pinecone-generated-ts-fetch';
+import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
+import type {
+  ResponseError,
+  FetchResponse,
+} from '../pinecone-generated-ts-fetch';
 import { mapHttpStatusError, PineconeConnectionError } from '../errors';
 import { builOptionConfigValidator } from '../validator';
 
@@ -9,26 +12,25 @@ const IdsArray = Type.Array(Type.String({ minLength: 1 }));
 export type IdsArray = Static<typeof IdsArray>;
 
 export const fetch = (api: VectorOperationsApi, namespace: string) => {
-  const validator = builOptionConfigValidator(
-    IdsArray,
-    'fetch'
-  );
+  const validator = builOptionConfigValidator(IdsArray, 'fetch');
 
   return async (ids: IdsArray): Promise<FetchResponse> => {
     validator(ids);
 
     try {
-      const vectors = await api.fetch({ ids: ids, namespace }); 
+      const vectors = await api.fetch({ ids: ids, namespace });
       return vectors;
     } catch (e) {
       if (e instanceof Error && e.name === 'FetchError') {
-        throw new PineconeConnectionError('Request failed to reach the server. Are you sure you are targeting an index that exists?')
+        throw new PineconeConnectionError(
+          'Request failed to reach the server. Are you sure you are targeting an index that exists?'
+        );
       } else {
         const fetchError = e as ResponseError;
         let message = await fetchError.response.text();
 
         // Error response of this endpoint seems different from others,
-        // so we will try to parse out the actual message text, but 
+        // so we will try to parse out the actual message text, but
         // we wrap it in a try to avoid crashing in a way that obscures
         // the actual error if the response format changes in the future.
         try {

--- a/src/data/fetch.ts
+++ b/src/data/fetch.ts
@@ -1,6 +1,6 @@
 import { FetchError, VectorOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { ResponseError, FetchResponse } from '../pinecone-generated-ts-fetch';
-import { mapHttpStatusError } from '../errors';
+import { mapHttpStatusError, PineconeConnectionError } from '../errors';
 import { builOptionConfigValidator } from '../validator';
 
 import { Static, Type } from '@sinclair/typebox';
@@ -22,10 +22,24 @@ export const fetch = (api: VectorOperationsApi, namespace: string) => {
       return vectors;
     } catch (e) {
       if (e instanceof Error && e.name === 'FetchError') {
-        throw 'Request failed to reach the server. Are you sure you are connected to the internet?'
+        throw new PineconeConnectionError('Request failed to reach the server. Are you sure you are targeting an index that exists?')
       } else {
         const fetchError = e as ResponseError;
-        const message = await fetchError.response.text();
+        let message = await fetchError.response.text();
+
+        // Error response of this endpoint seems different from others,
+        // so we will try to parse out the actual message text, but 
+        // we wrap it in a try to avoid crashing in a way that obscures
+        // the actual error if the response format changes in the future.
+        try {
+          const messageJSON = JSON.parse(message);
+          if (messageJSON.message) {
+            message = messageJSON.message;
+          }
+        } catch (e) {
+          // noop
+        }
+
         throw mapHttpStatusError({
           status: fetchError.response.status,
           url: fetchError.response.url,

--- a/src/data/fetch.ts
+++ b/src/data/fetch.ts
@@ -1,0 +1,37 @@
+import { FetchError, VectorOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError, FetchResponse } from '../pinecone-generated-ts-fetch';
+import { mapHttpStatusError } from '../errors';
+import { builOptionConfigValidator } from '../validator';
+
+import { Static, Type } from '@sinclair/typebox';
+
+const IdsArray = Type.Array(Type.String({ minLength: 1 }));
+export type IdsArray = Static<typeof IdsArray>;
+
+export const fetch = (api: VectorOperationsApi, namespace: string) => {
+  const validator = builOptionConfigValidator(
+    IdsArray,
+    'fetch'
+  );
+
+  return async (ids: IdsArray): Promise<FetchResponse> => {
+    validator(ids);
+
+    try {
+      const vectors = await api.fetch({ ids: ids, namespace }); 
+      return vectors;
+    } catch (e) {
+      if (e instanceof Error && e.name === 'FetchError') {
+        throw 'Request failed to reach the server. Are you sure you are connected to the internet?'
+      } else {
+        const fetchError = e as ResponseError;
+        const message = await fetchError.response.text();
+        throw mapHttpStatusError({
+          status: fetchError.response.status,
+          url: fetchError.response.url,
+          message: message,
+        });
+      }
+    }
+  };
+};

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,43 @@
+import type { ConfigurationParameters } from "../pinecone-generated-ts-fetch";
+import { Configuration, VectorOperationsApi } from "../pinecone-generated-ts-fetch";
+import { upsert } from './upsert';
+import { fetch } from './fetch';
+
+type ApiConfig = {
+    projectId: string,
+    apiKey: string,
+    environment: string
+}
+
+export class Index {
+    private config: ApiConfig;
+    private target: {
+        index: string,
+        namespace: string
+    };
+
+    upsert: ReturnType<typeof upsert>;
+    fetch: ReturnType<typeof fetch>;
+
+    constructor(indexName: string, config: ApiConfig, namespace = '') {
+        const indexConfigurationParameters: ConfigurationParameters = {
+            basePath: `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`,
+            apiKey: config.apiKey,
+          };
+
+        const indexConfiguration = new Configuration(indexConfigurationParameters);
+        const vectorOperations = new VectorOperationsApi(indexConfiguration);
+        this.config = config;
+        this.target = {
+            index: indexName,
+            namespace: namespace
+        }
+
+        this.upsert = upsert(vectorOperations, namespace);
+        this.fetch = fetch(vectorOperations, namespace);
+    }
+
+    namespace(namespace: string): Index {
+        return new Index(this.target.index, this.config, namespace);
+    }
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,43 +1,46 @@
-import type { ConfigurationParameters } from "../pinecone-generated-ts-fetch";
-import { Configuration, VectorOperationsApi } from "../pinecone-generated-ts-fetch";
+import type { ConfigurationParameters } from '../pinecone-generated-ts-fetch';
+import {
+  Configuration,
+  VectorOperationsApi,
+} from '../pinecone-generated-ts-fetch';
 import { upsert } from './upsert';
 import { fetch } from './fetch';
 
 type ApiConfig = {
-    projectId: string,
-    apiKey: string,
-    environment: string
-}
+  projectId: string;
+  apiKey: string;
+  environment: string;
+};
 
 export class Index {
-    private config: ApiConfig;
-    private target: {
-        index: string,
-        namespace: string
+  private config: ApiConfig;
+  private target: {
+    index: string;
+    namespace: string;
+  };
+
+  upsert: ReturnType<typeof upsert>;
+  fetch: ReturnType<typeof fetch>;
+
+  constructor(indexName: string, config: ApiConfig, namespace = '') {
+    const indexConfigurationParameters: ConfigurationParameters = {
+      basePath: `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`,
+      apiKey: config.apiKey,
     };
 
-    upsert: ReturnType<typeof upsert>;
-    fetch: ReturnType<typeof fetch>;
+    const indexConfiguration = new Configuration(indexConfigurationParameters);
+    const vectorOperations = new VectorOperationsApi(indexConfiguration);
+    this.config = config;
+    this.target = {
+      index: indexName,
+      namespace: namespace,
+    };
 
-    constructor(indexName: string, config: ApiConfig, namespace = '') {
-        const indexConfigurationParameters: ConfigurationParameters = {
-            basePath: `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`,
-            apiKey: config.apiKey,
-          };
+    this.upsert = upsert(vectorOperations, namespace);
+    this.fetch = fetch(vectorOperations, namespace);
+  }
 
-        const indexConfiguration = new Configuration(indexConfigurationParameters);
-        const vectorOperations = new VectorOperationsApi(indexConfiguration);
-        this.config = config;
-        this.target = {
-            index: indexName,
-            namespace: namespace
-        }
-
-        this.upsert = upsert(vectorOperations, namespace);
-        this.fetch = fetch(vectorOperations, namespace);
-    }
-
-    namespace(namespace: string): Index {
-        return new Index(this.target.index, this.config, namespace);
-    }
+  namespace(namespace: string): Index {
+    return new Index(this.target.index, this.config, namespace);
+  }
 }

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -1,6 +1,10 @@
 import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { ResponseError } from '../pinecone-generated-ts-fetch';
-import { mapHttpStatusError, PineconeConnectionError } from '../errors';
+import {
+  mapHttpStatusError,
+  PineconeConnectionError,
+  extractMessage,
+} from '../errors';
 import { builOptionConfigValidator } from '../validator';
 
 import { Static, Type } from '@sinclair/typebox';
@@ -42,20 +46,7 @@ export const upsert = (api: VectorOperationsApi, namespace: string) => {
         );
       } else {
         const upsertError = e as ResponseError;
-        let message = await upsertError.response.text();
-
-        // Error response of this endpoint seems different from others,
-        // so we will try to parse out the actual message text, but
-        // we wrap it in a try to avoid crashing in a way that obscures
-        // the actual error if the response format changes in the future.
-        try {
-          const messageJSON = JSON.parse(message);
-          if (messageJSON.message) {
-            message = messageJSON.message;
-          }
-        } catch (e) {
-          // noop
-        }
+        const message = await extractMessage(upsertError);
 
         throw mapHttpStatusError({
           status: upsertError.response.status,

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -1,0 +1,57 @@
+import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+import { mapHttpStatusError } from '../errors';
+import { builOptionConfigValidator } from '../validator';
+
+import { Static, Type } from '@sinclair/typebox';
+
+const nonemptyString = Type.String({ minLength: 1 });
+
+const SparseValues = Type.Object({
+    indices: Type.Array(Type.Integer()),
+    values: Type.Array(Type.Number()),
+});
+
+const Vector = Type.Object({
+    id: nonemptyString,
+    values: Type.Array(Type.Number()),
+    sparseValues: Type.Optional(SparseValues),
+    metadata: Type.Optional(Type.Object({}, { additionalProperties: true }))
+});
+
+const VectorArray = Type.Array(Vector);
+
+export type Vector = Static<typeof Vector>;
+export type SparseValues = Static<typeof SparseValues>;
+
+export type VectorArray = Static<typeof VectorArray>;
+
+export const upsert = (api: VectorOperationsApi, namespace: string) => {
+  const validator = builOptionConfigValidator(
+    VectorArray,
+    'upsert'
+  );
+
+  return async (vectors: VectorArray): Promise<void> => {
+    validator(vectors);
+
+    try {
+      await api.upsert({ upsertRequest: { vectors, namespace } }); 
+      return;
+    } catch (e) {
+      if (e instanceof Error && e.name === 'FetchError') {
+        throw 'Request failed to reach the server. Are you sure you are connected to the internet?'
+      } else {
+        const upsertError = e as ResponseError;
+        const message = await upsertError.response.text();
+        console.log(message)
+        console.log(JSON.stringify(e))
+        throw mapHttpStatusError({
+          status: upsertError.response.status,
+          url: upsertError.response.url,
+          message: message,
+        });  
+      }
+    }
+  };
+};

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -8,15 +8,15 @@ import { Static, Type } from '@sinclair/typebox';
 const nonemptyString = Type.String({ minLength: 1 });
 
 const SparseValues = Type.Object({
-    indices: Type.Array(Type.Integer()),
-    values: Type.Array(Type.Number()),
+  indices: Type.Array(Type.Integer()),
+  values: Type.Array(Type.Number()),
 });
 
 const Vector = Type.Object({
-    id: nonemptyString,
-    values: Type.Array(Type.Number()),
-    sparseValues: Type.Optional(SparseValues),
-    metadata: Type.Optional(Type.Object({}, { additionalProperties: true }))
+  id: nonemptyString,
+  values: Type.Array(Type.Number()),
+  sparseValues: Type.Optional(SparseValues),
+  metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
 });
 
 const VectorArray = Type.Array(Vector);
@@ -27,26 +27,25 @@ export type SparseValues = Static<typeof SparseValues>;
 export type VectorArray = Static<typeof VectorArray>;
 
 export const upsert = (api: VectorOperationsApi, namespace: string) => {
-  const validator = builOptionConfigValidator(
-    VectorArray,
-    'upsert'
-  );
+  const validator = builOptionConfigValidator(VectorArray, 'upsert');
 
   return async (vectors: VectorArray): Promise<void> => {
     validator(vectors);
 
     try {
-      await api.upsert({ upsertRequest: { vectors, namespace } }); 
+      await api.upsert({ upsertRequest: { vectors, namespace } });
       return;
     } catch (e) {
       if (e instanceof Error && e.name === 'FetchError') {
-        throw new PineconeConnectionError('Request failed to reach the server. Are you sure you are targeting an index that exists?')
+        throw new PineconeConnectionError(
+          'Request failed to reach the server. Are you sure you are targeting an index that exists?'
+        );
       } else {
         const upsertError = e as ResponseError;
         let message = await upsertError.response.text();
-        
+
         // Error response of this endpoint seems different from others,
-        // so we will try to parse out the actual message text, but 
+        // so we will try to parse out the actual message text, but
         // we wrap it in a try to avoid crashing in a way that obscures
         // the actual error if the response format changes in the future.
         try {
@@ -62,7 +61,7 @@ export const upsert = (api: VectorOperationsApi, namespace: string) => {
           status: upsertError.response.status,
           url: upsertError.response.url,
           message: message,
-        });  
+        });
       }
     }
   };

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -5,4 +5,7 @@ export {
   PineconeUnknownRequestFailure,
 } from './config';
 export * from './http';
+export {
+  PineconeConnectionError
+} from './request';
 export { PineconeArgumentError } from './validation';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -5,7 +5,5 @@ export {
   PineconeUnknownRequestFailure,
 } from './config';
 export * from './http';
-export {
-  PineconeConnectionError
-} from './request';
+export { PineconeConnectionError } from './request';
 export { PineconeArgumentError } from './validation';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -7,3 +7,4 @@ export {
 export * from './http';
 export { PineconeConnectionError } from './request';
 export { PineconeArgumentError } from './validation';
+export { extractMessage } from './utils';

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -1,8 +1,8 @@
-import { BasePineconeError } from "./base";
+import { BasePineconeError } from './base';
 
 export class PineconeConnectionError extends BasePineconeError {
-    constructor(message: string) {
-      super(message);
-      this.name = 'PineconeConnectionError';
-    }
+  constructor(message: string) {
+    super(message);
+    this.name = 'PineconeConnectionError';
   }
+}

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -1,0 +1,8 @@
+import { BasePineconeError } from "./base";
+
+export class PineconeConnectionError extends BasePineconeError {
+    constructor(message: string) {
+      super(message);
+      this.name = 'PineconeConnectionError';
+    }
+  }

--- a/src/errors/utils.ts
+++ b/src/errors/utils.ts
@@ -1,0 +1,20 @@
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+
+export const extractMessage = async (error: ResponseError): Promise<string> => {
+  let message = await error.response.text();
+
+  // Error response is sometimes the raw message, sometimes it's JSON
+  // so we will try to parse out the actual message text, but
+  // we wrap it in a try to avoid crashing in a way that obscures
+  // the actual error if the response format changes in the future.
+  try {
+    const messageJSON = JSON.parse(message);
+    if (messageJSON.message) {
+      message = messageJSON.message;
+    }
+  } catch (e) {
+    // noop
+  }
+
+  return message;
+};


### PR DESCRIPTION
## Problem

Need to add `upsert` and `fetch` functionality to new client. Compared to the old client, these methods:

- Provide feedback when called with improper parameters
- Map server errors into a cleaner error with stacktrace
- Elevate the concept of namespaces using an optional chained index constructor method. By creating an object that has data operations scoped to that namespace, I believe you are less likely to encounter errors caused by inconsistently passing the optional namespace param.

## Solution

Similar to approach followed in other new client methods, I have wrapped the generated openapi client with additional typing and error handling.

To upsert:

```javascript
import { Pinecone } from '@pinecone-database/pinecone'

// Read config from env vars
const client = await Pinecone.createClient();

const vectors = [
  {
    id: '1',
    values: [0.1, 0.2, 0.3],
    sparseValues: {
        indices: [2],
        values: [0.1]
    },
    metadata: {}
  },
  {
    id: '2',
    values: [0.4, 0.5, 0.6],
    sparseValues: {
        indices: [2],
        values: [0.1]
    },
    metadata: {}
  }
]

// Target an index. The index dimension must match the vectors we are planning to upsert.
const index = client.index('index-name')

// Now we can upsert into the default namespace
await index.upsert(vectors)

// Now we can fetch upserted data by id
const data = await index.fetch(['1']) 

// If we wish to use non-default namespaces, we can chain a namespace call
// before upserting/fetching to create a copy of the client object scoped to perform
// all operations within that namespace.
const ns1 = index.namespace('ns1')
await ns1.upsert(vectors)

// Fetching takes place within the context of a namespace.
// This should return data because we upserted into this namespace.
await ns1.fetch(['1'])

// If we try to fetch these vectors in a different namespace,
// they will not be found.
const ns2 = index.namespace('ns2')
await ns2.fetch(['1']) // returns empty list of vector results 
```

## Known issues

There is a known issue affecting the underlying generated openapi client that does not properly build the request URL when fetching multiple ids at once. I think I have pinpointed the cause but will post a follow-up separately because it needs to be applied to both the new and old client and don't really want to do that in the same commit where I am adding a new feature.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Added unit tests, which should be run automatically.

For manual testing, run `npm run repl` to launch a node repl with credentials pulled from `.env`.

Manual test cases:
- ✅  Calling targeting an index that doesn't exist and trying to upsert/fetch displays a sensible error
- ✅ Calling upsert with no params errors with user feedback
- ✅ Upserting with malformed vector data errors with user feedback
- ✅ Fetching: when id does not exist returns empty results list
- ✅ Fetching: when id exists, but not in current namespace returns empty results list
- ✅ Fetching: called with no params errors with user feedback
- ✅ Fetching: called with improper type params errors with user feedback
- ❌ Fetching: when called with multiple ids (known issue)
