### PR TITLE
[v1] Refactoring data method error handling

### DIFF
--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -1,10 +1,5 @@
 import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
-import type { ResponseError } from '../pinecone-generated-ts-fetch';
-import {
-  mapHttpStatusError,
-  PineconeConnectionError,
-  extractMessage,
-} from '../errors';
+import { handleDataError } from './utils/errorHandling';
 import { builOptionConfigValidator } from '../validator';
 
 import { Static, Type } from '@sinclair/typebox';
@@ -27,7 +22,6 @@ const VectorArray = Type.Array(Vector);
 
 export type Vector = Static<typeof Vector>;
 export type SparseValues = Static<typeof SparseValues>;
-
 export type VectorArray = Static<typeof VectorArray>;
 
 export const upsert = (api: VectorOperationsApi, namespace: string) => {
@@ -40,20 +34,8 @@ export const upsert = (api: VectorOperationsApi, namespace: string) => {
       await api.upsert({ upsertRequest: { vectors, namespace } });
       return;
     } catch (e) {
-      if (e instanceof Error && e.name === 'FetchError') {
-        throw new PineconeConnectionError(
-          'Request failed to reach the server. Are you sure you are targeting an index that exists?'
-        );
-      } else {
-        const upsertError = e as ResponseError;
-        const message = await extractMessage(upsertError);
-
-        throw mapHttpStatusError({
-          status: upsertError.response.status,
-          url: upsertError.response.url,
-          message: message,
-        });
-      }
+      const err = await handleDataError(e);
+      throw err;
     }
   };
 };

--- a/src/data/utils/errorHandling.ts
+++ b/src/data/utils/errorHandling.ts
@@ -1,0 +1,21 @@
+import {
+  mapHttpStatusError,
+  PineconeConnectionError,
+  extractMessage,
+} from '../../errors';
+import type { ResponseError } from '../../pinecone-generated-ts-fetch';
+
+export const handleDataError = async (e: unknown): Promise<Error> => {
+  if (e instanceof Error && e.name === 'FetchError') {
+    return new PineconeConnectionError();
+  } else {
+    const responseError = e as ResponseError;
+    const message = await extractMessage(responseError);
+
+    return mapHttpStatusError({
+      status: responseError.response.status,
+      url: responseError.response.url,
+      message: message,
+    });
+  }
+};

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -1,8 +1,10 @@
 import { BasePineconeError } from './base';
 
 export class PineconeConnectionError extends BasePineconeError {
-  constructor(message: string) {
-    super(message);
+  constructor() {
+    super(
+      'Request failed to reach the server. Are you sure you are targeting an index that exists?'
+    );
     this.name = 'PineconeConnectionError';
   }
 }


### PR DESCRIPTION
## Problem

It takes a lot of boilerplate code to implement error handling for each client method. 

## Solution

Create an error-handling function that can be reused in the implementation of the remaining data plane methods for the v1 client.

## Type of Change

- [x] None of the above: Refactoring

## Test Plan

Unit tests should continue to pass after this change with no changes. This is a purely mechanical refactor.