### PR TITLE
[v1] Refactor runtime validation

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -49,7 +49,7 @@ describe('Client', () => {
             apiKey: '',
           });
         }).toThrow(
-          "The client configuration must have required properties: projectId. There were also validation errors: property 'apiKey' must not be blank."
+          "The client configuration must have required property: projectId. There were also validation errors: property 'apiKey' must not be blank."
         );
       });
     });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -8,7 +8,7 @@ describe('Client', () => {
           // @ts-ignore
           new Client();
         }).toThrow(
-          'Configuration passed to Client constructor had a problem. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io'
+          'The client configuration had type errors: the argument must be object.'
         );
       });
 
@@ -17,7 +17,7 @@ describe('Client', () => {
           // @ts-ignore
           new Client({ apiKey: 'test-key' });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The argument must have required property 'environment'. The argument must have required property 'projectId'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          'The client configuration must have required properties: environment, projectId.'
         );
 
         expect(() => {
@@ -26,7 +26,7 @@ describe('Client', () => {
             environment: 'test-environment',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The argument must have required property 'apiKey'. The argument must have required property 'projectId'. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          'The client configuration must have required properties: apiKey, projectId.'
         );
       });
 
@@ -39,7 +39,7 @@ describe('Client', () => {
             apiKey: 'test-key',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The property 'environment' must not be blank. The property 'projectId' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "The client configuration had validation errors: property 'environment' must not be blank, property 'projectId' must not be blank."
         );
 
         expect(() => {
@@ -49,7 +49,7 @@ describe('Client', () => {
             apiKey: '',
           });
         }).toThrow(
-          "Configuration passed to Client constructor had a problem. The argument must have required property 'projectId'. The property 'apiKey' must not be blank. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io"
+          "The client configuration must have required properties: projectId. There were also validation errors: property 'apiKey' must not be blank."
         );
       });
     });
@@ -65,7 +65,7 @@ describe('Client', () => {
             unknownProp: 'banana',
           } as any);
         }).toThrow(
-          'Configuration passed to Client constructor had a problem. The argument must NOT have additional properties. Configuration must be an object with keys environment, apiKey, projectId. You can find the configuration values for your project in the Pinecone developer console at https://app.pinecone.io'
+          'The client configuration had validation errors: the argument must NOT have additional properties.'
         );
       });
     });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -8,7 +8,7 @@ describe('Client', () => {
           // @ts-ignore
           new Client();
         }).toThrow(
-          'The client configuration had type errors: the argument must be object.'
+          'The client configuration had type errors: argument must be object.'
         );
       });
 
@@ -65,7 +65,7 @@ describe('Client', () => {
             unknownProp: 'banana',
           } as any);
         }).toThrow(
-          'The client configuration had validation errors: the argument must NOT have additional properties.'
+          'The client configuration had validation errors: argument must NOT have additional properties.'
         );
       });
     });

--- a/src/__tests__/validator.test.ts
+++ b/src/__tests__/validator.test.ts
@@ -40,7 +40,7 @@ describe('validation', () => {
       expect(
         errorFormatter('The argument to createIndex', validationErrors)
       ).toEqual(
-        'The argument to createIndex had type errors: the argument must be object.'
+        'The argument to createIndex had type errors: argument must be object.'
       );
     });
 
@@ -58,7 +58,7 @@ describe('validation', () => {
       expect(
         errorFormatter('The argument to describeIndex', validationErrors)
       ).toEqual(
-        'The argument to describeIndex had type errors: the argument must be string.'
+        'The argument to describeIndex had type errors: argument must be string.'
       );
     });
 
@@ -319,7 +319,7 @@ describe('validation', () => {
       expect(
         errorFormatter('The argument to describeIndex', validationErrors)
       ).toEqual(
-        'The argument to describeIndex had validation errors: the argument must not be blank.'
+        'The argument to describeIndex had validation errors: argument must not be blank.'
       );
     });
 
@@ -455,7 +455,7 @@ describe('validation', () => {
       ];
 
       expect(errorFormatter('The argument to fetch', validationErrors)).toEqual(
-        'The argument to fetch had validation errors: the argument must NOT have fewer than 1 items.'
+        'The argument to fetch had validation errors: argument must NOT have fewer than 1 items.'
       );
     });
 

--- a/src/__tests__/validator.test.ts
+++ b/src/__tests__/validator.test.ts
@@ -1,0 +1,487 @@
+import { errorFormatter, buildValidator } from '../validator';
+
+describe('validation', () => {
+  test('can be disabled with environment variable when performance is the #1 concern', () => {
+    const enabledValidator = buildValidator('The test function', {
+      type: 'number',
+    });
+    const runEnabled = () => enabledValidator('not a number');
+    expect(runEnabled).toThrow();
+
+    process.env.PINECONE_DISABLE_RUNTIME_VALIDATIONS = 'true';
+    const disabledValidator = buildValidator('The test function', {
+      type: 'number',
+    });
+    const runDisabled = () => disabledValidator('not a number');
+    expect(runDisabled).not.toThrow();
+
+    // cleanup and verify cleanup
+    delete process.env.PINECONE_DISABLE_RUNTIME_VALIDATIONS;
+    const enabledValidator2 = buildValidator('The test function', {
+      type: 'number',
+    });
+    const runEnabled2 = () => enabledValidator2('not a number');
+    expect(runEnabled2).toThrow();
+  });
+
+  describe('errorFormatter', () => {
+    test('when argument is expecting object, return type error', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/type',
+          keyword: 'type',
+          params: { type: 'object' },
+
+          message: 'must be object',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        'The argument to createIndex had type errors: the argument must be object.'
+      );
+    });
+
+    test('when argument is expecting string, return type error', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to describeIndex', validationErrors)
+      ).toEqual(
+        'The argument to describeIndex had type errors: the argument must be string.'
+      );
+    });
+
+    test('when item in array has incorrect type', () => {
+      const validationErrors = [
+        {
+          instancePath: '/0',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+      ];
+
+      expect(errorFormatter('The argument to fetch', validationErrors)).toEqual(
+        'The argument to fetch had type errors: item at index 0 of the array must be string.'
+      );
+    });
+
+    test('when multiple required properties are missing', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/required',
+          keyword: 'required',
+          params: { missingProperty: 'name' },
+          message: "must have required property 'name'",
+        },
+        {
+          instancePath: '',
+          schemaPath: '#/required',
+          keyword: 'required',
+          params: { missingProperty: 'dimension' },
+          message: "must have required property 'dimension'",
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        'The argument to createIndex must have required properties: name, dimension.'
+      );
+    });
+
+    test('when one required property is missing', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/required',
+          keyword: 'required',
+          params: { missingProperty: 'dimension' },
+          message: "must have required property 'dimension'",
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        'The argument to createIndex must have required properties: dimension.'
+      );
+    });
+
+    test('when a property is the wrong type (multiple errors)', () => {
+      const validationErrors = [
+        {
+          instancePath: '/name',
+          schemaPath: '#/properties/name/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+        {
+          instancePath: '/dimension',
+          schemaPath: '#/properties/dimension/type',
+          keyword: 'type',
+          params: { type: 'integer' },
+          message: 'must be integer',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        "The argument to createIndex had type errors: property 'name' must be string, property 'dimension' must be integer."
+      );
+    });
+
+    test('when a property is the wrong type (single error)', () => {
+      const validationErrors = [
+        {
+          instancePath: '/name',
+          schemaPath: '#/properties/name/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        "The argument to createIndex had type errors: property 'name' must be string."
+      );
+    });
+
+    test('mixed error types (required and type)', () => {
+      // e.g. await client.createIndex({ name: 100 })
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/required',
+          keyword: 'required',
+          params: { missingProperty: 'dimension' },
+          message: "must have required property 'dimension'",
+        },
+        {
+          instancePath: '/name',
+          schemaPath: '#/properties/name/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        "The argument to createIndex must have required properties: dimension. There were also type errors: property 'name' must be string."
+      );
+    });
+
+    test('when anyOf is in play returns both sets of errors', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf/0/required',
+          keyword: 'required',
+          params: { missingProperty: 'id' },
+          message: "must have required property 'id'",
+        },
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf/1/required',
+          keyword: 'required',
+          params: { missingProperty: 'vector' },
+          message: "must have required property 'vector'",
+        },
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf',
+          keyword: 'anyOf',
+          params: {},
+          message: 'must match a schema in anyOf',
+        },
+      ];
+
+      expect(errorFormatter('The argument to query', validationErrors)).toEqual(
+        'The argument to query accepts multiple types. Either 1) must have required properties: id. 2) must have required properties: vector.'
+      );
+    });
+
+    test('anyOf can handle multiple errors from each schema', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf/0/required',
+          keyword: 'required',
+          params: { missingProperty: 'topK' },
+          message: "must have required property 'topK'",
+        },
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf/0/required',
+          keyword: 'required',
+          params: { missingProperty: 'id' },
+          message: "must have required property 'id'",
+        },
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf/1/required',
+          keyword: 'required',
+          params: { missingProperty: 'topK' },
+          message: "must have required property 'topK'",
+        },
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf/1/required',
+          keyword: 'required',
+          params: { missingProperty: 'vector' },
+          message: "must have required property 'vector'",
+        },
+        {
+          instancePath: '',
+          schemaPath: '#/anyOf',
+          keyword: 'anyOf',
+          params: {},
+          message: 'must match a schema in anyOf',
+        },
+      ];
+
+      expect(errorFormatter('The argument to query', validationErrors)).toEqual(
+        'The argument to query accepts multiple types. Either 1) must have required properties: topK, id. 2) must have required properties: topK, vector.'
+      );
+    });
+
+    test('when an object string property is blank', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/required',
+          keyword: 'required',
+          params: { missingProperty: 'dimension' },
+          message: "must have required property 'dimension'",
+        },
+        {
+          instancePath: '/name',
+          schemaPath: '#/properties/name/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        "The argument to createIndex must have required properties: dimension. There were also validation errors: property 'name' must not be blank."
+      );
+    });
+
+    test('when an array string item is blank', () => {
+      const validationErrors = [
+        {
+          instancePath: '/0',
+          schemaPath: '#/items/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+      ];
+
+      expect(errorFormatter('The argument to fetch', validationErrors)).toEqual(
+        'The argument to fetch had validation errors: item at index 0 of the array must not be blank.'
+      );
+    });
+
+    test('when a string argument is blank', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to describeIndex', validationErrors)
+      ).toEqual(
+        'The argument to describeIndex had validation errors: the argument must not be blank.'
+      );
+    });
+
+    test('when a number is out of range', () => {
+      const validationErrors = [
+        {
+          instancePath: '/dimension',
+          schemaPath: '#/properties/dimension/minimum',
+          keyword: 'minimum',
+          params: { comparison: '>=', limit: 1 },
+          message: 'must be >= 1',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to createIndex', validationErrors)
+      ).toEqual(
+        "The argument to createIndex had validation errors: property 'dimension' must be >= 1."
+      );
+    });
+
+    test('when numerous type errors, truncates the list with error count', () => {
+      const validationErrors = [
+        {
+          instancePath: '/0',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+        {
+          instancePath: '/1',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+        {
+          instancePath: '/2',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+        {
+          instancePath: '/3',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+        {
+          instancePath: '/4',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+        {
+          instancePath: '/5',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+        {
+          instancePath: '/6',
+          schemaPath: '#/items/type',
+          keyword: 'type',
+          params: { type: 'string' },
+          message: 'must be string',
+        },
+      ];
+
+      expect(errorFormatter('The argument to fetch', validationErrors)).toEqual(
+        'The argument to fetch had type errors: item at index 0 of the array must be string, item at index 1 of the array must be string, item at index 2 of the array must be string, and 4 other errors.'
+      );
+    });
+
+    test('when numerous validation errors, truncates the list with error count', () => {
+      const validationErrors = [
+        {
+          instancePath: '/0',
+          schemaPath: '#/items/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+        {
+          instancePath: '/1',
+          schemaPath: '#/items/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+        {
+          instancePath: '/2',
+          schemaPath: '#/items/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+        {
+          instancePath: '/3',
+          schemaPath: '#/items/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+        {
+          instancePath: '/4',
+          schemaPath: '#/items/minLength',
+          keyword: 'minLength',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 characters',
+        },
+      ];
+
+      expect(errorFormatter('The argument to fetch', validationErrors)).toEqual(
+        'The argument to fetch had validation errors: item at index 0 of the array must not be blank, item at index 1 of the array must not be blank, item at index 2 of the array must not be blank, and 2 other errors.'
+      );
+    });
+
+    test('minItems error mapped', () => {
+      const validationErrors = [
+        {
+          instancePath: '',
+          schemaPath: '#/minItems',
+          keyword: 'minItems',
+          params: { limit: 1 },
+          message: 'must NOT have fewer than 1 items',
+        },
+      ];
+
+      expect(errorFormatter('The argument to fetch', validationErrors)).toEqual(
+        'The argument to fetch had validation errors: the argument must NOT have fewer than 1 items.'
+      );
+    });
+
+    test('correctly describes errors on object properties that are arrays', () => {
+      const validationErrors = [
+        {
+          instancePath: '/0/values/0',
+          schemaPath: '#/items/properties/values/items/type',
+          keyword: 'type',
+          params: { type: 'number' },
+          message: 'must be number',
+        },
+        {
+          instancePath: '/0/values/1',
+          schemaPath: '#/items/properties/values/items/type',
+          keyword: 'type',
+          params: { type: 'number' },
+          message: 'must be number',
+        },
+      ];
+
+      expect(
+        errorFormatter('The argument to upsert', validationErrors)
+      ).toEqual(
+        "The argument to upsert had type errors: item at index 0 of the 'values' array must be number, item at index 1 of the 'values' array must be number."
+      );
+    });
+  });
+});

--- a/src/__tests__/validator.test.ts
+++ b/src/__tests__/validator.test.ts
@@ -117,7 +117,7 @@ describe('validation', () => {
       expect(
         errorFormatter('The argument to createIndex', validationErrors)
       ).toEqual(
-        'The argument to createIndex must have required properties: dimension.'
+        'The argument to createIndex must have required property: dimension.'
       );
     });
 
@@ -186,7 +186,7 @@ describe('validation', () => {
       expect(
         errorFormatter('The argument to createIndex', validationErrors)
       ).toEqual(
-        "The argument to createIndex must have required properties: dimension. There were also type errors: property 'name' must be string."
+        "The argument to createIndex must have required property: dimension. There were also type errors: property 'name' must be string."
       );
     });
 
@@ -216,7 +216,7 @@ describe('validation', () => {
       ];
 
       expect(errorFormatter('The argument to query', validationErrors)).toEqual(
-        'The argument to query accepts multiple types. Either 1) must have required properties: id. 2) must have required properties: vector.'
+        'The argument to query accepts multiple types. Either 1) must have required property: id. 2) must have required property: vector.'
       );
     });
 
@@ -285,7 +285,7 @@ describe('validation', () => {
       expect(
         errorFormatter('The argument to createIndex', validationErrors)
       ).toEqual(
-        "The argument to createIndex must have required properties: dimension. There were also validation errors: property 'name' must not be blank."
+        "The argument to createIndex must have required property: dimension. There were also validation errors: property 'name' must not be blank."
       );
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,3 @@
-import { PineconeConfigurationError } from './errors';
 import type { ConfigurationParameters as IndexOperationsApiConfigurationParameters } from './pinecone-generated-ts-fetch';
 import {
   IndexOperationsApi,

--- a/src/client.ts
+++ b/src/client.ts
@@ -258,29 +258,10 @@ export class Client {
 
   /** @internal */
   _validateConfig(options: ClientConfiguration) {
-    buildValidator(ClientConfigurationSchema, (errorsList) => {
-      const messageParts: Array<string> = [];
-      messageParts.push(
-        'Configuration passed to Client constructor had a problem.'
-      );
-
-      if (
-        errorsList.length === 1 &&
-        errorsList[0] === 'The argument must be object.'
-      ) {
-        // This error doesn't really say anything that isn't covered in the other parts
-        // of the error message. So leave it out.
-      } else {
-        messageParts.push(...errorsList);
-      }
-
-      const requiredKeys = ['environment', 'apiKey', 'projectId'];
-      messageParts.push(
-        `Configuration must be an object with keys ${requiredKeys.join(', ')}.`
-      );
-
-      throw new PineconeConfigurationError(`${messageParts.join(' ')}`);
-    })(options);
+    buildValidator(
+      'The client configuration',
+      ClientConfigurationSchema
+    )(options);
   }
 
   /**

--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -52,7 +52,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The second argument to configureIndex accepts multiple types. Either 1) must have required properties: replicas. 2) must have required properties: podType.'
+        'The second argument to configureIndex accepts multiple types. Either 1) must have required property: replicas. 2) must have required property: podType.'
       );
     });
 
@@ -62,7 +62,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex accepts multiple types. Either 1) had type errors: property 'replicas' must be integer. 2) must have required properties: podType."
+        "The second argument to configureIndex accepts multiple types. Either 1) had type errors: property 'replicas' must be integer. 2) must have required property: podType."
       );
     });
 
@@ -72,7 +72,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex accepts multiple types. Either 1) must have required properties: replicas. 2) had type errors: property 'podType' must be string."
+        "The second argument to configureIndex accepts multiple types. Either 1) must have required property: replicas. 2) had type errors: property 'podType' must be string."
       );
     });
 
@@ -82,7 +82,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex accepts multiple types. Either 1) had validation errors: property 'replicas' must be >= 1. 2) must have required properties: podType."
+        "The second argument to configureIndex accepts multiple types. Either 1) had validation errors: property 'replicas' must be >= 1. 2) must have required property: podType."
       );
     });
   });

--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -23,7 +23,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'Argument to configureIndex has a problem. The argument must be string.'
+        'The first argument to configureIndex had type errors: the argument must be string.'
       );
     });
 
@@ -33,7 +33,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'Argument to configureIndex has a problem. The argument must be string.'
+        'The first argument to configureIndex had type errors: the argument must be string.'
       );
     });
 
@@ -43,7 +43,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'Argument to configureIndex has a problem. The argument must not be blank.'
+        'The first argument to configureIndex had validation errors: the argument must not be blank.'
       );
     });
 
@@ -52,7 +52,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+        'The second argument to configureIndex accepts multiple types. Either 1) must have required properties: replicas. 2) must have required properties: podType.'
       );
     });
 
@@ -62,7 +62,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+        "The second argument to configureIndex accepts multiple types. Either 1) had type errors: property 'replicas' must be integer. 2) must have required properties: podType."
       );
     });
 
@@ -72,7 +72,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+        "The second argument to configureIndex accepts multiple types. Either 1) must have required properties: replicas. 2) had type errors: property 'podType' must be string."
       );
     });
 
@@ -82,7 +82,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "At least one mutable property must be specified from list ['replicas', 'podType']. Replicas must be a non-negative integer, podType must be a known pod type. See the API reference documentation at https://docs.pinecone.io/reference/configure_index"
+        "The second argument to configureIndex accepts multiple types. Either 1) had validation errors: property 'replicas' must be >= 1. 2) must have required properties: podType."
       );
     });
   });

--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -23,7 +23,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The first argument to configureIndex had type errors: the argument must be string.'
+        'The first argument to configureIndex had type errors: argument must be string.'
       );
     });
 
@@ -33,7 +33,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The first argument to configureIndex had type errors: the argument must be string.'
+        'The first argument to configureIndex had type errors: argument must be string.'
       );
     });
 
@@ -43,7 +43,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The first argument to configureIndex had validation errors: the argument must not be blank.'
+        'The first argument to configureIndex had validation errors: argument must not be blank.'
       );
     });
 

--- a/src/control/__tests__/createCollection.test.ts
+++ b/src/control/__tests__/createCollection.test.ts
@@ -34,7 +34,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'Argument to createCollection has a problem. The argument must be object.'
+        'The argument to createCollection had type errors: the argument must be object.'
       );
     });
 
@@ -47,7 +47,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'Argument to createCollection has a problem. The argument must be object.'
+        'The argument to createCollection had type errors: the argument must be object.'
       );
     });
 
@@ -60,7 +60,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createCollection has a problem. The argument must have required property 'name'. The argument must have required property 'source'."
+        'The argument to createCollection must have required properties: name, source.'
       );
     });
 
@@ -75,7 +75,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createCollection has a problem. The property 'name' must not be blank."
+        "The argument to createCollection had validation errors: property 'name' must not be blank."
       );
     });
 
@@ -88,7 +88,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createCollection has a problem. The property 'name' must be string."
+        "The argument to createCollection had type errors: property 'name' must be string."
       );
     });
 
@@ -101,7 +101,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createCollection has a problem. The argument must have required property 'source'."
+        'The argument to createCollection must have required properties: source.'
       );
     });
 
@@ -114,7 +114,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createCollection has a problem. The property 'source' must be string."
+        "The argument to createCollection had type errors: property 'source' must be string."
       );
     });
 
@@ -129,7 +129,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createCollection has a problem. The property 'source' must not be blank."
+        "The argument to createCollection had validation errors: property 'source' must not be blank."
       );
     });
   });

--- a/src/control/__tests__/createCollection.test.ts
+++ b/src/control/__tests__/createCollection.test.ts
@@ -101,7 +101,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The argument to createCollection must have required properties: source.'
+        'The argument to createCollection must have required property: source.'
       );
     });
 

--- a/src/control/__tests__/createCollection.test.ts
+++ b/src/control/__tests__/createCollection.test.ts
@@ -34,7 +34,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The argument to createCollection had type errors: the argument must be object.'
+        'The argument to createCollection had type errors: argument must be object.'
       );
     });
 
@@ -47,7 +47,7 @@ describe('createCollection', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The argument to createCollection had type errors: the argument must be object.'
+        'The argument to createCollection had type errors: argument must be object.'
       );
     });
 

--- a/src/control/__tests__/createIndex.validation.test.ts
+++ b/src/control/__tests__/createIndex.validation.test.ts
@@ -23,7 +23,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'Argument to createIndex has a problem. The argument must be object.'
+        'The argument to createIndex had type errors: the argument must be object.'
       );
     });
 
@@ -33,7 +33,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'name' must be string."
+        "The argument to createIndex had type errors: property 'name' must be string."
       );
     });
 
@@ -43,7 +43,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'name' must not be blank."
+        "The argument to createIndex had validation errors: property 'name' must not be blank."
       );
     });
 
@@ -53,7 +53,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The argument must have required property 'dimension'."
+        'The argument to createIndex must have required properties: dimension.'
       );
     });
 
@@ -63,7 +63,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'dimension' must be integer."
+        "The argument to createIndex had type errors: property 'dimension' must be integer."
       );
     });
 
@@ -73,7 +73,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'dimension' must be integer."
+        "The argument to createIndex had type errors: property 'dimension' must be integer."
       );
     });
 
@@ -83,7 +83,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'dimension' must be >= 1."
+        "The argument to createIndex had validation errors: property 'dimension' must be >= 1."
       );
     });
   });
@@ -99,7 +99,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'metric' must be string."
+        "The argument to createIndex had type errors: property 'metric' must be string."
       );
     });
 
@@ -113,7 +113,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'metric' must not be blank."
+        "The argument to createIndex had validation errors: property 'metric' must not be blank."
       );
     });
 
@@ -127,7 +127,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'replicas' must be integer."
+        "The argument to createIndex had type errors: property 'replicas' must be integer."
       );
     });
 
@@ -141,7 +141,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'replicas' must be >= 1."
+        "The argument to createIndex had validation errors: property 'replicas' must be >= 1."
       );
     });
 
@@ -155,7 +155,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'podType' must be string."
+        "The argument to createIndex had type errors: property 'podType' must be string."
       );
     });
 
@@ -169,7 +169,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'podType' must not be blank."
+        "The argument to createIndex had validation errors: property 'podType' must not be blank."
       );
     });
 
@@ -183,7 +183,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'pods' must be integer."
+        "The argument to createIndex had type errors: property 'pods' must be integer."
       );
     });
 
@@ -197,7 +197,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'pods' must be >= 1."
+        "The argument to createIndex had validation errors: property 'pods' must be >= 1."
       );
     });
 
@@ -211,7 +211,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'metadataConfig' must be object."
+        "The argument to createIndex had type errors: property 'metadataConfig' must be object."
       );
     });
 
@@ -225,7 +225,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'sourceCollection' must be string."
+        "The argument to createIndex had type errors: property 'sourceCollection' must be string."
       );
     });
 
@@ -239,7 +239,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "Argument to createIndex has a problem. The property 'sourceCollection' must not be blank."
+        "The argument to createIndex had validation errors: property 'sourceCollection' must not be blank."
       );
     });
   });

--- a/src/control/__tests__/createIndex.validation.test.ts
+++ b/src/control/__tests__/createIndex.validation.test.ts
@@ -23,7 +23,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The argument to createIndex had type errors: the argument must be object.'
+        'The argument to createIndex had type errors: argument must be object.'
       );
     });
 

--- a/src/control/__tests__/createIndex.validation.test.ts
+++ b/src/control/__tests__/createIndex.validation.test.ts
@@ -53,7 +53,7 @@ describe('createIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The argument to createIndex must have required properties: dimension.'
+        'The argument to createIndex must have required property: dimension.'
       );
     });
 

--- a/src/control/__tests__/deleteCollection.test.ts
+++ b/src/control/__tests__/deleteCollection.test.ts
@@ -36,7 +36,7 @@ describe('deleteCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to deleteCollection has a problem. The argument must be string.'
+        'The argument to deleteCollection had type errors: the argument must be string.'
       );
     });
 
@@ -47,7 +47,7 @@ describe('deleteCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to deleteCollection has a problem. The argument must be string.'
+        'The argument to deleteCollection had type errors: the argument must be string.'
       );
     });
 
@@ -58,7 +58,7 @@ describe('deleteCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to deleteCollection has a problem. The argument must not be blank.'
+        'The argument to deleteCollection had validation errors: the argument must not be blank.'
       );
     });
   });

--- a/src/control/__tests__/deleteCollection.test.ts
+++ b/src/control/__tests__/deleteCollection.test.ts
@@ -36,7 +36,7 @@ describe('deleteCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to deleteCollection had type errors: the argument must be string.'
+        'The argument to deleteCollection had type errors: argument must be string.'
       );
     });
 
@@ -47,7 +47,7 @@ describe('deleteCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to deleteCollection had type errors: the argument must be string.'
+        'The argument to deleteCollection had type errors: argument must be string.'
       );
     });
 
@@ -58,7 +58,7 @@ describe('deleteCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to deleteCollection had validation errors: the argument must not be blank.'
+        'The argument to deleteCollection had validation errors: argument must not be blank.'
       );
     });
   });

--- a/src/control/__tests__/deleteIndex.test.ts
+++ b/src/control/__tests__/deleteIndex.test.ts
@@ -20,7 +20,7 @@ describe('deleteIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to deleteIndex has a problem. The argument must be string.'
+        'The argument to deleteIndex had type errors: the argument must be string.'
       );
     });
 
@@ -37,7 +37,7 @@ describe('deleteIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to deleteIndex has a problem. The argument must be string.'
+        'The argument to deleteIndex had type errors: the argument must be string.'
       );
     });
 
@@ -54,7 +54,7 @@ describe('deleteIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to deleteIndex has a problem. The argument must not be blank.'
+        'The argument to deleteIndex had validation errors: the argument must not be blank.'
       );
     });
   });

--- a/src/control/__tests__/deleteIndex.test.ts
+++ b/src/control/__tests__/deleteIndex.test.ts
@@ -20,7 +20,7 @@ describe('deleteIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to deleteIndex had type errors: the argument must be string.'
+        'The argument to deleteIndex had type errors: argument must be string.'
       );
     });
 
@@ -37,7 +37,7 @@ describe('deleteIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to deleteIndex had type errors: the argument must be string.'
+        'The argument to deleteIndex had type errors: argument must be string.'
       );
     });
 
@@ -54,7 +54,7 @@ describe('deleteIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to deleteIndex had validation errors: the argument must not be blank.'
+        'The argument to deleteIndex had validation errors: argument must not be blank.'
       );
     });
   });

--- a/src/control/__tests__/describeCollection.test.ts
+++ b/src/control/__tests__/describeCollection.test.ts
@@ -39,7 +39,7 @@ describe('describeCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeCollection has a problem. The argument must be string.'
+        'The argument to describeCollection had type errors: the argument must be string.'
       );
     });
 
@@ -53,7 +53,7 @@ describe('describeCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeCollection has a problem. The argument must be string.'
+        'The argument to describeCollection had type errors: the argument must be string.'
       );
     });
 
@@ -67,7 +67,7 @@ describe('describeCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeCollection has a problem. The argument must not be blank.'
+        'The argument to describeCollection had validation errors: the argument must not be blank.'
       );
     });
   });

--- a/src/control/__tests__/describeCollection.test.ts
+++ b/src/control/__tests__/describeCollection.test.ts
@@ -39,7 +39,7 @@ describe('describeCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to describeCollection had type errors: the argument must be string.'
+        'The argument to describeCollection had type errors: argument must be string.'
       );
     });
 
@@ -53,7 +53,7 @@ describe('describeCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to describeCollection had type errors: the argument must be string.'
+        'The argument to describeCollection had type errors: argument must be string.'
       );
     });
 
@@ -67,7 +67,7 @@ describe('describeCollection', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to describeCollection had validation errors: the argument must not be blank.'
+        'The argument to describeCollection had validation errors: argument must not be blank.'
       );
     });
   });

--- a/src/control/__tests__/describeIndex.test.ts
+++ b/src/control/__tests__/describeIndex.test.ts
@@ -58,7 +58,7 @@ describe('describeIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeIndex has a problem. The argument must be string.'
+        'The argument to describeIndex had type errors: the argument must be string.'
       );
     });
 
@@ -74,7 +74,7 @@ describe('describeIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeIndex has a problem. The argument must be string.'
+        'The argument to describeIndex had type errors: the argument must be string.'
       );
     });
 
@@ -90,7 +90,7 @@ describe('describeIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'Argument to describeIndex has a problem. The argument must not be blank.'
+        'The argument to describeIndex had validation errors: the argument must not be blank.'
       );
     });
   });

--- a/src/control/__tests__/describeIndex.test.ts
+++ b/src/control/__tests__/describeIndex.test.ts
@@ -58,7 +58,7 @@ describe('describeIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to describeIndex had type errors: the argument must be string.'
+        'The argument to describeIndex had type errors: argument must be string.'
       );
     });
 
@@ -74,7 +74,7 @@ describe('describeIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to describeIndex had type errors: the argument must be string.'
+        'The argument to describeIndex had type errors: argument must be string.'
       );
     });
 
@@ -90,7 +90,7 @@ describe('describeIndex', () => {
 
       expect(expectToThrow).rejects.toThrowError(PineconeArgumentError);
       expect(expectToThrow).rejects.toThrowError(
-        'The argument to describeIndex had validation errors: the argument must not be blank.'
+        'The argument to describeIndex had validation errors: argument must not be blank.'
       );
     });
   });

--- a/src/control/createCollection.ts
+++ b/src/control/createCollection.ts
@@ -1,7 +1,7 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { ResponseError } from '../pinecone-generated-ts-fetch';
 import { mapHttpStatusError } from '../errors';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 import { validIndexMessage } from './utils';
 
 import { Static, Type } from '@sinclair/typebox';
@@ -18,7 +18,7 @@ export type CreateCollectionOptions = Static<
 >;
 
 export const createCollection = (api: IndexOperationsApi) => {
-  const validator = builOptionConfigValidator(
+  const validator = buildConfigValidator(
     CreateCollectionOptionsSchema,
     'createCollection'
   );

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -1,7 +1,7 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { ResponseError } from '../pinecone-generated-ts-fetch';
 import { mapHttpStatusError, extractMessage } from '../errors';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 
 import { Static, Type } from '@sinclair/typebox';
 
@@ -26,7 +26,7 @@ const CreateIndexOptionsSchema = Type.Object({
 export type CreateIndexOptions = Static<typeof CreateIndexOptionsSchema>;
 
 export const createIndex = (api: IndexOperationsApi) => {
-  const validator = builOptionConfigValidator(
+  const validator = buildConfigValidator(
     CreateIndexOptionsSchema,
     'createIndex'
   );

--- a/src/control/deleteCollection.ts
+++ b/src/control/deleteCollection.ts
@@ -1,7 +1,7 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { ResponseError } from '../pinecone-generated-ts-fetch';
 import { mapHttpStatusError } from '../errors';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 import { Static, Type } from '@sinclair/typebox';
 import { validCollectionMessage } from './utils';
 
@@ -9,7 +9,7 @@ const DeleteCollectionIndex = Type.String({ minLength: 1 });
 export type CollectionName = Static<typeof DeleteCollectionIndex>;
 
 export const deleteCollection = (api: IndexOperationsApi) => {
-  const validator = builOptionConfigValidator(
+  const validator = buildConfigValidator(
     DeleteCollectionIndex,
     'deleteCollection'
   );

--- a/src/control/deleteIndex.ts
+++ b/src/control/deleteIndex.ts
@@ -1,7 +1,7 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { ResponseError } from '../pinecone-generated-ts-fetch';
 import { mapHttpStatusError } from '../errors';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 import { Static, Type } from '@sinclair/typebox';
 import { validIndexMessage } from './utils';
 
@@ -9,10 +9,7 @@ const DescribeIndexSchema = Type.String({ minLength: 1 });
 export type IndexName = Static<typeof DescribeIndexSchema>;
 
 export const deleteIndex = (api: IndexOperationsApi) => {
-  const validator = builOptionConfigValidator(
-    DescribeIndexSchema,
-    'deleteIndex'
-  );
+  const validator = buildConfigValidator(DescribeIndexSchema, 'deleteIndex');
 
   return async (indexName: IndexName): Promise<void> => {
     validator(indexName);

--- a/src/control/describeCollection.ts
+++ b/src/control/describeCollection.ts
@@ -1,6 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 import { mapHttpStatusError } from '../errors';
 import { validCollectionMessage } from './utils';
 import type {
@@ -18,7 +18,7 @@ const DescribeCollectionSchema = Type.String({ minLength: 1 });
 export type CollectionName = Static<typeof DescribeCollectionSchema>;
 
 export const describeCollection = (api: IndexOperationsApi) => {
-  const validator = builOptionConfigValidator(
+  const validator = buildConfigValidator(
     DescribeCollectionSchema,
     'describeCollection'
   );

--- a/src/control/describeIndex.ts
+++ b/src/control/describeIndex.ts
@@ -1,6 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 import { mapHttpStatusError } from '../errors';
 import { validIndexMessage } from './utils';
 import type {
@@ -18,7 +18,7 @@ const DescribeIndexOptionsSchema = Type.String({ minLength: 1 });
 export type IndexName = Static<typeof DescribeIndexOptionsSchema>;
 
 export const describeIndex = (api: IndexOperationsApi) => {
-  const validator = builOptionConfigValidator(
+  const validator = buildConfigValidator(
     DescribeIndexOptionsSchema,
     'describeIndex'
   );

--- a/src/data/delete.ts
+++ b/src/data/delete.ts
@@ -16,10 +16,7 @@ const DeleteVectorOptionsSchema = Type.Object({
 export type DeleteVectorOptions = Static<typeof DeleteVectorOptionsSchema>;
 
 export const deleteVector = (api: VectorOperationsApi, namespace: string) => {
-  const validator = buildConfigValidator(
-    DeleteVectorOptionsSchema,
-    'delete'
-  );
+  const validator = buildConfigValidator(DeleteVectorOptionsSchema, 'delete');
 
   return async (options: DeleteVectorOptions): Promise<void> => {
     validator(options);

--- a/src/data/delete.ts
+++ b/src/data/delete.ts
@@ -1,6 +1,6 @@
 import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
 import { handleDataError } from './utils/errorHandling';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 import { Static, Type } from '@sinclair/typebox';
 
 const idsArray = Type.Array(Type.String({ minLength: 1 }));
@@ -16,7 +16,7 @@ const DeleteVectorOptionsSchema = Type.Object({
 export type DeleteVectorOptions = Static<typeof DeleteVectorOptionsSchema>;
 
 export const deleteVector = (api: VectorOperationsApi, namespace: string) => {
-  const validator = builOptionConfigValidator(
+  const validator = buildConfigValidator(
     DeleteVectorOptionsSchema,
     'delete'
   );

--- a/src/data/fetch.ts
+++ b/src/data/fetch.ts
@@ -1,15 +1,15 @@
 import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { FetchResponse } from '../pinecone-generated-ts-fetch';
 import { handleDataError } from './utils/errorHandling';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 
 import { Static, Type } from '@sinclair/typebox';
 
-const IdsArray = Type.Array(Type.String({ minLength: 1 }));
+const IdsArray = Type.Array(Type.String({ minLength: 1 }), { minItems: 1 });
 export type IdsArray = Static<typeof IdsArray>;
 
 export const fetch = (api: VectorOperationsApi, namespace: string) => {
-  const validator = builOptionConfigValidator(IdsArray, 'fetch');
+  const validator = buildConfigValidator(IdsArray, 'fetch');
 
   return async (ids: IdsArray): Promise<FetchResponse> => {
     validator(ids);

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -18,10 +18,7 @@ const UpdateVectorOptionsSchema = Type.Object({
 export type UpdateVectorOptions = Static<typeof UpdateVectorOptionsSchema>;
 
 export const update = (api: VectorOperationsApi, namespace: string) => {
-  const validator = buildConfigValidator(
-    UpdateVectorOptionsSchema,
-    'update'
-  );
+  const validator = buildConfigValidator(UpdateVectorOptionsSchema, 'update');
 
   return async (options: UpdateVectorOptions): Promise<void> => {
     validator(options);

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -1,6 +1,6 @@
 import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
 import { handleDataError } from './utils/errorHandling';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 import { Static, Type } from '@sinclair/typebox';
 
 const SparseValues = Type.Object({
@@ -18,7 +18,7 @@ const UpdateVectorOptionsSchema = Type.Object({
 export type UpdateVectorOptions = Static<typeof UpdateVectorOptionsSchema>;
 
 export const update = (api: VectorOperationsApi, namespace: string) => {
-  const validator = builOptionConfigValidator(
+  const validator = buildConfigValidator(
     UpdateVectorOptionsSchema,
     'update'
   );

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -1,6 +1,6 @@
 import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
 import { handleDataError } from './utils/errorHandling';
-import { builOptionConfigValidator } from '../validator';
+import { buildConfigValidator } from '../validator';
 
 import { Static, Type } from '@sinclair/typebox';
 
@@ -25,7 +25,7 @@ export type SparseValues = Static<typeof SparseValues>;
 export type VectorArray = Static<typeof VectorArray>;
 
 export const upsert = (api: VectorOperationsApi, namespace: string) => {
-  const validator = builOptionConfigValidator(VectorArray, 'upsert');
+  const validator = buildConfigValidator(VectorArray, 'upsert');
 
   return async (vectors: VectorArray): Promise<void> => {
     validator(vectors);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -82,9 +82,7 @@ const typeErrors = (
 
     if (e.keyword === 'type') {
       errorCount += 1;
-      if (errorCount > maxErrors) {
-        continue;
-      } else {
+      if (errorCount <= maxErrors) {
         formatIndividualError(e, typeErrorsList);
       }
     }
@@ -114,9 +112,7 @@ const validationErrors = (
   let errorCount = 0;
 
   // List of error keywords from https://ajv.js.org/api.html#validation-errors
-  for (let i = 0; i < errors.length; i++) {
-    const e = errors[i];
-
+  for (const e of errors) {
     if (e.keyword === 'minLength' && e.params.limit === 1) {
       e.message = 'must not be blank';
     }
@@ -169,8 +165,7 @@ export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
   );
   if (anyOfErrors.length > 0) {
     const groups = {};
-    for (let i = 0; i < anyOfErrors.length; i++) {
-      const error = anyOfErrors[i];
+    for (const error of anyOfErrors) {
       const schemaPathMatch = schemaPathGroupNumberRegex.exec(error.schemaPath);
       const groupNumber = schemaPathMatch ? schemaPathMatch[1] : 'unknown';
       // Remove the anyOf portion of the schema path to avoid infinite loop
@@ -187,11 +182,8 @@ export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
     // concat errors for each error group
     return (
       `${subject} accepts multiple types. Either ` +
-      Object.keys(groups)
-        .map((key) => {
-          const group = groups[key];
-          return `${parseInt(key) + 1})` + errorFormatter('', group);
-        })
+      Object.entries(groups)
+        .map(([key, group]) => (`${parseInt(key) + 1})` + errorFormatter('', group as Array<ErrorObject>)))
         .join(' ')
     );
   }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -42,7 +42,7 @@ const formatIndividualError = (e, formattedMessageList) => {
     );
   } else if (e.instancePath === '') {
     // parameter is something other than an object, e.g. string
-    formattedMessageList.push(`the argument ${e.message}`);
+    formattedMessageList.push(`argument ${e.message}`);
   }
 };
 
@@ -183,7 +183,11 @@ export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
     return (
       `${subject} accepts multiple types. Either ` +
       Object.entries(groups)
-        .map(([key, group]) => (`${parseInt(key) + 1})` + errorFormatter('', group as Array<ErrorObject>)))
+        .map(
+          ([key, group]) =>
+            `${parseInt(key) + 1})` +
+            errorFormatter('', group as Array<ErrorObject>)
+        )
         .join(' ')
     );
   }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -75,8 +75,8 @@ const typeErrors = (
   const typeErrorsList: Array<string> = [];
   let errorCount = 0;
 
-  for (var i = 0; i < errors.length; i++) {
-    let e = errors[i];
+  for (let i = 0; i < errors.length; i++) {
+    const e = errors[i];
 
     if (e.keyword === 'type') {
       errorCount += 1;
@@ -112,8 +112,8 @@ const validationErrors = (
   let errorCount = 0;
 
   // List of error keywords from https://ajv.js.org/api.html#validation-errors
-  for (var i = 0; i < errors.length; i++) {
-    let e = errors[i];
+  for (let i = 0; i < errors.length; i++) {
+    const e = errors[i];
 
     if (e.keyword === 'minLength' && e.params.limit === 1) {
       e.message = 'must not be blank';
@@ -138,6 +138,7 @@ const validationErrors = (
         } else {
           formatIndividualError(e, validationErrors);
         }
+        break;
       default:
       // noop, other non-validation error handled elsewhere
     }
@@ -167,7 +168,7 @@ export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
   if (anyOfErrors.length > 0) {
     const groups = {};
     for (let i = 0; i < anyOfErrors.length; i++) {
-      let error = anyOfErrors[i];
+      const error = anyOfErrors[i];
       const schemaPathMatch = schemaPathGroupNumberRegex.exec(error.schemaPath);
       const groupNumber = schemaPathMatch ? schemaPathMatch[1] : 'unknown';
       // Remove the anyOf portion of the schema path to avoid infinite loop
@@ -218,7 +219,7 @@ export const buildValidator = (errorMessagePrefix: string, schema: any) => {
     // The PINECONE_DISABLE_RUNTIME_VALIDATIONS env var provides a way to disable
     // all runtime validation. If it is set, all validator functions will immediately
     // return without performing any validation.
-    return (data: any) => {};
+    return (data: any) => {}; // eslint-disable-line
   }
 
   const ajv = new Ajv({ allErrors: true });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -85,7 +85,6 @@ const typeErrors = (
       } else {
         formatIndividualError(e, typeErrorsList);
       }
-
     }
   }
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,10 +2,226 @@ import Ajv from 'ajv';
 import type { ErrorObject } from 'ajv';
 import { PineconeArgumentError } from './errors';
 
-export const buildValidator = (
-  schema: any,
-  onError: (errorsList: string[]) => void
+const prepend = (prefix: string, message: string) => {
+  return `${prefix} ${message}`;
+};
+
+const propNameRegex = /properties\/(.+)\//;
+const arrayPropNameRegex = /properties\/(.+)\/items/;
+const itemIndexRegex = /(\d+)$/;
+const maxErrors = 3;
+
+const formatIndividualError = (e, formattedMessageList) => {
+  if (e.schemaPath.indexOf('properties') > -1) {
+    // property of an object
+    if (e.schemaPath.indexOf('items') > -1) {
+      // property is an array
+      const propNameMatch = arrayPropNameRegex.exec(e.schemaPath);
+      const propName = propNameMatch ? propNameMatch[1] : 'unknown';
+      const itemIndexMatch = itemIndexRegex.exec(e.instancePath);
+      const itemIndex = itemIndexMatch ? itemIndexMatch[1] : 'unknown';
+      formattedMessageList.push(
+        `item at index ${itemIndex} of the '${propName}' array ${e.message}`
+      );
+    } else {
+      // property is not an array
+      const propNameMatch = propNameRegex.exec(e.schemaPath);
+      const propName = propNameMatch ? propNameMatch[1] : 'unknown';
+      formattedMessageList.push(`property '${propName}' ${e.message}`);
+    }
+  } else if (e.schemaPath.indexOf('items') > -1) {
+    // item in an array
+    const itemIndexMatch = itemIndexRegex.exec(e.instancePath);
+    const itemIndex = itemIndexMatch ? itemIndexMatch[1] : 'unknown';
+    formattedMessageList.push(
+      `item at index ${itemIndex} of the array ${e.message}`
+    );
+  } else if (e.instancePath === '') {
+    // parameter is something other than an object, e.g. string
+    formattedMessageList.push(`the argument ${e.message}`);
+  }
+};
+
+const missingPropertiesErrors = (
+  subject: string,
+  errors: Array<ErrorObject>,
+  messageParts: Array<string>
 ) => {
+  const missingPropertyNames = errors
+    .filter((error) => error.keyword === 'required')
+    .map((error) => {
+      return error.params.missingProperty !== undefined
+        ? error.params.missingProperty
+        : 'unknown';
+    });
+  if (missingPropertyNames.length > 0) {
+    const missingMessage = prepend(
+      subject,
+      `must have required properties: ${missingPropertyNames.join(', ')}.`
+    );
+    messageParts.push(missingMessage);
+  }
+};
+
+const typeErrors = (
+  subject: string,
+  errors: Array<ErrorObject>,
+  messageParts: Array<string>
+) => {
+  const typeErrorsList: Array<string> = [];
+  let errorCount = 0;
+
+  for (var i = 0; i < errors.length; i++) {
+    let e = errors[i];
+
+    switch (e.keyword) {
+      case 'type':
+        errorCount += 1;
+        if (errorCount > maxErrors) {
+          continue;
+        } else {
+          formatIndividualError(e, typeErrorsList);
+        }
+      default:
+      // noop, other non-validation error handled elsewhere
+    }
+  }
+
+  if (errorCount > maxErrors) {
+    typeErrorsList.push(`and ${errorCount - maxErrors} other errors`);
+  }
+
+  if (typeErrorsList.length > 0) {
+    const prefix =
+      messageParts.length > 0
+        ? 'There were also type errors:'
+        : `${subject} had type errors:`;
+    const typeErrorMessage = prepend(prefix, typeErrorsList.join(', ')) + '.';
+
+    messageParts.push(typeErrorMessage);
+  }
+};
+
+const validationErrors = (
+  subject: string,
+  errors: Array<ErrorObject>,
+  messageParts: Array<string>
+) => {
+  const validationErrors: Array<string> = [];
+  let errorCount = 0;
+
+  // List of error keywords from https://ajv.js.org/api.html#validation-errors
+  for (var i = 0; i < errors.length; i++) {
+    let e = errors[i];
+
+    if (e.keyword === 'minLength' && e.params.limit === 1) {
+      e.message = 'must not be blank';
+    }
+
+    switch (e.keyword) {
+      case 'minimum':
+      case 'maximum':
+      case 'exclusiveMinimum':
+      case 'exclusiveMaximum':
+      case 'minLength':
+      case 'maxLength':
+      case 'maxProperties':
+      case 'minProperties':
+      case 'minItems':
+      case 'maxItems':
+      case 'additionalItems':
+      case 'additionalProperties':
+        errorCount += 1;
+        if (errorCount > maxErrors) {
+          continue;
+        } else {
+          formatIndividualError(e, validationErrors);
+        }
+      default:
+      // noop, other non-validation error handled elsewhere
+    }
+  }
+
+  if (errorCount > maxErrors) {
+    validationErrors.push(`and ${errorCount - maxErrors} other errors`);
+  }
+
+  if (validationErrors.length > 0) {
+    const prefix =
+      messageParts.length > 0
+        ? 'There were also validation errors:'
+        : `${subject} had validation errors:`;
+    const validationErrorMessage =
+      prepend(prefix, validationErrors.join(', ')) + '.';
+
+    messageParts.push(validationErrorMessage);
+  }
+};
+
+export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
+  const anyOfErrors = errors.filter(
+    (error) =>
+      error.schemaPath.indexOf('anyOf') > -1 && error.keyword !== 'anyOf'
+  );
+  if (anyOfErrors.length > 0) {
+    const groups = {};
+    for (let i = 0; i < anyOfErrors.length; i++) {
+      let error = anyOfErrors[i];
+
+      const schemaPathRegex = /anyOf\/(\d+)\/(.+)/;
+      const schemaPathMatch = schemaPathRegex.exec(error.schemaPath);
+      const groupNumber = schemaPathMatch ? schemaPathMatch[1] : 'unknown';
+      // Remove the anyOf portion of the schema path to avoid infinite loop
+      // when building message for each error group
+      error.schemaPath = schemaPathMatch ? schemaPathMatch[2] : 'unknown';
+
+      if (groups[groupNumber]) {
+        groups[groupNumber].push(error);
+      } else {
+        groups[groupNumber] = [error];
+      }
+    }
+
+    // concat errors for each error group
+    return (
+      `${subject} accepts multiple types. Either ` +
+      Object.keys(groups)
+        .map((key) => {
+          const group = groups[key];
+          return `${parseInt(key) + 1})` + errorFormatter('', group);
+        })
+        .join(' ')
+    );
+  }
+
+  const messageParts: Array<string> = [];
+
+  missingPropertiesErrors(subject, errors, messageParts);
+  typeErrors(subject, errors, messageParts);
+  validationErrors(subject, errors, messageParts);
+
+  return messageParts.join(' ');
+};
+
+export const buildValidator = (errorMessagePrefix: string, schema: any) => {
+  if (
+    process &&
+    process.env &&
+    process.env.PINECONE_DISABLE_RUNTIME_VALIDATIONS
+  ) {
+    // Runtime method validations are most useful when learning to use the client
+    // in an interactive REPL or when developing an application that does not use
+    // Typescript to provide the benefits of static type-checking. However, if your
+    // application is using Typescript and/or you have gained confidence of correct
+    // usage through testing, you may want to disable these runtime validations
+    // to improve performance.
+    //
+    // The PINECONE_DISABLE_RUNTIME_VALIDATIONS env var provides a way to disable
+    // all runtime validation. If it is set, all validator functions will immediately
+    // return without performing any validation.
+    return (data: any) => {};
+  }
+
   const ajv = new Ajv({ allErrors: true });
   const validate = ajv.compile(schema);
 
@@ -13,38 +229,14 @@ export const buildValidator = (
     const valid = validate(data);
     if (!valid) {
       const errors = validate.errors || ([] as Array<ErrorObject>);
-      const errorsList = errors
-        .map((error) => {
-          if (error.message === 'must NOT have fewer than 1 characters') {
-            error.message = 'must not be blank';
-          }
-          return error;
-        })
-        .map((error) => {
-          if (error.instancePath) {
-            return `the property '${error.instancePath.slice(1)}' ${
-              error.message
-            }`;
-          } else {
-            return `the argument ${error.message}`;
-          }
-        })
-        .map((error) => {
-          // Turn errors into sentences
-          return error.charAt(0).toUpperCase() + error.slice(1) + '.';
-        })
-        .filter((message): message is string => message !== undefined);
-      onError(errorsList);
+      const msg = errorFormatter(errorMessagePrefix, errors);
+      throw new PineconeArgumentError(msg);
     }
     return data;
   };
 };
 
-export const builOptionConfigValidator = (schema: any, methodName: string) => {
-  return buildValidator(schema, (errorsList) => {
-    const message = errorsList.join(' ');
-    throw new PineconeArgumentError(
-      `Argument to ${methodName} has a problem. ${message || ''}`
-    );
-  });
+export const buildConfigValidator = (schema: any, methodName: string) => {
+  const prefix = `The argument to ${methodName}`;
+  return buildValidator(prefix, schema);
 };

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -61,7 +61,9 @@ const missingPropertiesErrors = (
   if (missingPropertyNames.length > 0) {
     const missingMessage = prepend(
       subject,
-      `must have required properties: ${missingPropertyNames.join(', ')}.`
+      `must have required ${
+        missingPropertyNames.length > 1 ? 'properties' : 'property'
+      }: ${missingPropertyNames.join(', ')}.`
     );
     messageParts.push(missingMessage);
   }


### PR DESCRIPTION
## Problem

This is a large refactor of how runtime validations are implemented in the node client. It was motivated by the need to handle more complex error conditions in the forthcoming `query` method. My goal was to have a standard way to consume the validation errors emitted by AJV and convert them into text that makes sense in context.

## Solution

- I implemented a new `errorFormatter` function inside `validator.ts`. It is quite complex because there are numerous types of errors that can be emitted from AJV. Even the current implementation is a simplification and doesn't handle the complexity of arbitrarily nested object types, but after a lot of testing I am confident it covers the cases currently needed in this client. 
- Due to the complexity in this new `errorFormatter`, I also added a pretty detailed test suite to exercise the major logical branches. Data for test cases was generated by logging out AJV errors while trying out different error cases in the interactive REPL run via `npm run repl`.
- Consolidate a couple different methods doing validation into a single validation entrypoint: `buildValidator`.
- Remove some bespoke error handling code in the client configuration logic that was written before I introduced the current types-based validation strategy. 
- Refactor and update all client methods to use this `buildValidator` validation entrypoint.

Some things this approach does well compared to the code it replaces:
- Common situations (such as object missing required properties A, B, and C) are expressed more concisely than in the past by being expressed as a list rather than as a concatenation of repetitive error sentences. 
    - Before: `"Argument to createCollection has a problem. The argument must have required property 'name'. The argument must have required property 'source'."`
    - After: `'The argument to createCollection must have required properties: name, source.'` 
- In some situations, does a better job of indicating which named object properties or array elements are having a problem
    - Before: `"Argument to upsert has a problem. The property '0/values/0' must be number. The property '0/values/1' must be number."`
    - After: `"The argument to upsert had type errors: item at index 0 of the 'values' array must be number, item at index 1 of the 'values' array must be number."` 
- This handles situations where there are multiple argument types accepted by a method. This was the primary motivation for this diff.
    - Example: `'The argument to query accepts multiple types. Either 1) must have required property: id. 2) must have required property: vector.'`
- When there are numerous errors (for example: due to many incorrect items in a large array), it only prints out the first few of these errors followed by an error count.
    - Example: `'The argument to fetch had type errors: item at index 0 of the array must be string, item at index 1 of the array must be string, item at index 2 of the array must be string, and 96 other errors.'`

Bonus:
- Having a unified approach to runtime validation makes it a simple matter to disable the validation, if desired, in production settings where performance is the overriding concern and confidence of correctness has been obtained through other means (experience, testing, use of Typescript types, etc). So I put in an environment variable, `PINECONE_DISABLE_RUNTIME_VALIDATIONS` that can be used to disable these validations when desired.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality): Runtime validations can be disabled with `PINECONE_DISABLE_RUNTIME_VALIDATIONS` env var. 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [x] None of the above: Refactor of unreleased code, so should not be considered breaking.

## Test Plan

I updated numerous unit tests in this diff and did extensive manual testing in `npm run repl`.