### PR TITLE
[v1] Add update vector functionality to new client

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "contributors": [
     "Jen Hamon (https://github.com/jhamon)",
-    "Roie Schwaber-Cohen (https://github.com/rschwabco)"
+    "Roie Schwaber-Cohen (https://github.com/rschwabco)",
+    "Austin DeNoble (https://github.com/austin-denoble)"
   ],
   "license": "MIT",
   "scripts": {

--- a/src/data/__tests__/update.test.ts
+++ b/src/data/__tests__/update.test.ts
@@ -5,7 +5,6 @@ import {
 } from '../../errors';
 import { VectorOperationsApi } from '../../pinecone-generated-ts-fetch';
 import type { UpdateOperationRequest } from '../../pinecone-generated-ts-fetch';
-import { Vector } from '../upsert';
 
 describe('update', () => {
   test('calls the openapi update endpoint, passing target namespace', async () => {

--- a/src/data/__tests__/update.test.ts
+++ b/src/data/__tests__/update.test.ts
@@ -1,0 +1,97 @@
+import { update } from '../update';
+import {
+  PineconeBadRequestError,
+  PineconeInternalServerError,
+} from '../../errors';
+import { VectorOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type { UpdateOperationRequest } from '../../pinecone-generated-ts-fetch';
+import { Vector } from '../upsert';
+
+describe('update', () => {
+  test('calls the openapi update endpoint, passing target namespace', async () => {
+    const fakeUpdate: (req: UpdateOperationRequest) => Promise<object> =
+      jest.fn();
+    const VOA = { update: fakeUpdate } as VectorOperationsApi;
+
+    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+      VectorOperationsApi: VOA,
+    }));
+
+    const updateFn = update(VOA, 'namespace');
+    const returned = await updateFn({
+      id: 'fake-vector',
+      values: [1, 2, 3, 4, 5],
+      sparseValues: {
+        indices: [15, 30, 25],
+        values: [0.5, 0.5, 0.2],
+      },
+      setMetadata: { genre: 'ambient' },
+    });
+
+    expect(returned).toBe(void 0);
+    expect(fakeUpdate).toHaveBeenCalledWith({
+      updateRequest: {
+        namespace: 'namespace',
+        id: 'fake-vector',
+        values: [1, 2, 3, 4, 5],
+        sparseValues: {
+          indices: [15, 30, 25],
+          values: [0.5, 0.5, 0.2],
+        },
+        setMetadata: { genre: 'ambient' },
+      },
+    });
+  });
+
+  describe('http error mapping', () => {
+    test('when 500 occurs', async () => {
+      const fakeUpdate: (req: UpdateOperationRequest) => Promise<object> = jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 500,
+              text: () => 'backend error message',
+            },
+          })
+        );
+      const VOA = { update: fakeUpdate } as VectorOperationsApi;
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        VectorOperationsApi: VOA,
+      }));
+
+      const toThrow = async () => {
+        const updateFn = update(VOA, 'namespace');
+        await updateFn({ id: 'fake-vector' });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeInternalServerError);
+    });
+
+    test('when 400 occurs, displays server message', async () => {
+      const fakeUpdate: (req: UpdateOperationRequest) => Promise<object> = jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.reject({
+            response: {
+              status: 400,
+              text: () => 'backend error message',
+            },
+          })
+        );
+      const VOA = { update: fakeUpdate } as VectorOperationsApi;
+
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        VectorOperationsApi: VOA,
+      }));
+
+      const toThrow = async () => {
+        const updateFn = update(VOA, 'namespace');
+        await updateFn({ id: 'fake-vector' });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeBadRequestError);
+      await expect(toThrow).rejects.toThrow('backend error message');
+    });
+  });
+});

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -5,6 +5,7 @@ import {
 } from '../pinecone-generated-ts-fetch';
 import { upsert } from './upsert';
 import { fetch } from './fetch';
+import { update } from './update';
 import { queryParamsStringify, buildUserAgent } from '../utils';
 import { deleteVector } from './delete';
 
@@ -24,6 +25,7 @@ export class Index {
   upsert: ReturnType<typeof upsert>;
   fetch: ReturnType<typeof fetch>;
   delete: ReturnType<typeof deleteVector>;
+  update: ReturnType<typeof update>;
 
   constructor(indexName: string, config: ApiConfig, namespace = '') {
     const indexConfigurationParameters: ConfigurationParameters = {
@@ -46,6 +48,7 @@ export class Index {
     this.upsert = upsert(vectorOperations, namespace);
     this.fetch = fetch(vectorOperations, namespace);
     this.delete = deleteVector(vectorOperations, namespace);
+    this.update = update(vectorOperations, namespace);
   }
 
   namespace(namespace: string): Index {

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -1,0 +1,54 @@
+import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { ResponseError } from '../pinecone-generated-ts-fetch';
+import {
+  mapHttpStatusError,
+  PineconeConnectionError,
+  extractMessage,
+} from '../errors';
+import { builOptionConfigValidator } from '../validator';
+import { Static, Type } from '@sinclair/typebox';
+
+const SparseValues = Type.Object({
+  indices: Type.Array(Type.Integer()),
+  values: Type.Array(Type.Number()),
+});
+
+const UpdateVectorOptionsSchema = Type.Object({
+  id: Type.String({ minLength: 1 }),
+  values: Type.Optional(Type.Array(Type.Number())),
+  sparseValues: Type.Optional(SparseValues),
+  setMetadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
+});
+
+export type UpdateVectorOptions = Static<typeof UpdateVectorOptionsSchema>;
+
+export const update = (api: VectorOperationsApi, namespace: string) => {
+  const validator = builOptionConfigValidator(
+    UpdateVectorOptionsSchema,
+    'update'
+  );
+
+  return async (options: UpdateVectorOptions): Promise<void> => {
+    validator(options);
+
+    try {
+      await api.update({ updateRequest: { ...options, namespace } });
+      return;
+    } catch (e) {
+      if (e instanceof Error && e.name === 'FetchError') {
+        throw new PineconeConnectionError(
+          'Request failed to reach the server. Are you sure you are targeting an index that exists?'
+        );
+      } else {
+        const updateVectorError = e as ResponseError;
+        const message = await extractMessage(updateVectorError);
+
+        throw mapHttpStatusError({
+          status: updateVectorError.response.status,
+          url: updateVectorError.response.url,
+          message: message,
+        });
+      }
+    }
+  };
+};


### PR DESCRIPTION
## Problem
The new node client does not currently support updating vectors via `/vectors/update`.

## Solution
- Add a new `update.ts` file within `/src/data/`.
- Implement `update` to allow HTTPS calls to update a single vector.
- Add a new `update.test.ts` file to support unit tests. Covers validating request parameters, and error cases.
- [Bonus] Update `package.json` contributors to include myself.

## Type of Change
- [ X] New feature (non-breaking change which adds functionality)

## Test Plan
- Added a new unit test file to cover the new module. Run with `npm run test:unit`.
- Use `npm run repl` to test manually.

To test you'll want to call update on a specific vector and validate the results with fetch.

```javascript
npm run repl

// generate the client and legacy instances
await init()

// grab an index from client
const index = client.index('test-upsert-delete')

// upsert vector(s) or use and existing vector
const vectors = [
  {
    id: 'test-vector-1',
    values: [1, 2, 3, 4, 5],
  },
];
await index.upsert(vectors);

// update via id
await index.update({ id: 'test-vector-1', values: [5, 4, 3, 2, 1]})

// validate the update
await index.fetch(['test-vector-1'])
// updated vector response: {vectors: { test-vector-1: { id: "test-vector-1", values: [5,4,3,2,1]}}, namespace: ""}

// test updating setMetadata and sparseValues
await index.update({ id: 'test-vector-1', sparseValues: { indices: [15, 30, 25], values: [0.5, 0.5, 0.2]}, setMetadata: { genre: 'ambient' })
```
