### PR TITLE
Add build-docs action for validating documentation build during pr workflow

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -1,0 +1,9 @@
+name: 'Build client documentation'
+description: 'Generates client documentation using TypeDoc'
+runs:
+  using: 'composite'
+  steps:
+    - name: Build html documentation
+      run: |
+        npm run docs:build
+      shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   basic-hygiene:
-    name: Linting, formatting, etc
+    name: Linting, formatting, documentation, etc
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,8 @@ jobs:
           fi
       - name: ESLint
         run: npm run lint
+      - name: TypeDoc
+        uses: ./.github/actions/build-docs
 
   run-integration-tests:
     name: Run integration tests


### PR DESCRIPTION
## Problem
Currently, we don't have any CI/CD processes for handling documentation and everything is rolled by hand. We're beginning work to automate some of our client documentation to ease the pain around keeping documentation in sync with code.

See the Spike document for more context: https://docs.google.com/document/d/1pz1BKe0NYBcQda5Dp6--D9Cf7Hc3-eXvhjNpONde89U/edit?usp=sharing

## Solution
For now keep changes small. We're moving forward leveraging TypeDoc as our generator as we're already using it as a dependency, and it's easy to integrate quickly with GitHub pages.

- Add a new action (`.github/actions/build-docs/action.yml`) to handle triggering the typedoc build in CI. For now we just want to run and validate that nothing broke.
- Update `.github/workflows/pr.yml` to include the `build-docs` action as a part of `basic-hygiene`. This should run the docs build on PRs, updates, and pushes to main along with prettier and eslint.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
We want to validate that the action is running as expected and not causing issues in CI. You can validate the added step in this PR:

- For this PR, check the workflow and make sure the `"Linting, formatting, etc"` step includes the TypeDoc step and it completes as expected: https://github.com/pinecone-io/pinecone-ts-client/actions/runs/6151814963/job/16692664139?pr=106 <img width="1022" alt="Screenshot 2023-09-11 at 5 11 35 PM" src="https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/daf79a4f-a629-4f4d-ab50-8f335cadfeb4"> 
- More generally, for other PRs after this lands - navigate to https://github.com/pinecone-io/pinecone-ts-client/actions/workflows/pr.yml to validate that the pr workflow run is completing as expected