### PR TITLE
use metadata: instead of setMetadata: for index.update param;

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ const updateRequest: UpdateRequest = {
     indices: [15, 30, 11],
     values: [0.1, 0.2, 0.3],
   }, // optional sparse values
-  setMetadata: metadata, // the new metadata
+  metadata: metadata, // the new metadata
   namespace,
 };
 await index.update({ updateRequest });

--- a/src/data/__tests__/update.test.ts
+++ b/src/data/__tests__/update.test.ts
@@ -37,7 +37,7 @@ describe('update', () => {
           indices: [15, 30, 25],
           values: [0.5, 0.5, 0.2],
         },
-        metadata: { genre: 'ambient' },
+        setMetadata: { genre: 'ambient' },
       },
     });
   });

--- a/src/data/__tests__/update.test.ts
+++ b/src/data/__tests__/update.test.ts
@@ -24,7 +24,7 @@ describe('update', () => {
         indices: [15, 30, 25],
         values: [0.5, 0.5, 0.2],
       },
-      setMetadata: { genre: 'ambient' },
+      metadata: { genre: 'ambient' },
     });
 
     expect(returned).toBe(void 0);
@@ -37,7 +37,7 @@ describe('update', () => {
           indices: [15, 30, 25],
           values: [0.5, 0.5, 0.2],
         },
-        setMetadata: { genre: 'ambient' },
+        metadata: { genre: 'ambient' },
       },
     });
   });

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -13,7 +13,6 @@ const UpdateVectorOptionsSchema = Type.Object({
   values: Type.Optional(Type.Array(Type.Number())),
   sparseValues: Type.Optional(SparseValues),
   metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
-  setMetadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
 });
 
 export type UpdateVectorOptions = Static<typeof UpdateVectorOptionsSchema>;
@@ -26,11 +25,16 @@ export const update = (api: VectorOperationsApi, namespace: string) => {
 
   return async (options: UpdateVectorOptions): Promise<void> => {
     validator(options);
-    options["setMetadata"] = options["metadata"];
-    delete(options["metadata"]);
+
+    const requestOptions = {
+      id: options['id'],
+      values: options['values'],
+      sparseValues: options['sparseValues'],
+      setMetadata: options['metadata'],
+    };
 
     try {
-      await api.update({ updateRequest: { ...options, namespace } });
+      await api.update({ updateRequest: { ...requestOptions, namespace } });
       return;
     } catch (e) {
       const err = await handleDataError(e);

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -12,6 +12,7 @@ const UpdateVectorOptionsSchema = Type.Object({
   id: Type.String({ minLength: 1 }),
   values: Type.Optional(Type.Array(Type.Number())),
   sparseValues: Type.Optional(SparseValues),
+  metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
   setMetadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
 });
 
@@ -25,6 +26,8 @@ export const update = (api: VectorOperationsApi, namespace: string) => {
 
   return async (options: UpdateVectorOptions): Promise<void> => {
     validator(options);
+    options["setMetadata"] = options["metadata"];
+    delete(options["metadata"]);
 
     try {
       await api.update({ updateRequest: { ...options, namespace } });


### PR DESCRIPTION
## Problem

index.update() used the unintuitive `setMetadata` parameter instead of `metadata` because the underlying API and generated files use `setMetadata`; originated in #79 

## Solution

This uses `metadata` instead of `setMetadata` in the ts interface, then modifies options to use `setMetadata` for the actual request to avoid changing the API.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
```
await index.update({id: "1", metadata: {foo: "bar"}}) //should work
await index.update({id: "1", setMetadata: {foo: "bar"}}) //shouldn't work
```
