### PR TITLE
[Bugfix] Fix fetch/delete with multiple ids

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "quotes": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-inferrable-types": "off",
     "import/no-cycle": "error"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,7 @@ import {
 } from './control';
 import { Index } from './data';
 import { buildValidator } from './validator';
+import { queryParamsStringify } from './utils/queryParamsStringify';
 import { Static, Type } from '@sinclair/typebox';
 
 const ClientConfigurationSchema = Type.Object(
@@ -236,6 +237,7 @@ export class Client {
     const apiConfig: IndexOperationsApiConfigurationParameters = {
       basePath: controllerPath,
       apiKey,
+      queryParamsStringify,
     };
     const api = new IndexOperationsApi(new ApiConfiguration(apiConfig));
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -5,6 +5,7 @@ import {
 } from '../pinecone-generated-ts-fetch';
 import { upsert } from './upsert';
 import { fetch } from './fetch';
+import { queryParamsStringify } from '../utils/queryParamsStringify';
 
 type ApiConfig = {
   projectId: string;
@@ -26,6 +27,7 @@ export class Index {
     const indexConfigurationParameters: ConfigurationParameters = {
       basePath: `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`,
       apiKey: config.apiKey,
+      queryParamsStringify,
     };
 
     const indexConfiguration = new Configuration(indexConfigurationParameters);

--- a/src/utils/queryParamsStringify.test.ts
+++ b/src/utils/queryParamsStringify.test.ts
@@ -1,0 +1,20 @@
+import { queryParamsStringify } from './queryParamsStringify';
+
+describe('queryParamsStringify', () => {
+  test('should stringify array params correctly', () => {
+    const params = {
+      ids: ['1', '2', '3'],
+    };
+    expect(queryParamsStringify(params)).toEqual('ids=1&ids=2&ids=3');
+  });
+
+  test('should stringify array params correctly when there are other params', () => {
+    const params = {
+      ids: ['1', '2', '3'],
+      other: 'param',
+    };
+    expect(queryParamsStringify(params)).toEqual(
+      'ids=1&ids=2&ids=3&other=param'
+    );
+  });
+});

--- a/src/utils/queryParamsStringify.ts
+++ b/src/utils/queryParamsStringify.ts
@@ -1,5 +1,10 @@
 import type { HTTPQuery } from '../pinecone-generated-ts-fetch';
 
+// Everything in this file is lifted from the generated openapi runtime.
+// I need to create a small modification of the generated queryParamStringify
+// function in order to fix an issue with array params.
+//
+// See https://github.com/pinecone-io/pinecone-ts-client/pull/74
 export function queryParamsStringify(
   params: HTTPQuery,
   prefix: string = ''

--- a/src/utils/queryParamsStringify.ts
+++ b/src/utils/queryParamsStringify.ts
@@ -1,0 +1,50 @@
+import type { HTTPQuery } from '../pinecone-generated-ts-fetch';
+
+export function queryParamsStringify(
+  params: HTTPQuery,
+  prefix: string = ''
+): string {
+  return Object.keys(params)
+    .map((key) => querystringSingleKey(key, params[key], prefix))
+    .filter((part) => part.length > 0)
+    .join('&');
+}
+
+function querystringSingleKey(
+  key: string,
+  value:
+    | string
+    | number
+    | null
+    | undefined
+    | boolean
+    | Array<string | number | null | boolean>
+    | Set<string | number | null | boolean>
+    | HTTPQuery,
+  keyPrefix: string = ''
+): string {
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+
+  // This is a one line change from the default querystring implementation. Checking
+  // with `Array.isArray` instead of `value instanceof Array` allows us to get the
+  // the correct behavior when stringifying array params.
+  if (Array.isArray(value)) {
+    const multiValue = value
+      .map((singleValue) => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(
+      value.toISOString()
+    )}`;
+  }
+  if (value instanceof Object) {
+    return queryParamsStringify(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+}

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -6,6 +6,7 @@ import {
   VectorOperationsApi,
 } from '../pinecone-generated-ts-fetch';
 import 'cross-fetch/polyfill';
+import { queryParamsStringify } from '../utils/queryParamsStringify';
 
 type PineconeClientConfiguration = {
   environment: string;
@@ -168,6 +169,7 @@ class PineconeClient {
     const controllerConfigurationParameters: ConfigurationParameters = {
       basePath: controllerPath,
       apiKey: apiKey,
+      queryParamsStringify
     };
 
     const controllerConfiguration = new Configuration(
@@ -192,6 +194,7 @@ class PineconeClient {
     const indexConfigurationParameters: ConfigurationParameters = {
       basePath: `https://${index}-${this.projectName}.svc.${this.environment}.pinecone.io`,
       apiKey: this.apiKey,
+      queryParamsStringify
     };
 
     const indexConfiguration = new Configuration(indexConfigurationParameters);


### PR DESCRIPTION
## Problem

The `fetch` and `delete` operations were not working as expected when passed multiple id values in an array. For example, ids could be fetched individually but not together.

```
import { Pinecone } from '@pinecone-database/pinecone'

// Read config from env vars
const client = await Pinecone.createClient();

const vectors = [
  {
    id: '1',
    values: [0.1, 0.2, 0.3],
    sparseValues: {
        indices: [2],
        values: [0.1]
    },
    metadata: {}
  },
  {
    id: '2',
    values: [0.4, 0.5, 0.6],
    sparseValues: {
        indices: [2],
        values: [0.1]
    },
    metadata: {}
  }
]

// Target an index. The index dimension must match the vectors we are planning to upsert.
const index = client.index('index-name')
await index.upsert(vectors)

await index.fetch(['1']) // returns data for vector 1
await index.fetch(['2']) // returns data for vector 2

// expected: returns data for both vectors
await index.fetch(['1', '2']) // actual: returns empty results 
```

The same issue is present in the legacy client, with modified sytnax.

## Solution

Since both clients are implemented around a core of generated openapi code, they shared the same root cause which is that the generated openapi client uses a faulty method of determining whether a value is an array before serializing query parameters into a string.

Previously this relied on the check `value instanceof Array` which is [known to produce confusing results](https://stackoverflow.com/questions/22289727/difference-between-using-array-isarray-and-instanceof-array) in a number of different situations. I copied the default implementation and modified this if-statement to use the much more reliable `Array.isArray` method.

Fortunately the fix is straightforward since the openapi generated client exposes a configuration parameter that allows us to substitute our own implementation for the query string generation function.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Re-run the above repoduction scenario and see the expected output.