### PR TITLE
Increase strictness of TypeBox Object schemas

### DIFF
--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -72,7 +72,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex accepts multiple types. Either 1) must have required property: replicas. 2) had type errors: property 'podType' must be string."
+        "The second argument to configureIndex accepts multiple types. Either 1) must have required property: replicas. There were also validation errors: argument must NOT have additional properties. 2) had type errors: property 'podType' must be string."
       );
     });
 

--- a/src/control/configureIndex.ts
+++ b/src/control/configureIndex.ts
@@ -11,12 +11,18 @@ const nonemptyString = Type.String({ minLength: 1 });
 const positiveInteger = Type.Integer({ minimum: 1 });
 
 const ConfigureIndexOptionsSchema = Type.Union([
-  Type.Object({
-    replicas: positiveInteger,
-  }),
-  Type.Object({
-    podType: nonemptyString,
-  }),
+  Type.Object(
+    {
+      replicas: positiveInteger,
+    },
+    { additionalProperties: false }
+  ),
+  Type.Object(
+    {
+      podType: nonemptyString,
+    },
+    { additionalProperties: false }
+  ),
 ]);
 
 export type ConfigureIndexOptions = Static<typeof ConfigureIndexOptionsSchema>;

--- a/src/control/createCollection.ts
+++ b/src/control/createCollection.ts
@@ -8,10 +8,13 @@ import { Static, Type } from '@sinclair/typebox';
 
 const nonemptyString = Type.String({ minLength: 1 });
 
-const CreateCollectionOptionsSchema = Type.Object({
-  name: nonemptyString,
-  source: nonemptyString,
-});
+const CreateCollectionOptionsSchema = Type.Object(
+  {
+    name: nonemptyString,
+    source: nonemptyString,
+  },
+  { additionalProperties: false }
+);
 
 export type CreateCollectionOptions = Static<
   typeof CreateCollectionOptionsSchema

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -8,20 +8,26 @@ import { Static, Type } from '@sinclair/typebox';
 const nonemptyString = Type.String({ minLength: 1 });
 const positiveInteger = Type.Integer({ minimum: 1 });
 
-const CreateIndexOptionsSchema = Type.Object({
-  name: nonemptyString,
-  dimension: positiveInteger,
-  metric: Type.Optional(nonemptyString),
-  pods: Type.Optional(positiveInteger),
-  replicas: Type.Optional(positiveInteger),
-  podType: Type.Optional(nonemptyString),
-  metadataConfig: Type.Optional(
-    Type.Object({
-      indexed: Type.Array(nonemptyString),
-    })
-  ),
-  sourceCollection: Type.Optional(nonemptyString),
-});
+const CreateIndexOptionsSchema = Type.Object(
+  {
+    name: nonemptyString,
+    dimension: positiveInteger,
+    metric: Type.Optional(nonemptyString),
+    pods: Type.Optional(positiveInteger),
+    replicas: Type.Optional(positiveInteger),
+    podType: Type.Optional(nonemptyString),
+    metadataConfig: Type.Optional(
+      Type.Object(
+        {
+          indexed: Type.Array(nonemptyString),
+        },
+        { additionalProperties: false }
+      )
+    ),
+    sourceCollection: Type.Optional(nonemptyString),
+  },
+  { additionalProperties: false }
+);
 
 export type CreateIndexOptions = Static<typeof CreateIndexOptionsSchema>;
 

--- a/src/data/delete.ts
+++ b/src/data/delete.ts
@@ -7,11 +7,14 @@ const idsArray = Type.Array(Type.String({ minLength: 1 }));
 const deleteAll = Type.Boolean();
 const filter = Type.Optional(Type.Object({}, { additionalProperties: true }));
 
-const DeleteVectorOptionsSchema = Type.Object({
-  ids: Type.Optional(idsArray),
-  deleteAll: Type.Optional(deleteAll),
-  filter: Type.Optional(filter),
-});
+const DeleteVectorOptionsSchema = Type.Object(
+  {
+    ids: Type.Optional(idsArray),
+    deleteAll: Type.Optional(deleteAll),
+    filter: Type.Optional(filter),
+  },
+  { additionalProperties: false }
+);
 
 export type DeleteVectorOptions = Static<typeof DeleteVectorOptionsSchema>;
 

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -3,17 +3,23 @@ import { handleDataError } from './utils/errorHandling';
 import { buildConfigValidator } from '../validator';
 import { Static, Type } from '@sinclair/typebox';
 
-const SparseValues = Type.Object({
-  indices: Type.Array(Type.Integer()),
-  values: Type.Array(Type.Number()),
-});
+const SparseValues = Type.Object(
+  {
+    indices: Type.Array(Type.Integer()),
+    values: Type.Array(Type.Number()),
+  },
+  { additionalProperties: false }
+);
 
-const UpdateVectorOptionsSchema = Type.Object({
-  id: Type.String({ minLength: 1 }),
-  values: Type.Optional(Type.Array(Type.Number())),
-  sparseValues: Type.Optional(SparseValues),
-  metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
-});
+const UpdateVectorOptionsSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    values: Type.Optional(Type.Array(Type.Number())),
+    sparseValues: Type.Optional(SparseValues),
+    metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  },
+  { additionalProperties: false }
+);
 
 export type UpdateVectorOptions = Static<typeof UpdateVectorOptionsSchema>;
 

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -6,17 +6,23 @@ import { Static, Type } from '@sinclair/typebox';
 
 const nonemptyString = Type.String({ minLength: 1 });
 
-const SparseValues = Type.Object({
-  indices: Type.Array(Type.Integer()),
-  values: Type.Array(Type.Number()),
-});
+const SparseValues = Type.Object(
+  {
+    indices: Type.Array(Type.Integer()),
+    values: Type.Array(Type.Number()),
+  },
+  { additionalProperties: false }
+);
 
-const Vector = Type.Object({
-  id: nonemptyString,
-  values: Type.Array(Type.Number()),
-  sparseValues: Type.Optional(SparseValues),
-  metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
-});
+const Vector = Type.Object(
+  {
+    id: nonemptyString,
+    values: Type.Array(Type.Number()),
+    sparseValues: Type.Optional(SparseValues),
+    metadata: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  },
+  { additionalProperties: false }
+);
 
 const VectorArray = Type.Array(Vector);
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -159,6 +159,7 @@ const validationErrors = (
 };
 
 export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
+  console.log('errorFormatter: ', errors);
   const anyOfErrors = errors.filter(
     (error) =>
       error.schemaPath.indexOf('anyOf') > -1 && error.keyword !== 'anyOf'
@@ -227,6 +228,7 @@ export const buildValidator = (errorMessagePrefix: string, schema: any) => {
     const valid = validate(data);
     if (!valid) {
       const errors = validate.errors || ([] as Array<ErrorObject>);
+      console.log('EARLY ERRORS: ', errors);
       const msg = errorFormatter(errorMessagePrefix, errors);
       throw new PineconeArgumentError(msg);
     }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -159,7 +159,6 @@ const validationErrors = (
 };
 
 export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
-  console.log('errorFormatter: ', errors);
   const anyOfErrors = errors.filter(
     (error) =>
       error.schemaPath.indexOf('anyOf') > -1 && error.keyword !== 'anyOf'
@@ -228,7 +227,6 @@ export const buildValidator = (errorMessagePrefix: string, schema: any) => {
     const valid = validate(data);
     if (!valid) {
       const errors = validate.errors || ([] as Array<ErrorObject>);
-      console.log('EARLY ERRORS: ', errors);
       const msg = errorFormatter(errorMessagePrefix, errors);
       throw new PineconeArgumentError(msg);
     }


### PR DESCRIPTION
## Problem
When creating schemas for runtime validation with typebox involving `Type.Object()`, we have not been providing the `additionalProperties: false` parameter via `ObjectOptions`. This would restrict users' ability to provide extraneous parameters at runtime when calling functions that receive objects, etc.

Initially, we had thought this flexibility would be beneficial in that users could leverage the client using fields that may have been added since the last update. However, OpenAPI prevents this behavior anyway under the hood, so we'd like to explicitly disallow the ability for users to pass additional values.

Context: https://pinecone-io.slack.com/archives/C04DQS0RG84/p1692816422329919 

## Solution

For all instances where we're leveraging `Type.Object({ ... })` with an explicit list of params, we want to make sure to provide the `additionalProperties` option explicitly: `Type.Object({ ... }, { additionalProperties: false })`. This will explicitly prevent users from passing extra params, and should alert them to this via our validation pipeline.

**Note:** I was curious what the behavior is when omitting the `additionalProperties` value entirely. My assumption was it would default to false. I dug around in the typebox code a bit to get a better sense of things:

```javascript
    function* Object(schema, references, value) {
        yield IsObjectCheck(value);
        if (IsNumber(schema.minProperties))
            yield `Object.getOwnPropertyNames(${value}).length >= ${schema.minProperties}`;
        if (IsNumber(schema.maxProperties))
            yield `Object.getOwnPropertyNames(${value}).length <= ${schema.maxProperties}`;
        const knownKeys = globalThis.Object.getOwnPropertyNames(schema.properties);
        for (const knownKey of knownKeys) {
            const memberExpression = MemberExpression.Encode(value, knownKey);
            const property = schema.properties[knownKey];
            if (schema.required && schema.required.includes(knownKey)) {
                yield* Visit(property, references, memberExpression);
                if (Types.ExtendsUndefined.Check(property) || IsAnyOrUnknown(property))
                    yield `('${knownKey}' in ${value})`;
            }
            else {
                const expression = CreateExpression(property, references, memberExpression);
                yield IsExactOptionalProperty(value, knownKey, expression);
            }
        }
        if (schema.additionalProperties === false) {
            if (schema.required && schema.required.length === knownKeys.length) {
                yield `Object.getOwnPropertyNames(${value}).length === ${knownKeys.length}`;
            }
            else {
                const keys = `[${knownKeys.map((key) => `'${key}'`).join(', ')}]`;
                yield `Object.getOwnPropertyNames(${value}).every(key => ${keys}.includes(key))`;
            }
        }
        if (typeof schema.additionalProperties === 'object') {
            const expression = CreateExpression(schema.additionalProperties, references, `${value}[key]`);
            const keys = `[${knownKeys.map((key) => `'${key}'`).join(', ')}]`;
            yield `(Object.getOwnPropertyNames(${value}).every(key => ${keys}.includes(key) || ${expression}))`;
        }
    }
```
(the above can be found in `/@sinclair/typebox/compiler/compiler.js` if you're curious)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Testing should involve attempting to pass objects with extra parameters to the specific functions that were affected and making sure we receive the proper validation error from AJV:
- `configureIndex`
- `createCollection`
- `createIndex`
- `update`
- `upsert`

### upsert example
```
npm run repl
await init()

> await client.index('test-create-index').upsert([{ id: 'testing', foo: 'bar', values: [1, 2, 3]}])
Uncaught:
PineconeArgumentError: The argument to upsert had validation errors: item at index 0 of the array must NOT have additional properties.
    at /Users/austin/workspace/pinecone-ts-client/dist/validator.js:191:19
    at /Users/austin/workspace/pinecone-ts-client/dist/data/upsert.js:62:21
    at step (/Users/austin/workspace/pinecone-ts-client/dist/data/upsert.js:33:23)
    at Object.next (/Users/austin/workspace/pinecone-ts-client/dist/data/upsert.js:14:53)
    at /Users/austin/workspace/pinecone-ts-client/dist/data/upsert.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/austin/workspace/pinecone-ts-client/dist/data/upsert.js:4:12)
    at Index.upsert (/Users/austin/workspace/pinecone-ts-client/dist/data/upsert.js:57:40)
    at REPL14:1:73
```
**NOTE:** It seems like there may be some issues regarding typebox union types that involve objects with restricted properties. This came up when running the `configureIndex.validation.test.ts` file after adjusting object types:

![Screenshot 2023-08-24 at 4 24 00 PM](https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/0fbdf602-a417-4062-9280-e89e72c81259)

The error message ends up looking a bit confusing here. I believe this may also be addressed in a `validator.ts` fix @jhamon is currently working on. For now, I've updated the expected string in the unit test, but am open to feedback.



