### PR TITLE
Add user-agent header with client version to HTTP requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,7 @@ import {
 } from './control';
 import { Index } from './data';
 import { buildValidator } from './validator';
-import { queryParamsStringify } from './utils/queryParamsStringify';
+import { queryParamsStringify, buildUserAgent } from './utils';
 import { Static, Type } from '@sinclair/typebox';
 
 const ClientConfigurationSchema = Type.Object(
@@ -238,6 +238,9 @@ export class Client {
       basePath: controllerPath,
       apiKey,
       queryParamsStringify,
+      headers: {
+        'User-Agent': buildUserAgent(false),
+      },
     };
     const api = new IndexOperationsApi(new ApiConfiguration(apiConfig));
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -5,7 +5,7 @@ import {
 } from '../pinecone-generated-ts-fetch';
 import { upsert } from './upsert';
 import { fetch } from './fetch';
-import { queryParamsStringify } from '../utils/queryParamsStringify';
+import { queryParamsStringify, buildUserAgent } from '../utils';
 
 type ApiConfig = {
   projectId: string;
@@ -28,6 +28,9 @@ export class Index {
       basePath: `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`,
       apiKey: config.apiKey,
       queryParamsStringify,
+      headers: {
+        'User-Agent': buildUserAgent(false),
+      },
     };
 
     const indexConfiguration = new Configuration(indexConfigurationParameters);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,4 @@
+import { queryParamsStringify } from './queryParamsStringify';
+import { buildUserAgent } from './user-agent';
+
+export { queryParamsStringify, buildUserAgent };

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import * as os from 'os';
+
+const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+
+export const buildUserAgent = (isLegacy: boolean) => {
+  // We always want to include the package name and version
+  // along with the langauge name to help distinguish these
+  // requests from those emitted by other clients
+  const userAgentParts = [
+    `${packageJson.name} v${packageJson.version}`,
+    'lang=typescript',
+  ];
+
+  // If available, capture information about the OS
+  if (os && os.release && os.platform && os.arch) {
+    const platform = os.platform();
+    const platformVersion = os.release();
+    const arch = os.arch();
+    userAgentParts.push(`${platform} ${platformVersion}, ${arch}`);
+  }
+
+  // If available, capture information about the Node.js version
+  if (process && process.version) {
+    userAgentParts.push(`node ${process.version}`);
+  }
+
+  // Use this flag to identify whether they are using the v0 legacy
+  // client export called PineconeClient
+  userAgentParts.push(`legacyExport=${isLegacy}`);
+
+  return userAgentParts.join('; ');
+};

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -6,7 +6,8 @@ import {
   VectorOperationsApi,
 } from '../pinecone-generated-ts-fetch';
 import 'cross-fetch/polyfill';
-import { queryParamsStringify } from '../utils/queryParamsStringify';
+import { queryParamsStringify, buildUserAgent } from '../utils';
+
 
 type PineconeClientConfiguration = {
   environment: string;
@@ -169,7 +170,10 @@ class PineconeClient {
     const controllerConfigurationParameters: ConfigurationParameters = {
       basePath: controllerPath,
       apiKey: apiKey,
-      queryParamsStringify
+      queryParamsStringify,
+      headers: {
+        'User-Agent': buildUserAgent(true),
+      }
     };
 
     const controllerConfiguration = new Configuration(
@@ -194,7 +198,10 @@ class PineconeClient {
     const indexConfigurationParameters: ConfigurationParameters = {
       basePath: `https://${index}-${this.projectName}.svc.${this.environment}.pinecone.io`,
       apiKey: this.apiKey,
-      queryParamsStringify
+      queryParamsStringify,
+      headers: {
+        'User-Agent': buildUserAgent(true),
+      }
     };
 
     const indexConfiguration = new Configuration(indexConfigurationParameters);


### PR DESCRIPTION
## Problem

We need a way to understand which client versions are being used with our APIs.

## Solution

Add a `User-Agent` header to each request. The header includes the following information:
- The client version
- The client language (to easily distinguish from similarly named packages built for other languages)
- Platform information (operation system and version)
- Node version
- A flag to indicate whether the legacyExport `PineconeClient` is being used. To make the upcoming release non-breaking, we plan to continue exporting the legacy client from the module until backend API changes force us to remove it. But this flag will help us know what fraction of our users have migrated to the new client export as we navigate that process.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Check datadog dashboards to see new request headers coming through in integration testing.

<img width="1484" alt="Screenshot 2023-08-10 at 4 16 02 PM" src="https://github.com/pinecone-io/pinecone-ts-client/assets/1326365/1ffa63e2-9597-4f2a-9558-42fa80a0b145">

