### PR TITLE
[v1] Change fetch return field from `vectors` to `records`

### DIFF
--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -132,12 +132,12 @@ describe('Pinecone', () => {
       const i = p.index<ProductMetadata>('product-embeddings');
 
       const result = await i.fetch(['1']);
-      if (result && result.vectors) {
+      if (result && result.records) {
         // No ts error
-        console.log(result.vectors['1'].metadata?.color);
+        console.log(result.records['1'].metadata?.color);
 
         // @ts-expect-error because colour not in ProductMetadata
-        console.log(result.vectors['1'].metadata.colour);
+        console.log(result.records['1'].metadata.colour);
       }
 
       // No ts errors when passing ProductMetadata

--- a/src/data/__tests__/fetch.test.ts
+++ b/src/data/__tests__/fetch.test.ts
@@ -33,7 +33,7 @@ describe('fetch', () => {
     const { VOA, cmd } = setupSuccess({ vectors: [] });
     const returned = await cmd.run(['1', '2']);
 
-    expect(returned).toEqual({ vectors: [] });
+    expect(returned).toEqual({ records: [] });
     expect(VOA.fetch).toHaveBeenCalledWith({
       ids: ['1', '2'],
       namespace: 'namespace',

--- a/src/data/__tests__/index.test.ts
+++ b/src/data/__tests__/index.test.ts
@@ -91,9 +91,9 @@ describe('Index', () => {
     expect(FetchCommand).toHaveBeenCalledTimes(1);
 
     const response = await index.fetch(['1']);
-    if (response && response.vectors) {
+    if (response && response.records) {
       // eslint-disable-next-line
-      Object.entries(response.vectors).forEach(([key, value]) => {
+      Object.entries(response.records).forEach(([key, value]) => {
         // No errors on these because they are properties from MovieMetadata
         console.log(value.metadata?.genre);
         console.log(value.metadata?.runtime);

--- a/src/data/fetch.ts
+++ b/src/data/fetch.ts
@@ -9,7 +9,7 @@ const RecordIdsArray = Type.Array(RecordIdSchema, { minItems: 1 });
 export type FetchOptions = Array<RecordId>;
 
 export type FetchResponse<T extends Record<string, RecordMetadataValue>> = {
-  vectors?: { [key: string]: PineconeRecord<T> };
+  records?: { [key: string]: PineconeRecord<T> };
   namespace?: string;
 };
 
@@ -32,7 +32,7 @@ export class FetchCommand<T extends Record<string, RecordMetadataValue>> {
       const response = await api.fetch({ ids: ids, namespace: this.namespace });
 
       return {
-        vectors: response.vectors,
+        records: response.vectors,
         namespace: response.namespace,
       } as FetchResponse<T>;
     } catch (e) {


### PR DESCRIPTION
## Problem

"Record" is now the [preferred terminology](https://docs.pinecone.io/docs/overview#pinecone-indexes-store-records-with-vector-data) for items stored in an index. The fetch command still refers to `vectors` in the response.

## Solution

Change the name of the property in the results object. Update tests.


## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Plan

After the change, the REPL shows:

```typescript
> let pinecone = new Pinecone()
undefined
> await pinecone.index('jen2').fetch(['1'])
{
  records: {
    '1': {
      id: '1',
      values: [Array],
      sparseValues: undefined,
      metadata: [Object]
    }
  },
  namespace: ''
}
```
