### PR TITLE
[v1] Adjust configureIndex types and fix pre-existing lint warnings

### DIFF
--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -52,7 +52,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The second argument to configureIndex should not be empty object. Please specify at least one property to update.'
+        'The second argument to configureIndex should not be empty object. Please specify at least one propert (replicas, podType) to update.'
       );
     });
 

--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -52,7 +52,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        'The second argument to configureIndex accepts multiple types. Either 1) must have required property: replicas. 2) must have required property: podType.'
+        'The second argument to configureIndex should not be empty object. Please specify at least one property to update.'
       );
     });
 
@@ -62,7 +62,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex accepts multiple types. Either 1) had type errors: property 'replicas' must be integer. 2) must have required property: podType."
+        "The second argument to configureIndex had type errors: property 'replicas' must be integer."
       );
     });
 
@@ -72,7 +72,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex accepts multiple types. Either 1) must have required property: replicas. There were also validation errors: argument must NOT have additional properties. 2) had type errors: property 'podType' must be string."
+        "The second argument to configureIndex had type errors: property 'podType' must be string."
       );
     });
 
@@ -82,7 +82,7 @@ describe('configureIndex argument validations', () => {
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex accepts multiple types. Either 1) had validation errors: property 'replicas' must be >= 1. 2) must have required property: podType."
+        "The second argument to configureIndex had validation errors: property 'replicas' must be >= 1."
       );
     });
   });

--- a/src/control/configureIndex.ts
+++ b/src/control/configureIndex.ts
@@ -1,4 +1,5 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
+import { PineconeArgumentError } from '../errors';
 import { buildValidator } from '../validator';
 import type { IndexName } from './types';
 import { handleIndexRequestError } from './utils';
@@ -6,10 +7,13 @@ import { handleIndexRequestError } from './utils';
 import { Static, Type } from '@sinclair/typebox';
 import { ReplicasSchema, PodTypeSchema, IndexNameSchema } from './types';
 
-const ConfigureIndexOptionsSchema = Type.Union([
-  Type.Object({ replicas: ReplicasSchema }, { additionalProperties: false }),
-  Type.Object({ podType: PodTypeSchema }, { additionalProperties: false }),
-]);
+const ConfigureIndexOptionsSchema = Type.Object(
+  {
+    replicas: Type.Optional(ReplicasSchema),
+    podType: Type.Optional(PodTypeSchema),
+  },
+  { additionalProperties: false }
+);
 
 export type ConfigureIndexOptions = Static<typeof ConfigureIndexOptionsSchema>;
 
@@ -29,6 +33,12 @@ export const configureIndex = (api: IndexOperationsApi) => {
   ): Promise<void> => {
     indexNameValidator(name);
     patchRequestValidator(options);
+
+    if (Object.keys(options).length === 0) {
+      throw new PineconeArgumentError(
+        'The second argument to configureIndex should not be empty object. Please specify at least one property to update.'
+      );
+    }
 
     try {
       await api.configureIndex({ indexName: name, patchRequest: options });

--- a/src/control/configureIndex.ts
+++ b/src/control/configureIndex.ts
@@ -36,7 +36,7 @@ export const configureIndex = (api: IndexOperationsApi) => {
 
     if (Object.keys(options).length === 0) {
       throw new PineconeArgumentError(
-        'The second argument to configureIndex should not be empty object. Please specify at least one property to update.'
+        'The second argument to configureIndex should not be empty object. Please specify at least one propert (replicas, podType) to update.'
       );
     }
 

--- a/src/data/__tests__/upsert.test.ts
+++ b/src/data/__tests__/upsert.test.ts
@@ -29,12 +29,6 @@ const setupFailure = (response) => {
 };
 
 describe('upsert', () => {
-  const generateTestRecords = (numberOfVectors: number) =>
-    Array.from({ length: numberOfVectors }, (_, i) => ({
-      id: `test-create-${i}`,
-      values: [1, 2, 3],
-    }));
-
   test('calls the openapi upsert endpoint', async () => {
     const { fakeUpsert, cmd } = setupSuccess('');
 

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '../errors';
 import { buildConfigValidator } from '../validator';
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 import {
   RecordIdSchema,

--- a/src/data/upsert.ts
+++ b/src/data/upsert.ts
@@ -1,10 +1,10 @@
-import { handleApiError, PineconeBatchUpsertError } from '../errors';
+import { handleApiError } from '../errors';
 import { buildConfigValidator } from '../validator';
-import { PineconeRecordSchema, type PineconeRecord } from './types';
+import { PineconeRecordSchema } from './types';
 import { Type } from '@sinclair/typebox';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 import type { Vector } from '../pinecone-generated-ts-fetch';
-import type { RecordMetadataValue } from './types';
+import type { PineconeRecord, RecordMetadataValue } from './types';
 
 const RecordArray = Type.Array(PineconeRecordSchema);
 

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -18,13 +18,10 @@ import {
   PineconeConfigurationError,
   PineconeEnvironmentVarsNotSupportedError,
 } from './errors';
-import { Index, type RecordMetadataValue } from './data';
+import { Index, PineconeConfigurationSchema } from './data';
 import { buildValidator } from './validator';
 import { queryParamsStringify, buildUserAgent } from './utils';
-import {
-  type PineconeConfiguration,
-  PineconeConfigurationSchema,
-} from './data';
+import type { PineconeConfiguration, RecordMetadataValue } from './data';
 
 /**
  * @example


### PR DESCRIPTION
## Problem

Previously, the `configureIndex` command only allowed changing either `replicas` or `podType` but not both. The API allows changing both at one time.

## Solution

Relax the type applied to the patch request options.

Also, fix a bunch of lint warnings that have accumulated (but which are not related to the change in this diff).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Unit tests passing.

Plus manual testing

```typescript
> await client.listIndexes()
[ { name: 'jen2' }, { name: 'jen3' }, { name: 'word-embeddings' } ]
> await client.configureIndex('word-embeddings', {})
Uncaught:
PineconeArgumentError: The second argument to configureIndex should not be empty object. Please specify at least one propert (replicas, podType) to update.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:60:31
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:4:12)
    at Pinecone.configureIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:52:46)
    at REPL50:1:46
> await client.configureIndex('word-embeddings', { replicas: 'asdf' })
Uncaught:
PineconeArgumentError: The second argument to configureIndex had type errors: property 'replicas' must be integer.
    at /Users/jhamon/workspace/pinecone-ts-client/dist/validator.js:201:19
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:58:21
    at step (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:33:23)
    at Object.next (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:14:53)
    at /Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:4:12)
    at Pinecone.configureIndex (/Users/jhamon/workspace/pinecone-ts-client/dist/control/configureIndex.js:52:46)
    at REPL51:1:46
> await client.describeIndex('word-embeddings')
{
  database: {
    name: 'word-embeddings',
    dimension: 384,
    metric: 'cosine',
    pods: 1,
    replicas: 1,
    shards: 1,
    podType: 'p1.x1'
  },
  status: {
    ready: true,
    state: 'Ready',
    host: 'word-embeddings-c01b9b5.svc.us-east1-gcp.pinecone.io',
    port: 433
  }
}
> await client.configureIndex('word-embeddings', { replicas: 2, podType: 'p1.x2' })
undefined
> await client.describeIndex('word-embeddings')
{
  database: {
    name: 'word-embeddings',
    dimension: 384,
    metric: 'cosine',
    pods: 2,
    replicas: 2,
    shards: 1,
    podType: 'p1.x2'
  },
  status: {
    ready: true,
    state: 'ScalingUpPodSize',
    host: 'word-embeddings-c01b9b5.svc.us-east1-gcp.pinecone.io',
    port: 433
  }
}
```