### PR TITLE
[v1] List operations return objects instead of strings

### DIFF
--- a/src/control/__tests__/listCollections.test.ts
+++ b/src/control/__tests__/listCollections.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../errors';
 
 describe('listCollections', () => {
-  test('should return a list of collections', async () => {
+  test('should return a list of collection objects', async () => {
     const IOA = {
       listCollections: jest
         .fn()
@@ -17,7 +17,10 @@ describe('listCollections', () => {
     // @ts-ignore
     const returned = await listCollections(IOA)();
 
-    expect(returned).toEqual(['collection-name', 'collection-name-2']);
+    expect(returned).toEqual([
+      { name: 'collection-name' },
+      { name: 'collection-name-2' },
+    ]);
   });
 
   test('it should map errors with the http error mapper (500)', async () => {

--- a/src/control/__tests__/listIndexes.test.ts
+++ b/src/control/__tests__/listIndexes.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../errors';
 
 describe('listIndexes', () => {
-  test('should return a list of indexes', async () => {
+  test('should return a list of index objects', async () => {
     const IndexOperationsApi = {
       listIndexes: jest
         .fn()
@@ -17,7 +17,10 @@ describe('listIndexes', () => {
     // @ts-ignore
     const returned = await listIndexes(IndexOperationsApi)();
 
-    expect(returned).toEqual(['index-name', 'index-name-2']);
+    expect(returned).toEqual([
+      { name: 'index-name' },
+      { name: 'index-name-2' },
+    ]);
   });
 
   test('it should map errors with the http error mapper (500)', async () => {

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -7,7 +7,7 @@ export { listIndexes } from './listIndexes';
 
 export type { ConfigureIndexOptions } from './configureIndex';
 export type { CreateIndexOptions } from './createIndex';
-export type { IndexList } from './listIndexes';
+export type { IndexList, IndexNameObj } from './listIndexes';
 export type { IndexName } from './describeIndex';
 
 // Collection Operations
@@ -16,4 +16,4 @@ export { deleteCollection } from './deleteCollection';
 export { describeCollection } from './describeCollection';
 export { listCollections } from './listCollections';
 
-export type { CollectionList, CollectionName } from './listCollections';
+export type { CollectionList, CollectionNameObj } from './listCollections';

--- a/src/control/listCollections.ts
+++ b/src/control/listCollections.ts
@@ -1,13 +1,22 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { handleApiError } from '../errors';
 
-export type CollectionName = string;
-export type CollectionList = CollectionName[];
+export type CollectionNameObj = {
+  name: string;
+};
+export type CollectionList = CollectionNameObj[];
 
 export const listCollections = (api: IndexOperationsApi) => {
   return async (): Promise<CollectionList> => {
     try {
-      return await api.listCollections();
+      const results = await api.listCollections();
+
+      // We know in a future version of the API that listing
+      // collections should return more information than just the
+      // collection names. Mapping these results into an object
+      // will allow us us to add more information in the future
+      // in a non-breaking way.
+      return results.map((c) => ({ name: c }));
     } catch (e) {
       const err = await handleApiError(e);
       throw err;

--- a/src/control/listIndexes.ts
+++ b/src/control/listIndexes.ts
@@ -1,13 +1,22 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { handleApiError } from '../errors';
 
-type IndexName = string;
-export type IndexList = IndexName[];
+export type IndexNameObj = {
+  name: string;
+};
+export type IndexList = Array<IndexNameObj>;
 
 export const listIndexes = (api: IndexOperationsApi) => {
   return async (): Promise<IndexList> => {
     try {
-      return await api.listIndexes();
+      const names = await api.listIndexes();
+
+      // We know in a future version of the API that listing
+      // indexes should return more information than just the
+      // index names. Mapping these results into an object
+      // will allow us us to add more information in the future
+      // in a non-breaking way.
+      return names.map((n) => ({ name: n }));
     } catch (e) {
       const err = await handleApiError(e);
       throw err;


### PR DESCRIPTION
## Problem

The `listIndex` and `listCollection` operations currently return arrays of strings. This makes it impossible to add additional information from future versions of the API without it being a breaking change.

## Solution

Map string responses into object responses. By returning objects, we can add in additional properties in the future without it being a breaking change.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Plan

Updated unit tests.

`npm run repl`

```node
> const pinecone = new Pinecone()
undefined
> await pinecone.listIndexes()
[
  { name: 'delete-me' },
  { name: 'from-collection' },
  { name: 'jen2' },
  { name: 'jen3' }
]
> await pinecone.listCollections()
[
  { name: 'collection3' },
  { name: 'collection1' },
  { name: 'collection-from-jen3' }
]
```