### PR TITLE
[v1] Implement typescript generics for metadata

### DIFF
--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -149,11 +149,11 @@ describe('Pinecone', () => {
         },
       ]);
 
-      // @ts-expect-error becuase 'pink' not a valid value for ProductMeta color field
       await i.upsert([
         {
           id: 'pink-shirt',
           values: [0.1, 0.1, 0.1],
+          // @ts-expect-error becuase 'pink' not a valid value for ProductMeta color field
           metadata: { color: 'pink', description: 'pink shirt' },
         },
       ]);

--- a/src/data/__tests__/index.test.ts
+++ b/src/data/__tests__/index.test.ts
@@ -1,0 +1,80 @@
+import { UpsertCommand } from '../upsert';
+import { FetchCommand } from '../fetch';
+import { Index } from '../index';
+
+jest.mock('../upsert');
+jest.mock('../fetch');
+
+describe('Index', () => {
+  let config;
+
+  beforeEach(() => {
+    config = {
+      apiKey: 'test-api-key',
+      environment: 'test-environment',
+    };
+  });
+
+  test('upsert: has type errors when passing malformed metadata', async () => {
+    type MovieMetadata = {
+      genre: string;
+      runtime: number;
+    };
+    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+    expect(UpsertCommand).toHaveBeenCalledTimes(1);
+
+    // No ts errors when upserting with propert MovieMetadata
+    await index.upsert([
+      {
+        id: '1',
+        values: [0.1, 0.1, 0.1],
+        metadata: {
+          genre: 'romance',
+          runtime: 120,
+        },
+      },
+    ]);
+
+    // No ts errors when upserting with no metadata
+    await index.upsert([
+      {
+        id: '2',
+        values: [0.1, 0.1, 0.1],
+      },
+    ]);
+
+    // ts error expected when passing metadata that doesn't match MovieMetadata
+    await index.upsert([
+      {
+        id: '3',
+        values: [0.1, 0.1, 0.1],
+        metadata: {
+          // @ts-expect-error
+          somethingElse: 'foo',
+        },
+      },
+    ]);
+  });
+
+  test('fetch: response is typed with generic metadata type', async () => {
+    type MovieMetadata = {
+      genre: string;
+      runtime: number;
+    };
+    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+    expect(FetchCommand).toHaveBeenCalledTimes(1);
+
+    const response = await index.fetch(['1']);
+    if (response && response.vectors) {
+      // eslint-disable-next-line
+      Object.entries(response.vectors).forEach(([key, value]) => {
+        // No errors on these because they are properties from MovieMetadata
+        console.log(value.metadata?.genre);
+        console.log(value.metadata?.runtime);
+
+        // @ts-expect-error because result is expecting metadata to be MovieMetadata
+        console.log(value.metadata?.bogus);
+      });
+    }
+  });
+});

--- a/src/data/__tests__/index.test.ts
+++ b/src/data/__tests__/index.test.ts
@@ -1,14 +1,21 @@
-import { UpsertCommand } from '../upsert';
 import { FetchCommand } from '../fetch';
 import { QueryCommand } from '../query';
+import { UpdateCommand } from '../update';
+import { UpsertCommand } from '../upsert';
 import { Index } from '../index';
 
-jest.mock('../upsert');
 jest.mock('../fetch');
 jest.mock('../query');
+jest.mock('../update');
+jest.mock('../upsert');
 
 describe('Index', () => {
   let config;
+
+  type MovieMetadata = {
+    genre: string;
+    runtime: number;
+  };
 
   beforeEach(() => {
     config = {
@@ -17,15 +24,36 @@ describe('Index', () => {
     };
   });
 
+  test('can be used without generic types param', async () => {
+    const index = new Index('index-name', config, 'namespace');
+
+    // You can use the index class without passing the generic type for metadata,
+    // but you lose type safety in that case.
+    await index.update({ id: '1', metadata: { foo: 'bar' } });
+    await index.update({ id: '1', metadata: { baz: 'quux' } });
+
+    // Same thing with upsert. You can upsert anything in metadata field without type.
+    await index.upsert([
+      { id: '2', values: [0.1, 0.2], metadata: { hello: 'world' } },
+    ]);
+
+    // @ts-expect-error even when you haven't passed a generic type, it enforces the expected shape of Record<string, RecordMetadataValue>
+    await index.upsert([{ id: '2', values: [0.1, 0.2], metadata: 2 }]);
+  });
+
+  test('preserves metadata typing through chained namespace calls', async () => {
+    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+    const ns1 = index.namespace('ns1');
+
+    // @ts-expect-error because MovieMetadata metadata still expected after chained namespace call
+    await ns1.update({ id: '1', metadata: { title: 'Vertigo', rating: 5 } });
+  });
+
   test('upsert: has type errors when passing malformed metadata', async () => {
-    type MovieMetadata = {
-      genre: string;
-      runtime: number;
-    };
     const index = new Index<MovieMetadata>('index-name', config, 'namespace');
     expect(UpsertCommand).toHaveBeenCalledTimes(1);
 
-    // No ts errors when upserting with propert MovieMetadata
+    // No ts errors when upserting with proper MovieMetadata
     await index.upsert([
       {
         id: '1',
@@ -59,10 +87,6 @@ describe('Index', () => {
   });
 
   test('fetch: response is typed with generic metadata type', async () => {
-    type MovieMetadata = {
-      genre: string;
-      runtime: number;
-    };
     const index = new Index<MovieMetadata>('index-name', config, 'namespace');
     expect(FetchCommand).toHaveBeenCalledTimes(1);
 
@@ -81,10 +105,6 @@ describe('Index', () => {
   });
 
   test('query: returns typed results', async () => {
-    type MovieMetadata = {
-      genre: string;
-      runtime: number;
-    };
     const index = new Index<MovieMetadata>('index-name', config, 'namespace');
     expect(QueryCommand).toHaveBeenCalledTimes(1);
 
@@ -104,5 +124,45 @@ describe('Index', () => {
         console.log(firstResult.metadata?.bogus);
       }
     }
+  });
+
+  test('update: has typed arguments', async () => {
+    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+    expect(UpdateCommand).toHaveBeenCalledTimes(1);
+
+    // Can update metadata only without ts errors
+    await index.update({
+      id: '1',
+      metadata: { genre: 'romance', runtime: 90 },
+    });
+
+    // Can update values only without ts errors
+    await index.update({ id: '2', values: [0.1, 0.2, 0.3] });
+
+    // Can update sparseValues only without ts errors
+    await index.update({
+      id: '3',
+      sparseValues: { indices: [0, 3], values: [0.2, 0.5] },
+    });
+
+    // Can update all fields without ts errors
+    await index.update({
+      id: '4',
+      values: [0.1, 0.2, 0.3],
+      sparseValues: { indices: [0], values: [0.789] },
+      metadata: { genre: 'horror', runtime: 10 },
+    });
+
+    // @ts-expect-error when id is missing
+    await index.update({ metadata: { genre: 'drama', runtime: 97 } });
+
+    // @ts-expect-error when metadata has unexpected fields
+    await index.update({ id: '5', metadata: { title: 'Vertigo' } });
+
+    await index.update({
+      id: '6',
+      // @ts-expect-error when metadata has extra properties
+      metadata: { genre: 'comedy', runtime: 80, title: 'Miss Congeniality' },
+    });
   });
 });

--- a/src/data/__tests__/update.test.ts
+++ b/src/data/__tests__/update.test.ts
@@ -15,7 +15,7 @@ const setupResponse = (response, isSuccess) => {
     );
   const VOA = { update: fakeUpdate } as VectorOperationsApi;
   const VoaProvider = { provide: async () => VOA } as VectorOperationsProvider;
-  const cmd = new UpdateCommand(VoaProvider, 'namespace')
+  const cmd = new UpdateCommand(VoaProvider, 'namespace');
   return { fakeUpdate, VOA, VoaProvider, cmd };
 };
 const setupSuccess = (response) => {
@@ -62,8 +62,7 @@ describe('update', () => {
       });
 
       const toThrow = async () => {
-        // @ts-expect-error
-        await cmd.run({ id: 'fake-vector' });
+        await cmd.run({ id: 'fake-vector', values: [0.1, 0.2, 0.3] });
       };
 
       await expect(toThrow).rejects.toThrow(PineconeInternalServerError);
@@ -76,8 +75,7 @@ describe('update', () => {
       });
 
       const toThrow = async () => {
-        // @ts-expect-error 
-        await cmd.run({ id: 'fake-vector' });
+        await cmd.run({ id: 'fake-vector', values: [0.1, 0.2, 0.3] });
       };
 
       await expect(toThrow).rejects.toThrow(PineconeBadRequestError);

--- a/src/data/__tests__/upsert.test.ts
+++ b/src/data/__tests__/upsert.test.ts
@@ -3,7 +3,10 @@ import {
   PineconeBadRequestError,
   PineconeInternalServerError,
 } from '../../errors';
-import { VectorOperationsApi, type UpsertOperationRequest } from '../../pinecone-generated-ts-fetch';
+import {
+  VectorOperationsApi,
+  type UpsertOperationRequest,
+} from '../../pinecone-generated-ts-fetch';
 import { VectorOperationsProvider } from '../vectorOperationsProvider';
 
 const setupResponse = (response, isSuccess) => {
@@ -45,7 +48,7 @@ describe('upsert', () => {
       },
     });
   });
-  
+
   describe('http error mapping', () => {
     test('when 500 occurs', async () => {
       const { cmd } = setupFailure({

--- a/src/data/fetch.ts
+++ b/src/data/fetch.ts
@@ -2,18 +2,18 @@ import { handleApiError } from '../errors';
 import { buildConfigValidator } from '../validator';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 import { RecordIdSchema } from './types';
-import type { PineconeRecord, RecordId } from './types';
+import type { PineconeRecord, RecordId, RecordMetadataValue } from './types';
 import { Type } from '@sinclair/typebox';
 
 const RecordIdsArray = Type.Array(RecordIdSchema, { minItems: 1 });
 export type FetchOptions = Array<RecordId>;
 
-export type FetchResponse<T> = {
+export type FetchResponse<T extends Record<string, RecordMetadataValue>> = {
   vectors?: { [key: string]: PineconeRecord<T> };
   namespace?: string;
 };
 
-export class FetchCommand<T> {
+export class FetchCommand<T extends Record<string, RecordMetadataValue>> {
   apiProvider: VectorOperationsProvider;
   namespace: string;
   validator: ReturnType<typeof buildConfigValidator>;

--- a/src/data/fetch.ts
+++ b/src/data/fetch.ts
@@ -1,30 +1,43 @@
-import type { FetchResponse as GeneratedFetchResponse } from '../pinecone-generated-ts-fetch';
 import { handleApiError } from '../errors';
 import { buildConfigValidator } from '../validator';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
-import { RecordIdSchema, type RecordId } from './types';
+import { RecordIdSchema } from './types';
+import type { PineconeRecord, RecordId } from './types';
 import { Type } from '@sinclair/typebox';
 
 const RecordIdsArray = Type.Array(RecordIdSchema, { minItems: 1 });
 export type FetchOptions = Array<RecordId>;
 
-export type FetchResponse = GeneratedFetchResponse;
+export type FetchResponse<T> = {
+  vectors?: { [key: string]: PineconeRecord<T> };
+  namespace?: string;
+};
 
-export const fetch = (
-  apiProvider: VectorOperationsProvider,
-  namespace: string
-) => {
-  const validator = buildConfigValidator(RecordIdsArray, 'fetch');
+export class FetchCommand<T> {
+  apiProvider: VectorOperationsProvider;
+  namespace: string;
+  validator: ReturnType<typeof buildConfigValidator>;
 
-  return async (ids: FetchOptions): Promise<FetchResponse> => {
-    validator(ids);
+  constructor(apiProvider, namespace) {
+    this.apiProvider = apiProvider;
+    this.namespace = namespace;
+    this.validator = buildConfigValidator(RecordIdsArray, 'fetch');
+  }
+
+  async run(ids: FetchOptions): Promise<FetchResponse<T>> {
+    this.validator(ids);
 
     try {
-      const api = await apiProvider.provide();
-      return await api.fetch({ ids: ids, namespace });
+      const api = await this.apiProvider.provide();
+      const response = await api.fetch({ ids: ids, namespace: this.namespace });
+
+      return {
+        vectors: response.vectors,
+        namespace: response.namespace,
+      } as FetchResponse<T>;
     } catch (e) {
       const err = await handleApiError(e);
       throw err;
     }
-  };
-};
+  }
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,5 +1,5 @@
 import { UpsertCommand } from './upsert';
-import { FetchCommand } from './fetch';
+import { FetchCommand, type FetchOptions } from './fetch';
 import { update } from './update';
 import { query } from './query';
 import { deleteOne } from './deleteOne';
@@ -7,14 +7,15 @@ import { deleteMany } from './deleteMany';
 import { deleteAll } from './deleteAll';
 import { describeIndexStats } from './describeIndexStats';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
-import type { PineconeConfiguration } from './types';
+import type { PineconeConfiguration, PineconeRecord, RecordMetadataValue } from './types';
 
 export type {
   PineconeConfiguration,
   PineconeRecord,
   RecordId,
-  SparseValues,
-  Values,
+  RecordSparseValues,
+  RecordValues,
+  RecordMetadataValue
 } from './types';
 export { PineconeConfigurationSchema } from './types';
 export type { DeleteManyOptions } from './deleteMany';
@@ -26,7 +27,6 @@ export type {
 } from './describeIndexStats';
 export type { FetchOptions, FetchResponse } from './fetch';
 export type { UpdateOptions } from './update';
-export type { UpsertOptions } from './upsert';
 export type {
   QueryByRecordId,
   QueryByVectorValues,
@@ -34,7 +34,7 @@ export type {
   QueryResponse,
 } from './query';
 
-export class Index<T> {
+export class Index<T extends Record<string, RecordMetadataValue>> {
   private config: PineconeConfiguration;
   private target: {
     index: string;
@@ -47,6 +47,9 @@ export class Index<T> {
   describeIndexStats: ReturnType<typeof describeIndexStats>;
   query: ReturnType<typeof query>;
   update: ReturnType<typeof update>;
+
+  private fetchCommand: FetchCommand<T>;
+  private upsertCommand: UpsertCommand<T>;
 
   constructor(
     indexName: string,

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,6 +1,6 @@
 import { UpsertCommand } from './upsert';
 import { FetchCommand, type FetchOptions } from './fetch';
-import { update } from './update';
+import { UpdateCommand, type UpdateOptions } from './update';
 import { QueryCommand, type QueryOptions } from './query';
 import { deleteOne } from './deleteOne';
 import { deleteMany } from './deleteMany';
@@ -49,11 +49,11 @@ export class Index<T extends Record<string, RecordMetadataValue>> {
   deleteMany: ReturnType<typeof deleteMany>;
   deleteOne: ReturnType<typeof deleteOne>;
   describeIndexStats: ReturnType<typeof describeIndexStats>;
-  update: ReturnType<typeof update>;
 
-  private fetchCommand: FetchCommand<T>;
-  private queryCommand: QueryCommand<T>;
-  private upsertCommand: UpsertCommand<T>;
+  private _fetchCommand: FetchCommand<T>;
+  private _queryCommand: QueryCommand<T>;
+  private _updateCommand: UpdateCommand<T>;
+  private _upsertCommand: UpsertCommand<T>;
 
   constructor(
     indexName: string,
@@ -72,11 +72,11 @@ export class Index<T extends Record<string, RecordMetadataValue>> {
     this.deleteMany = deleteMany(apiProvider, namespace);
     this.deleteOne = deleteOne(apiProvider, namespace);
     this.describeIndexStats = describeIndexStats(apiProvider);
-    this.update = update(apiProvider, namespace);
 
-    this.fetchCommand = new FetchCommand<T>(apiProvider, namespace);
-    this.upsertCommand = new UpsertCommand<T>(apiProvider, namespace);
-    this.queryCommand = new QueryCommand<T>(apiProvider, namespace);
+    this._fetchCommand = new FetchCommand<T>(apiProvider, namespace);
+    this._queryCommand = new QueryCommand<T>(apiProvider, namespace);
+    this._updateCommand = new UpdateCommand<T>(apiProvider, namespace);
+    this._upsertCommand = new UpsertCommand<T>(apiProvider, namespace);
   }
 
   namespace(namespace: string): Index<T> {
@@ -84,14 +84,18 @@ export class Index<T extends Record<string, RecordMetadataValue>> {
   }
 
   async upsert(data: Array<PineconeRecord<T>>) {
-    return await this.upsertCommand.run(data);
+    return await this._upsertCommand.run(data);
   }
 
   async fetch(options: FetchOptions) {
-    return await this.fetchCommand.run(options);
+    return await this._fetchCommand.run(options);
   }
 
   async query(options: QueryOptions) {
-    return await this.queryCommand.run(options);
+    return await this._queryCommand.run(options);
+  }
+
+  async update(options: UpdateOptions<T>) {
+    return await this._updateCommand.run(options);
   }
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,13 +1,17 @@
 import { UpsertCommand } from './upsert';
 import { FetchCommand, type FetchOptions } from './fetch';
 import { update } from './update';
-import { query } from './query';
+import { QueryCommand, type QueryOptions } from './query';
 import { deleteOne } from './deleteOne';
 import { deleteMany } from './deleteMany';
 import { deleteAll } from './deleteAll';
 import { describeIndexStats } from './describeIndexStats';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
-import type { PineconeConfiguration, PineconeRecord, RecordMetadataValue } from './types';
+import type {
+  PineconeConfiguration,
+  PineconeRecord,
+  RecordMetadataValue,
+} from './types';
 
 export type {
   PineconeConfiguration,
@@ -15,7 +19,7 @@ export type {
   RecordId,
   RecordSparseValues,
   RecordValues,
-  RecordMetadataValue
+  RecordMetadataValue,
 } from './types';
 export { PineconeConfigurationSchema } from './types';
 export type { DeleteManyOptions } from './deleteMany';
@@ -45,10 +49,10 @@ export class Index<T extends Record<string, RecordMetadataValue>> {
   deleteMany: ReturnType<typeof deleteMany>;
   deleteOne: ReturnType<typeof deleteOne>;
   describeIndexStats: ReturnType<typeof describeIndexStats>;
-  query: ReturnType<typeof query>;
   update: ReturnType<typeof update>;
 
   private fetchCommand: FetchCommand<T>;
+  private queryCommand: QueryCommand<T>;
   private upsertCommand: UpsertCommand<T>;
 
   constructor(
@@ -69,10 +73,10 @@ export class Index<T extends Record<string, RecordMetadataValue>> {
     this.deleteOne = deleteOne(apiProvider, namespace);
     this.describeIndexStats = describeIndexStats(apiProvider);
     this.update = update(apiProvider, namespace);
-    this.query = query(apiProvider, namespace);
 
     this.fetchCommand = new FetchCommand<T>(apiProvider, namespace);
     this.upsertCommand = new UpsertCommand<T>(apiProvider, namespace);
+    this.queryCommand = new QueryCommand<T>(apiProvider, namespace);
   }
 
   namespace(namespace: string): Index<T> {
@@ -85,5 +89,9 @@ export class Index<T extends Record<string, RecordMetadataValue>> {
 
   async fetch(options: FetchOptions) {
     return await this.fetchCommand.run(options);
+  }
+
+  async query(options: QueryOptions) {
+    return await this.queryCommand.run(options);
   }
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -32,7 +32,7 @@ export const PineconeRecordSchema = Type.Object(
 export type RecordId = Static<typeof RecordIdSchema>;
 export type RecordValues = Static<typeof RecordValuesSchema>;
 export type RecordSparseValues = Static<typeof RecordSparseValuesSchema>;
-export type RecordMetadataValue = string | boolean | number | Array<string>
+export type RecordMetadataValue = string | boolean | number | Array<string>;
 export type PineconeRecord<T extends Record<string, RecordMetadataValue>> = {
   id: RecordId;
   values: RecordValues;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -30,6 +30,12 @@ export const PineconeRecordSchema = Type.Object(
 );
 
 export type RecordId = Static<typeof RecordIdSchema>;
-export type Values = Static<typeof RecordValuesSchema>;
-export type SparseValues = Static<typeof RecordSparseValuesSchema>;
-export type PineconeRecord = Static<typeof PineconeRecordSchema>;
+export type RecordValues = Static<typeof RecordValuesSchema>;
+export type RecordSparseValues = Static<typeof RecordSparseValuesSchema>;
+export type RecordMetadataValue = string | boolean | number | Array<string>
+export type PineconeRecord<T extends Record<string, RecordMetadataValue>> = {
+  id: RecordId;
+  values: RecordValues;
+  sparseValues?: RecordSparseValues;
+  metadata?: T;
+};

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -6,8 +6,10 @@ import {
   RecordIdSchema,
   RecordValuesSchema,
   RecordSparseValuesSchema,
-  type PineconeRecord,
-  type RecordMetadataValue
+  type RecordId,
+  type RecordValues,
+  type RecordSparseValues,
+  type RecordMetadataValue,
 } from './types';
 
 const UpdateRecordOptionsSchema = Type.Object(
@@ -20,7 +22,15 @@ const UpdateRecordOptionsSchema = Type.Object(
   { additionalProperties: false }
 );
 
-export interface UpdateOptions<T extends Record<string, RecordMetadataValue>> extends PineconeRecord<T> {};
+// This is very similar to PineconeRecord, but differs because values field
+// is optional here. E.g. perhaps the caller only wants to update metadata
+// for a given record.
+export type UpdateOptions<T extends Record<string, RecordMetadataValue>> = {
+  id: RecordId;
+  values?: RecordValues;
+  sparseValues?: RecordSparseValues;
+  metadata?: T;
+};
 
 export class UpdateCommand<T extends Record<string, RecordMetadataValue>> {
   apiProvider: VectorOperationsProvider;
@@ -45,11 +55,13 @@ export class UpdateCommand<T extends Record<string, RecordMetadataValue>> {
 
     try {
       const api = await this.apiProvider.provide();
-      await api.update({ updateRequest: { ...requestOptions, namespace: this.namespace } });
+      await api.update({
+        updateRequest: { ...requestOptions, namespace: this.namespace },
+      });
       return;
     } catch (e) {
       const err = await handleApiError(e);
       throw err;
     }
-  };
+  }
 }

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -4,10 +4,11 @@ import { PineconeRecordSchema, type PineconeRecord } from './types';
 import { Type } from '@sinclair/typebox';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 import type { Vector } from '../pinecone-generated-ts-fetch';
+import type { RecordMetadataValue } from './types';
 
 const RecordArray = Type.Array(PineconeRecordSchema);
 
-export class UpsertCommand<T> {
+export class UpsertCommand<T extends Record<string, RecordMetadataValue>> {
   apiProvider: VectorOperationsProvider;
   namespace: string;
   validator: ReturnType<typeof buildConfigValidator>;
@@ -21,9 +22,6 @@ export class UpsertCommand<T> {
   async run(records: Array<PineconeRecord<T>>): Promise<void> {
     this.validator(records);
 
-    const isBatchUpsert = !Array.isArray(options);
-
-    let api;
     try {
       const api = await this.apiProvider.provide();
       await api.upsert({

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,26 +20,6 @@ export type {
   PartialCollectionDescription,
 } from './control';
 export type {
-  ConfigureIndexOptions,
-  CreateIndexOptions,
-  DeleteIndexOptions,
-  DescribeIndexOptions,
-  IndexDescription,
-  IndexList,
-  PartialIndexDescription,
-  CreateCollectionOptions,
-  DeleteCollectionOptions,
-  DescribeCollectionOptions,
-  CollectionDescription,
-  CollectionList,
-  PartialCollectionDescription,
-} from './control';
-export type {
-  PineconeConfiguration,
-  PineconeRecord,
-  RecordId,
-  Values,
-  SparseValues,
   DeleteManyOptions,
   DeleteOneOptions,
   DescribeIndexStatsOptions,
@@ -56,8 +36,9 @@ export type {
   QueryOptions,
   QueryResponse,
   RecordId,
-  SparseValues,
-  Values,
+  RecordMetadataValue,
+  RecordSparseValues,
+  RecordValues,
 } from './data';
 
 // Legacy exports for backwards compatibility

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,26 @@ export type {
   PartialCollectionDescription,
 } from './control';
 export type {
+  ConfigureIndexOptions,
+  CreateIndexOptions,
+  DeleteIndexOptions,
+  DescribeIndexOptions,
+  IndexDescription,
+  IndexList,
+  PartialIndexDescription,
+  CreateCollectionOptions,
+  DeleteCollectionOptions,
+  DescribeCollectionOptions,
+  CollectionDescription,
+  CollectionList,
+  PartialCollectionDescription,
+} from './control';
+export type {
+  PineconeConfiguration,
+  PineconeRecord,
+  RecordId,
+  Values,
+  SparseValues,
   DeleteManyOptions,
   DeleteOneOptions,
   DescribeIndexStatsOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ export type {
   PineconeConfiguration,
   PineconeRecord,
   UpdateOptions,
-  UpsertOptions,
   QueryByRecordId,
   QueryByVectorValues,
   QueryOptions,

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -18,7 +18,7 @@ import {
   PineconeConfigurationError,
   PineconeEnvironmentVarsNotSupportedError,
 } from './errors';
-import { Index } from './data';
+import { Index, type RecordMetadataValue } from './data';
 import { buildValidator } from './validator';
 import { queryParamsStringify, buildUserAgent } from './utils';
 import {
@@ -325,13 +325,13 @@ export class Pinecone {
     return this.config;
   }
 
-  index(indexName: string) {
-    return new Index(indexName, this.config);
+  index<T extends Record<string, RecordMetadataValue>>(indexName: string) {
+    return new Index<T>(indexName, this.config);
   }
 
   // Alias method to match the Python SDK capitalization
-  Index(indexName: string) {
-    return this.index(indexName);
+  Index<T extends Record<string, RecordMetadataValue>>(indexName: string) {
+    return this.index<T>(indexName);
   }
 
   __curlStarter() {


### PR DESCRIPTION
## Problem

Even with exported typescript types, results from the pinecone client have to be cast by the caller because the metadata property is a flexible data field and is currently untyped. We should allow the caller to tell us what type to expect so they don't have to be repeatedly casting as they work with this data.

## Solution

I have converted the `upsert` and `fetch` actions to a new class-based implementation that allows us to handle the generic Metadata type. The functional changes are minimal (just shuffling around existing logic), but using a class here instead of a high-order-function let me coax typescript generics into doing what I want.

Data returned should be unchanged, but the typescript compiler should understand what data is expected by `upsert` and returned by `fetch` due to the `MovieMetadata` type getting passed by the caller.

```typescript
const pinecone = new Pinecone()

type MovieMetadata = {
  title: string,
  genre: string,
  runtime: number
}

// This is the main usage change. You now pass your expected metadata type 
// as a generic type param.
const index = pinecone.index<MovieMetadata>('movie-embeddings')

const response = index.fetch(['1234'])
const movieRecord = response.vectors['1234']
if (movieRecord && movieRecord.metadata) {
  // Benefit 1: typescript should no longer require any casting to interact with this metadata
  console.log(movieRecord.metadata.genre)
}

// Benefit 2: if you pass the wrong metadata into upsert you should now get typescript feedback
await index.upsert([{ 
  id: '2345', 
  values: [0.2, 0.3, 0.4], 
  metadata: { description: 'this prop not in MovieMetadata' } // should be ts error
}])
```

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Plan

I added unit tests for the typescript errors under `src/data/__tests__/index.test.ts`

Also did more manual testing to confirm upsert and fetch still functional.

## Actions

Eventually we should have all the actions using the same pattern, but on the data plane we only __have__ to do it for those actions which involve metadata in either the method params or in the returned data. That means these are the must-dos:

- [x] upsert
- [x] fetch
- [x] query
- [x] update

For now we don't need to worry about these because they don't input or output metadata:
- deleteOne
- deleteMany
- deleteAll
- describeIndexStats