### PR TITLE
[v1] Allow createIndex to support waitUntilReady for async polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@jest/globals": "^29.3.1",
-        "@types/jest": "^29.2.5",
+        "@types/jest": "^29.5.0",
         "@types/node": "^18.11.17",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
@@ -1244,9 +1244,10 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.2.5",
+      "version": "29.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.4.tgz",
+      "integrity": "sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.3.1",
-    "@types/jest": "^29.2.5",
+    "@types/jest": "^29.5.0",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",

--- a/src/control/__tests__/createIndex.test.ts
+++ b/src/control/__tests__/createIndex.test.ts
@@ -20,8 +20,7 @@ describe('createIndex', () => {
       IndexOperationsApi: IOA,
     }));
 
-    const createIndexFn = createIndex(IOA);
-    const returned = await createIndexFn({
+    const returned = await createIndex(IOA)({
       name: 'index-name',
       dimension: 10,
     });
@@ -36,6 +35,13 @@ describe('createIndex', () => {
   });
 
   describe('waitUntilReady', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     test('when passed waitUntilReady, calls the create index endpoint and begins polling describeIndex', async () => {
       const fakeCreateIndex: (req: CreateIndexRequest) => Promise<string> =
         jest.fn();
@@ -53,8 +59,7 @@ describe('createIndex', () => {
         IndexOperationsApi: IOA,
       }));
 
-      const createIndexFn = createIndex(IOA);
-      const returned = await createIndexFn({
+      const returned = await createIndex(IOA)({
         name: 'index-name',
         dimension: 10,
         waitUntilReady: true,
@@ -74,7 +79,6 @@ describe('createIndex', () => {
     });
 
     test('will continue polling describeIndex if the index is not yet ready', async () => {
-      jest.useFakeTimers();
       const fakeCreateIndex: (req: CreateIndexRequest) => Promise<string> =
         jest.fn();
       const fakeDescribeIndex: (
@@ -115,7 +119,6 @@ describe('createIndex', () => {
         expect(fakeDescribeIndex).toHaveBeenNthCalledWith(3, {
           indexName: 'index-name',
         });
-        jest.useRealTimers();
       });
     });
   });

--- a/src/control/__tests__/createIndex.test.ts
+++ b/src/control/__tests__/createIndex.test.ts
@@ -25,23 +25,18 @@ const setupCreateIndexResponse = (
         : Promise.reject({ response: createIndexResponse })
     );
 
-  // unfold describeIndexResponses
+  // unfold describeIndexResponse
+  const describeResponses = Array.isArray(describeIndexResponse)
+    ? describeIndexResponse
+    : [describeIndexResponse];
   const describeIndexMock = jest.fn();
-  if (Array.isArray(describeIndexResponse)) {
-    describeIndexResponse.forEach((response) => {
-      describeIndexMock.mockImplementationOnce(() =>
-        isDescribeIndexSuccess
-          ? Promise.resolve(response)
-          : Promise.reject({ response })
-      );
-    });
-  } else if (describeIndexResponse) {
-    describeIndexMock.mockImplementation(() =>
+  describeResponses.forEach((response) => {
+    describeIndexMock.mockImplementationOnce(() =>
       isDescribeIndexSuccess
-        ? Promise.resolve(describeIndexResponse)
-        : Promise.reject({ response: describeIndexResponse })
+        ? Promise.resolve(response)
+        : Promise.reject({ response })
     );
-  }
+  });
 
   const fakeDescribeIndex: (req: DescribeIndexRequest) => Promise<IndexMeta> =
     describeIndexMock;

--- a/src/control/__tests__/createIndex.test.ts
+++ b/src/control/__tests__/createIndex.test.ts
@@ -1,23 +1,170 @@
 import { createIndex } from '../createIndex';
+import {
+  PineconeBadRequestError,
+  PineconeInternalServerError,
+} from '../../errors';
 import { IndexOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type {
+  CreateIndexRequest,
+  DescribeIndexRequest,
+  IndexMeta,
+} from '../../pinecone-generated-ts-fetch';
 
 describe('createIndex', () => {
-  let IOA: IndexOperationsApi;
-  beforeEach(() => {
-    // @ts-ignore
-    IOA = { createIndex: jest.fn() };
-    jest.mock('../../pinecone-generated-ts-fetch', () => ({
+  test('calls the openapi create index endpoint, passing name and dimension', async () => {
+    const fakeCreateIndex: (req: CreateIndexRequest) => Promise<string> =
+      jest.fn();
+    const IOA = { createIndex: fakeCreateIndex } as IndexOperationsApi;
+
+    jest.mock('../../pinecone-generated-ts-fetch', async () => ({
       IndexOperationsApi: IOA,
     }));
-  });
 
-  test('calls the create endpoint', async () => {
-    const returned = await createIndex(IOA)({
+    const createIndexFn = createIndex(IOA);
+    const returned = await createIndexFn({
       name: 'index-name',
       dimension: 10,
     });
 
     expect(returned).toBe(void 0);
-    expect(IOA.createIndex).toHaveBeenCalled();
+    expect(IOA.createIndex).toHaveBeenCalledWith({
+      createRequest: {
+        name: 'index-name',
+        dimension: 10,
+      },
+    });
+  });
+
+  describe('waitUntilReady', () => {
+    test('when passed waitUntilReady, calls the create index endpoint and begins polling describeIndex', async () => {
+      const fakeCreateIndex: (req: CreateIndexRequest) => Promise<string> =
+        jest.fn();
+      const fakeDescribeIndex: (
+        req: DescribeIndexRequest
+      ) => Promise<IndexMeta> = jest.fn().mockImplementation(() => ({
+        status: { ready: true, state: 'Ready' },
+      }));
+
+      const IOA = {
+        createIndex: fakeCreateIndex,
+        describeIndex: fakeDescribeIndex,
+      } as IndexOperationsApi;
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        IndexOperationsApi: IOA,
+      }));
+
+      const createIndexFn = createIndex(IOA);
+      const returned = await createIndexFn({
+        name: 'index-name',
+        dimension: 10,
+        waitUntilReady: true,
+      });
+
+      expect(returned).toBe('Index is ready after 0 seconds');
+      expect(IOA.createIndex).toHaveBeenCalledWith({
+        createRequest: {
+          name: 'index-name',
+          dimension: 10,
+          waitUntilReady: true,
+        },
+      });
+      expect(IOA.describeIndex).toHaveBeenCalledWith({
+        indexName: 'index-name',
+      });
+    });
+
+    test('will continue polling describeIndex if the index is not yet ready', async () => {
+      jest.useFakeTimers();
+      const fakeCreateIndex: (req: CreateIndexRequest) => Promise<string> =
+        jest.fn();
+      const fakeDescribeIndex: (
+        req: DescribeIndexRequest
+      ) => Promise<IndexMeta> = jest
+        .fn()
+        .mockResolvedValueOnce({
+          status: { ready: false, state: 'Initializing' },
+        })
+        .mockResolvedValueOnce({
+          status: { ready: false, state: 'ScalingUp' },
+        })
+        .mockResolvedValueOnce({
+          status: { ready: false, state: 'ScalingUp' },
+        })
+        .mockResolvedValueOnce({
+          status: { ready: true, state: 'Ready' },
+        });
+
+      const IOA = {
+        createIndex: fakeCreateIndex,
+        describeIndex: fakeDescribeIndex,
+      } as IndexOperationsApi;
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        IndexOperationsApi: IOA,
+      }));
+
+      const returned = createIndex(IOA)({
+        name: 'index-name',
+        dimension: 10,
+        waitUntilReady: true,
+      });
+
+      await jest.advanceTimersByTimeAsync(3000);
+
+      return returned.then((result) => {
+        expect(result).toBe('Index is ready after 3 seconds');
+        expect(fakeDescribeIndex).toHaveBeenNthCalledWith(3, {
+          indexName: 'index-name',
+        });
+        jest.useRealTimers();
+      });
+    });
+  });
+
+  describe('http error mapping', () => {
+    test('when 500 occurs', async () => {
+      const fakeCreateIndex: (req: CreateIndexRequest) => Promise<string> = jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.reject({
+            response: { status: 500, text: () => 'backend error message' },
+          })
+        );
+
+      const IOA = { createIndex: fakeCreateIndex } as IndexOperationsApi;
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        IndexOperationsApi: IOA,
+      }));
+
+      const toThrow = async () => {
+        const createIndexFn = createIndex(IOA);
+        await createIndexFn({ name: 'index-name', dimension: 10 });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeInternalServerError);
+    });
+
+    test('when 400 occurs, displays server message', async () => {
+      const serverError = 'there has been a server error!';
+      const fakeCreateIndex: (req: CreateIndexRequest) => Promise<string> = jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.reject({
+            response: { status: 400, text: () => serverError },
+          })
+        );
+
+      const IOA = { createIndex: fakeCreateIndex } as IndexOperationsApi;
+      jest.mock('../../pinecone-generated-ts-fetch', () => ({
+        IndexOperationsApi: IOA,
+      }));
+
+      const toThrow = async () => {
+        const createIndexFn = createIndex(IOA);
+        await createIndexFn({ name: 'index-name', dimension: 10 });
+      };
+
+      await expect(toThrow).rejects.toThrow(PineconeBadRequestError);
+      await expect(toThrow).rejects.toThrow(serverError);
+    });
   });
 });

--- a/src/control/__tests__/createIndex.test.ts
+++ b/src/control/__tests__/createIndex.test.ts
@@ -26,11 +26,12 @@ const setupCreateIndexResponse = (
     );
 
   // unfold describeIndexResponse
-  const describeResponses = Array.isArray(describeIndexResponse)
+  const describeIndexResponses = Array.isArray(describeIndexResponse)
     ? describeIndexResponse
     : [describeIndexResponse];
+
   const describeIndexMock = jest.fn();
-  describeResponses.forEach((response) => {
+  describeIndexResponses.forEach((response) => {
     describeIndexMock.mockImplementationOnce(() =>
       isDescribeIndexSuccess
         ? Promise.resolve(response)

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -66,6 +66,6 @@ const waitUntilIndexIsReady = async (
       return `Index is ready after ${seconds} seconds`;
     }
   } catch (e) {
-    throw new Error('Error creating index');
+    throw new Error(`Error creating index: ${e}`);
   }
 };

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -1,5 +1,7 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
+import { debugLog } from '../utils';
+import { handleApiError } from '../errors';
 import { handleIndexRequestError } from './utils';
 import { Static, Type } from '@sinclair/typebox';
 
@@ -63,9 +65,15 @@ const waitUntilIndexIsReady = async (
       await new Promise((r) => setTimeout(r, 1000));
       return await waitUntilIndexIsReady(api, indexName, seconds + 1);
     } else {
-      return `Index is ready after ${seconds} seconds`;
+      debugLog(`Index ${indexName} is ready after ${seconds}`);
+      return;
     }
   } catch (e) {
-    throw new Error(`Error creating index: ${e}`);
+    const err = await handleApiError(
+      e,
+      async (_, rawMessageText) =>
+        `Error creating index ${indexName}: ${rawMessageText}`
+    );
+    throw err;
   }
 };

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -1,7 +1,6 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
 import { handleIndexRequestError } from './utils';
-
 import { Static, Type } from '@sinclair/typebox';
 
 const nonemptyString = Type.String({ minLength: 1 });
@@ -24,6 +23,7 @@ const CreateIndexOptionsSchema = Type.Object(
       )
     ),
     sourceCollection: Type.Optional(nonemptyString),
+    waitUntilReady: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false }
 );
@@ -36,15 +36,36 @@ export const createIndex = (api: IndexOperationsApi) => {
     'createIndex'
   );
 
-  return async (options: CreateIndexOptions): Promise<void> => {
+  return async (options: CreateIndexOptions): Promise<string | void> => {
     validator(options);
 
     try {
       await api.createIndex({ createRequest: options });
+      if (options.waitUntilReady) {
+        return await waitUntilIndexIsReady(api, options.name);
+      }
       return;
     } catch (e) {
       const err = await handleIndexRequestError(e, api, options.name);
       throw err;
     }
   };
+};
+
+const waitUntilIndexIsReady = async (
+  api: IndexOperationsApi,
+  indexName: string,
+  seconds: number = 0
+) => {
+  try {
+    const indexDescription = await api.describeIndex({ indexName });
+    if (!indexDescription.status?.ready) {
+      await new Promise((r) => setTimeout(r, 1000));
+      return await waitUntilIndexIsReady(api, indexName, seconds + 1);
+    } else {
+      return `Index is ready after ${seconds} seconds`;
+    }
+  } catch (e) {
+    throw new Error('Error creating index');
+  }
 };

--- a/src/utils/__tests__/debugLog.test.ts
+++ b/src/utils/__tests__/debugLog.test.ts
@@ -1,0 +1,22 @@
+import { debugLog } from '../debugLog';
+
+describe('debugLog', () => {
+  let consoleLogSpy;
+  beforeEach(() => {
+    consoleLogSpy = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => jest.fn());
+  });
+
+  test('logs when PINECONE_DEBUG is true', () => {
+    process.env.PINECONE_DEBUG = 'true';
+    debugLog('There was an error!');
+    expect(consoleLogSpy).toHaveBeenCalledWith('There was an error!');
+  });
+
+  test('does not log when PINECONE_DEBUG is false', () => {
+    delete process.env.PINECONE_DEBUG;
+    debugLog('There was an error!');
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/queryParamsStringify.test.ts
+++ b/src/utils/__tests__/queryParamsStringify.test.ts
@@ -1,4 +1,4 @@
-import { queryParamsStringify } from './queryParamsStringify';
+import { queryParamsStringify } from '../queryParamsStringify';
 
 describe('queryParamsStringify', () => {
   test('should stringify array params correctly', () => {

--- a/src/utils/debugLog.ts
+++ b/src/utils/debugLog.ts
@@ -1,0 +1,5 @@
+export const debugLog = (str: string) => {
+  if (process && process.env && process.env.PINECONE_DEBUG) {
+    console.log(str);
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
+import { debugLog } from './debugLog';
 import { queryParamsStringify } from './queryParamsStringify';
 import { buildUserAgent } from './user-agent';
 
-export { queryParamsStringify, buildUserAgent };
+export { debugLog, queryParamsStringify, buildUserAgent };


### PR DESCRIPTION
## Problem
Creating a new index is an asynchronous operation on the backend. When calling `client.createIndex({ ... })` the operation to trigger creating the index occurs nearly immediately, but the index will not actually be ready for some amount of time after the creation call returns (somewhere between 10-13 seconds average currently).

v0 offered a utility function `waitUntilIndexIsReady` which allowed an async call leveraging polling `describeIndex()`.

## Solution
- Add a new `waitUntilReady` option to `createIndex()` allowing the user to opt for returning an async function that polls `describeIndex()` until the index is ready.
- Add a new `waitUntilIndexIsReady()` function in `/createIndex.ts` to handle polling `describeIndex()` if desired. Originally I was going to put the function in `/utils` but it felt specific enough to creating the index that it made more sense living here for now.
- Update `createIndex.test.ts`
   - Added some error case tests for the basic functionality.
   - Added tests to run through the asynchronous logic of `waitUntilIndexIsReady()`.
   - Upgraded `@types/jest` as there was some functionality in Jest 29.5.0 that wasn't represented. Did a lot of troubleshooting around jest and mocking timers while working on tests for this, they had [exposed a bunch of new functions recently for working with fake timers](https://github.com/jestjs/jest/pull/13981) and autocomplete lead me astray. 😭 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Validate that passing `waitUntilReady: true` to `createIndex()` await the creation of the index on the backend.

```
$ npm run repl

$ await init()

// Wait until index is ready
$ await client.createIndex({ name: 'test-create-1', dimension: 5, waitUntilReady: true })
'Index is ready after 13 seconds'

// Test the basic scenario of returning as soon as the create call completes
$ await client.createIndex({ name: 'test-create-2', dimension: 5 })
undefined
```

