### PR TITLE
Print coverage report after CI test runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Run tests
         env:
           CI: true
-        run: npm run test:unit
+        run: npm run test:unit -- --coverage

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/run.ts
 .DS_Store
 scratch
 docs/
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,11 @@ module.exports = {
   testTimeout: 100000,
   verbose: true,
   detectOpenHandles: true,
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.ts',
+    '!**/src/pinecone-generated-ts-fetch/**',
+    '!**/src/v0/**',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+  ],
 };


### PR DESCRIPTION
## Problem

I'd like to have access to a test coverage report.

## Solution

- Add jest configuration for the coverage report, excluding the generated client code.
- Adjust our CI workflow to pass the coverage flag 
- Add `coverage/` directory to the `.gitignore` file because we don't want to commit the temporary files created in this directory while generating the coverage report.

If you would like to see the coverage report on a local machine, you can see `npm run test:unit -- --coverage`.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

Check the CI log and see the coverage report is printed

<img width="868" alt="Screenshot 2023-08-17 at 12 33 19 PM" src="https://github.com/pinecone-io/pinecone-ts-client/assets/1326365/99f441ef-03b6-4563-82c4-d01fa6a38387">


