### PR TITLE
Fix missing dimension in index description

### DIFF
--- a/src/pinecone-generated-ts-fetch/models/IndexMetaDatabase.ts
+++ b/src/pinecone-generated-ts-fetch/models/IndexMetaDatabase.ts
@@ -37,7 +37,7 @@ export interface IndexMetaDatabase {
      * @type {string}
      * @memberof IndexMetaDatabase
      */
-    dimensions?: string;
+    dimension?: string;
     /**
      * 
      * @type {string}
@@ -109,7 +109,7 @@ export function IndexMetaDatabaseFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'name': !exists(json, 'name') ? undefined : json['name'],
-        'dimensions': !exists(json, 'dimensions') ? undefined : json['dimensions'],
+        'dimension': !exists(json, 'dimension') ? undefined : json['dimension'],
         'indexType': !exists(json, 'index_type') ? undefined : json['index_type'],
         'metric': !exists(json, 'metric') ? undefined : json['metric'],
         'pods': !exists(json, 'pods') ? undefined : json['pods'],
@@ -131,7 +131,7 @@ export function IndexMetaDatabaseToJSON(value?: IndexMetaDatabase | null): any {
     return {
         
         'name': value.name,
-        'dimensions': value.dimensions,
+        'dimension': value.dimension,
         'index_type': value.indexType,
         'metric': value.metric,
         'pods': value.pods,


### PR DESCRIPTION
## Problem

When checking an index description, the `dimension` field is missing. This defect affects both the new and legacy clients.

I can see this by examining my `jen2` index in the interactive repl started with `npm run repl`

```
> await client.describeIndex('jen2')
{
  database: {.  // <------ no dimension
    name: 'jen2',
    metric: 'cosine',
    pods: 1,
    replicas: 1,
    shards: 1,
    podType: 'p1.x1'
  },
  status: { ready: true, state: 'Ready' }
}
> await legacy.describeIndex({ indexName: 'jen2' })
{
  database: {
    name: 'jen2',
    dimensions: undefined,    // <-------- missing value
    indexType: undefined,
    metric: 'cosine',
    pods: 1,
    replicas: 1,
    shards: 1,
    podType: 'p1.x1',
    indexConfig: undefined,
    metadataConfig: undefined
  },
  status: { ready: true, state: 'Ready' }
}
```


## Solution

The root cause of this issue is a bug in our private openapi spec that caused the generated client code to have a typo of "dimensions" instead of "dimension". Correcting this typo fixes the error.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Going back into the repl with the fix applied, we see the dimension value is being set correctly.

```
> await init()
> await client.describeIndex('jen2')
{
  database: {
    name: 'jen2',
    dimension: 1,  // <----- yay
    metric: 'cosine',
    pods: 1,
    replicas: 1,
    shards: 1,
    podType: 'p1.x1'
  },
  status: { ready: true, state: 'Ready' }
}
> await legacy.describeIndex({ indexName: 'jen2' })
{
  database: {
    name: 'jen2',
    dimension: 1, // <----- yay
    indexType: undefined,
    metric: 'cosine',
    pods: 1,
    replicas: 1,
    shards: 1,
    podType: 'p1.x1',
    indexConfig: undefined,
    metadataConfig: undefined
  },
  status: { ready: true, state: 'Ready' }
}
```

