### PR TITLE
[v1] Add query method to new client

### DIFF
--- a/src/__tests__/validator.test.ts
+++ b/src/__tests__/validator.test.ts
@@ -484,4 +484,35 @@ describe('validation', () => {
       );
     });
   });
+
+  test('handles Never conditions', () => {
+    // await client.index('jen3').query({ topK: 3, vector: [0.5, 0.5, 0.5], sparseVector: { indices: [0, 1], values: [0.1, 0.25]}, id: '1' })
+    const validationErrors = [
+      {
+        instancePath: '/vector',
+        schemaPath: '#/anyOf/0/properties/vector/not',
+        keyword: 'not',
+        params: {},
+        message: 'must NOT be valid',
+      },
+      {
+        instancePath: '/id',
+        schemaPath: '#/anyOf/1/properties/id/not',
+        keyword: 'not',
+        params: {},
+        message: 'must NOT be valid',
+      },
+      {
+        instancePath: '',
+        schemaPath: '#/anyOf',
+        keyword: 'anyOf',
+        params: {},
+        message: 'must match a schema in anyOf',
+      },
+    ];
+
+    expect(errorFormatter('The argument to query', validationErrors)).toEqual(
+      'The argument to query accepts multiple types. Either 1) must not have property: vector. 2) must not have property: id.'
+    );
+  });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -278,4 +278,13 @@ export class Client {
   Index(indexName: string) {
     return this.index(indexName);
   }
+
+  __curlStarter() {
+    // Every endpoint is going to have a different path and expect different data (in the case of POST requests),
+    // but this is a good starting point for users to see how to use curl to interact with the REST API.
+    console.log('Example curl command to list indexes: ');
+    console.log(
+      `curl "https://controller.${this.config.environment}.pinecone.io/databases" -H "Api-Key: ${this.config.apiKey}" -H "Accept: application/json"`
+    );
+  }
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -17,7 +17,7 @@ export type { IdsArray } from './fetch';
 export type { DeleteVectorOptions } from './delete';
 export type { UpdateVectorOptions } from './update';
 export type { Vector, VectorArray, SparseValues } from './upsert';
-export type { Query, QueryByVectorId, QueryByVectorValues } from './query';
+export type { QueryOptions, QueryByVectorId, QueryByVectorValues } from './query';
 
 type ApiConfig = {
   projectId: string;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -17,7 +17,11 @@ export type { IdsArray } from './fetch';
 export type { DeleteVectorOptions } from './delete';
 export type { UpdateVectorOptions } from './update';
 export type { Vector, VectorArray, SparseValues } from './upsert';
-export type { QueryOptions, QueryByVectorId, QueryByVectorValues } from './query';
+export type {
+  QueryOptions,
+  QueryByVectorId,
+  QueryByVectorValues,
+} from './query';
 
 type ApiConfig = {
   projectId: string;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -6,17 +6,27 @@ import {
 import { upsert } from './upsert';
 import { fetch } from './fetch';
 import { update } from './update';
+import { query } from './query';
 import { queryParamsStringify, buildUserAgent } from '../utils';
 import { deleteVector } from './delete';
 import { describeIndexStats } from './describeIndexStats';
 
 export type { DescribeIndexStatsOptions } from './describeIndexStats';
 
+export type { IdsArray } from './fetch';
+export type { DeleteVectorOptions } from './delete';
+export type { UpdateVectorOptions } from './update';
+export type { Vector, VectorArray, SparseValues } from './upsert';
+export type { Query, QueryByVectorId, QueryByVectorValues } from './query';
+
 type ApiConfig = {
   projectId: string;
   apiKey: string;
   environment: string;
 };
+
+const basePath = (config: ApiConfig, indexName: string) =>
+  `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`;
 
 export class Index {
   private config: ApiConfig;
@@ -25,15 +35,16 @@ export class Index {
     namespace: string;
   };
 
-  upsert: ReturnType<typeof upsert>;
-  fetch: ReturnType<typeof fetch>;
   delete: ReturnType<typeof deleteVector>;
   describeIndexStats: ReturnType<typeof describeIndexStats>;
+  fetch: ReturnType<typeof fetch>;
   update: ReturnType<typeof update>;
+  upsert: ReturnType<typeof upsert>;
+  query: ReturnType<typeof query>;
 
   constructor(indexName: string, config: ApiConfig, namespace = '') {
     const indexConfigurationParameters: ConfigurationParameters = {
-      basePath: `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`,
+      basePath: basePath(config, indexName),
       apiKey: config.apiKey,
       queryParamsStringify,
       headers: {
@@ -49,11 +60,12 @@ export class Index {
       namespace: namespace,
     };
 
-    this.upsert = upsert(vectorOperations, namespace);
-    this.fetch = fetch(vectorOperations, namespace);
     this.delete = deleteVector(vectorOperations, namespace);
     this.describeIndexStats = describeIndexStats(vectorOperations);
+    this.fetch = fetch(vectorOperations, namespace);
     this.update = update(vectorOperations, namespace);
+    this.upsert = upsert(vectorOperations, namespace);
+    this.query = query(vectorOperations, namespace);
   }
 
   namespace(namespace: string): Index {

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -3,7 +3,6 @@ import type { QueryResponse } from '../pinecone-generated-ts-fetch';
 import { handleDataError } from './utils/errorHandling';
 import { buildConfigValidator } from '../validator';
 import { SparseValuesSchema } from './upsert';
-
 import { Static, Type } from '@sinclair/typebox';
 
 const nonemptyString = Type.String({ minLength: 1 });
@@ -29,16 +28,16 @@ const QueryByVectorValues = Type.Object({
   id: Type.Optional(Type.Never()),
 });
 
-const Query = Type.Union([QueryByVectorId, QueryByVectorValues]);
+const QuerySchema = Type.Union([QueryByVectorId, QueryByVectorValues]);
 
 export type QueryByVectorId = Static<typeof QueryByVectorId>;
 export type QueryByVectorValues = Static<typeof QueryByVectorValues>;
-export type Query = Static<typeof Query>;
+export type QueryOptions = Static<typeof QuerySchema>;
 
 export const query = (api: VectorOperationsApi, namespace: string) => {
-  const validator = buildConfigValidator(Query, 'query');
+  const validator = buildConfigValidator(QuerySchema, 'query');
 
-  return async (query: Query): Promise<QueryResponse> => {
+  return async (query: QueryOptions): Promise<QueryResponse> => {
     validator(query);
 
     try {

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -2,7 +2,7 @@ import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { QueryResponse } from '../pinecone-generated-ts-fetch';
 import { handleDataError } from './utils/errorHandling';
 import { buildConfigValidator } from '../validator';
-import { SparseValues } from './upsert';
+import { SparseValuesSchema } from './upsert';
 
 import { Static, Type } from '@sinclair/typebox';
 
@@ -25,7 +25,7 @@ const QueryByVectorId = Type.Object({
 const QueryByVectorValues = Type.Object({
   ...shared,
   vector: Type.Array(Type.Number()),
-  sparseVector: Type.Optional(SparseValues),
+  sparseVector: Type.Optional(SparseValuesSchema),
   id: Type.Optional(Type.Never()),
 });
 

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -1,0 +1,55 @@
+import { VectorOperationsApi } from '../pinecone-generated-ts-fetch';
+import type { QueryResponse } from '../pinecone-generated-ts-fetch';
+import { handleDataError } from './utils/errorHandling';
+import { buildConfigValidator } from '../validator';
+import { SparseValues } from './upsert';
+
+import { Static, Type } from '@sinclair/typebox';
+
+const nonemptyString = Type.String({ minLength: 1 });
+
+const shared = {
+  topK: Type.Number(),
+  includeValues: Type.Optional(Type.Boolean()),
+  includeMetadata: Type.Optional(Type.Boolean()),
+  filter: Type.Optional(Type.Object({})),
+};
+
+const QueryByVectorId = Type.Object({
+  ...shared,
+  id: nonemptyString,
+  vector: Type.Optional(Type.Never()),
+  sparseVector: Type.Optional(Type.Never()),
+});
+
+const QueryByVectorValues = Type.Object({
+  ...shared,
+  vector: Type.Array(Type.Number()),
+  sparseVector: Type.Optional(SparseValues),
+  id: Type.Optional(Type.Never()),
+});
+
+const Query = Type.Union([QueryByVectorId, QueryByVectorValues]);
+
+export type QueryByVectorId = Static<typeof QueryByVectorId>;
+export type QueryByVectorValues = Static<typeof QueryByVectorValues>;
+export type Query = Static<typeof Query>;
+
+export const query = (api: VectorOperationsApi, namespace: string) => {
+  const validator = buildConfigValidator(Query, 'query');
+
+  return async (query: Query): Promise<QueryResponse> => {
+    validator(query);
+
+    try {
+      const results = await api.query({
+        queryRequest: { ...query, namespace },
+      });
+      delete results.results;
+      return results;
+    } catch (e) {
+      const err = await handleDataError(e);
+      throw err;
+    }
+  };
+};

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -6,7 +6,7 @@ import { Static, Type } from '@sinclair/typebox';
 
 const nonemptyString = Type.String({ minLength: 1 });
 
-const SparseValues = Type.Object(
+export const SparseValuesSchema = Type.Object(
   {
     indices: Type.Array(Type.Integer()),
     values: Type.Array(Type.Number()),
@@ -18,7 +18,7 @@ const Vector = Type.Object(
   {
     id: nonemptyString,
     values: Type.Array(Type.Number()),
-    sparseValues: Type.Optional(SparseValues),
+    sparseValues: Type.Optional(SparseValuesSchema),
     metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
   },
   { additionalProperties: false }
@@ -27,7 +27,7 @@ const Vector = Type.Object(
 const VectorArray = Type.Array(Vector);
 
 export type Vector = Static<typeof Vector>;
-export type SparseValues = Static<typeof SparseValues>;
+export type SparseValues = Static<typeof SparseValuesSchema>;
 export type VectorArray = Static<typeof VectorArray>;
 
 export const upsert = (api: VectorOperationsApi, namespace: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,17 @@ export * as Errors from './errors';
 
 // Type exports
 export type { IndexName, IndexList, CreateIndexOptions } from './control';
-export type { DescribeIndexStatsOptions } from './data';
+export type {
+  IdsArray,
+  DeleteVectorOptions,
+  DescribeIndexStatsOptions,
+  UpdateVectorOptions,
+  VectorArray,
+  SparseValues,
+  Query,
+  QueryByVectorId,
+  QueryByVectorValues,
+} from './data';
 
 // Legacy exports for backwards compatibility
 export { PineconeClient } from './v0';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export type {
   UpdateVectorOptions,
   VectorArray,
   SparseValues,
-  Query,
+  QueryOptions,
   QueryByVectorId,
   QueryByVectorValues,
 } from './data';

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -61,11 +61,32 @@ const missingPropertiesErrors = (
   if (missingPropertyNames.length > 0) {
     const missingMessage = prepend(
       subject,
-      `must have required ${
+      `${messageParts.length > 0 ? 'M' : 'm'}ust have required ${
         missingPropertyNames.length > 1 ? 'properties' : 'property'
       }: ${missingPropertyNames.join(', ')}.`
     );
     messageParts.push(missingMessage);
+  }
+};
+
+const neverErrors = (
+  subject: string,
+  errors: Array<ErrorObject>,
+  messageParts: Array<string>
+) => {
+  const neverPropertyErrors = errors
+    .filter((error) => error.keyword === 'not')
+    .map((error) => {
+      return error.instancePath.slice(1);
+    });
+  if (neverPropertyErrors.length > 0) {
+    const neverMessage = prepend(
+      subject,
+      `must not have ${
+        neverPropertyErrors.length > 1 ? 'properties' : 'property'
+      }: ${neverPropertyErrors.join(', ')}.`
+    );
+    messageParts.push(neverMessage);
   }
 };
 
@@ -194,6 +215,7 @@ export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
 
   const messageParts: Array<string> = [];
 
+  neverErrors(subject, errors, messageParts);
   missingPropertiesErrors(subject, errors, messageParts);
   typeErrors(subject, errors, messageParts);
   validationErrors(subject, errors, messageParts);
@@ -227,6 +249,7 @@ export const buildValidator = (errorMessagePrefix: string, schema: any) => {
     const valid = validate(data);
     if (!valid) {
       const errors = validate.errors || ([] as Array<ErrorObject>);
+      // console.log(errors)
       const msg = errorFormatter(errorMessagePrefix, errors);
       throw new PineconeArgumentError(msg);
     }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -249,7 +249,6 @@ export const buildValidator = (errorMessagePrefix: string, schema: any) => {
     const valid = validate(data);
     if (!valid) {
       const errors = validate.errors || ([] as Array<ErrorObject>);
-      // console.log(errors)
       const msg = errorFormatter(errorMessagePrefix, errors);
       throw new PineconeArgumentError(msg);
     }


### PR DESCRIPTION
## Problem

Need to add and expose query functionality in new client.

## Solution

By leveraging recent changes to error handling and validation, the new code to add query is mostly just a new type definition. I should add a couple tests in a follow-up, but there's not much new logic in here.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

`npm run repl`

#### Argument validations

Checks required stuff is there, and also that you're not passing a non-sensical mix of id and vector params.

```
await client.index('jen2').query({})
Uncaught:
PineconeArgumentError: The argument to query accepts multiple types. Either 1) must have required properties: topK, id. 2) must have required properties: topK, vector.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:191:19
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:72:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:44:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:25:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:19:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:15:12)
    at Index.query (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:67:38)
    at REPL18:1:60
> await client.index('jen2').query({ id: 1, topK: 3 })
Uncaught:
PineconeArgumentError: The argument to query accepts multiple types. Either 1) had type errors: property 'id' must be string. 2) must have required property: vector.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:191:19
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:72:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:44:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:25:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:19:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:15:12)
    at Index.query (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:67:38)
    at REPL19:1:60
> await client.index('jen3').query({ topK: 3, vector: [0.5, 0.5, 0.5], sparseVector: { indices: [0, 1], values: [0.1, 0.25]}, id: '1' })
[
  {
    instancePath: '/vector',
    schemaPath: '#/anyOf/0/properties/vector/not',
    keyword: 'not',
    params: {},
    message: 'must NOT be valid'
  },
  {
    instancePath: '/sparseVector',
    schemaPath: '#/anyOf/0/properties/sparseVector/not',
    keyword: 'not',
    params: {},
    message: 'must NOT be valid'
  },
  {
    instancePath: '/id',
    schemaPath: '#/anyOf/1/properties/id/not',
    keyword: 'not',
    params: {},
    message: 'must NOT be valid'
  },
  {
    instancePath: '',
    schemaPath: '#/anyOf',
    keyword: 'anyOf',
    params: {},
    message: 'must match a schema in anyOf'
  }
]
Uncaught:
PineconeArgumentError: The argument to query accepts multiple types. Either 1) must not have properties: vector, sparseVector. 2) must not have property: id.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:205:19
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:72:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:44:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:25:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:19:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:15:12)
    at Index.query (/Users/jhamon/workspace/pinecone-ts-client/dist/data/query.js:67:38)
    at REPL3:1:60
>
```


#### Happy path

query by id, in namespace with results, including optional values and metadata in response
```
> await client.index('jen2').namespace('foo').query({ id: '1', topK: 3, includeValues: true, includeMetadata: true })
{
  matches: [
    {
      id: '1',
      score: 1,
      values: [Array],
      sparseValues: [Object],
      metadata: [Object]
    },
    {
      id: '3',
      score: 1,
      values: [Array],
      sparseValues: [Object],
      metadata: [Object]
    },
    {
      id: '2',
      score: 1,
      values: [Array],
      sparseValues: undefined,
      metadata: undefined
    }
  ],
  namespace: 'foo'
}
>
```

query by id, in namespace with no results
```
> await client.index('jen2').namespace('bar').query({ id: '1', topK: 3, includeValues: true, includeMetadata: true })
{ matches: [], namespace: '' }
```

query by vector value,  in namespace with results
```
> await client.index('jen2').namespace('foo').query({ topK: 2, vector: [0.1] })
{
  matches: [
    {
      id: '2',
      score: 1,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    },
    {
      id: '5',
      score: 1,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    }
  ],
  namespace: 'foo'
}
```

query by vector value, in empty namespace
```
> await client.index('jen2').namespace('bar').query({ topK: 2, vector: [0.1] })
{ matches: [], namespace: 'bar' }
```

Note: At first I was suspicious that all these results have a score of 1, but I think it's an artifact of the fact the test index in these examples only has dimension 1. I did some testing with a different index and got more plausible looking similarity scores.

After creating a `jen3` index using the `dotproduct` metric and dimension 3 to try out hybrid search, I saw that passing sparseVector had an effect on the results and similarity scores.

```
> await client.index('jen3').query({ topK: 3, vector: [0.5, 0.5, 0.5] })
{
  matches: [
    {
      id: '50',
      score: 1.28853202,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    },
    {
      id: '53',
      score: 1.22128367,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    },
    {
      id: '69',
      score: 1.18652403,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    }
  ],
  namespace: ''
}

> await client.index('jen3').query({ topK: 3, vector: [0.5, 0.5, 0.5], sparseVector: { indices: [0, 1], values: [0.1, 0.25]} })
{
  matches: [
    {
      id: '50',
      score: 1.36086488,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    },
    {
      id: '53',
      score: 1.35499585,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    },
    {
      id: '20',
      score: 1.3517946,
      values: [],
      sparseValues: undefined,
      metadata: undefined
    }
  ],
  namespace: ''
}
```

#### Error cases

Vector dimension does not match index

```
> await client.index('jen2').namespace('foo').query({ topK: 10, vector: [0.1, 0.2] })
Uncaught:
PineconeBadRequestError: Query vector dimension 2 does not match the dimension of the index 1
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/utils/errorHandling.js:53:71
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/data/utils/errorHandling.js:33:23)
```

attempting a hybrid search on an index that doesn't support it

```
> await client.index('jen2').query({ topK: 4, vector: [0.25, 0.25], sparseVector: { indices: [0], values: [0.66]}  })
Uncaught PineconeBadRequestError: Index configuration does not support sparse values
    at mapHttpStatusError (/Users/jhamon/workspace/pinecone-ts-client/dist/errors/http.js:127:20)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/data/utils/errorHandling.js:53:71
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/data/utils/errorHandling.js:33:23)
> await client.describeIndex('jen2')
{
  database: {
    name: 'jen2',
    dimension: 2,
    metric: 'cosine',
    pods: 1,
    replicas: 1,
    shards: 1,
    podType: 'p1.x1'
  },
  status: { ready: true, state: 'Ready' }
}
```

Known issues:
- Error message is mangled when sparseValues fields have incorrect type

Needs testing:
- Metadata filtering