### PR TITLE
Remove typebox Static<> type inference in favor of TypeScript

### DIFF
--- a/src/control/configureIndex.ts
+++ b/src/control/configureIndex.ts
@@ -4,7 +4,7 @@ import { buildValidator } from '../validator';
 import type { IndexName } from './types';
 import { handleIndexRequestError } from './utils';
 
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 import { ReplicasSchema, PodTypeSchema, IndexNameSchema } from './types';
 
 const ConfigureIndexOptionsSchema = Type.Object(
@@ -14,8 +14,7 @@ const ConfigureIndexOptionsSchema = Type.Object(
   },
   { additionalProperties: false }
 );
-
-export type ConfigureIndexOptions = Static<typeof ConfigureIndexOptionsSchema>;
+export type ConfigureIndexOptions = { replicas?: number; podType?: string };
 
 export const configureIndex = (api: IndexOperationsApi) => {
   const indexNameValidator = buildValidator(

--- a/src/control/createCollection.ts
+++ b/src/control/createCollection.ts
@@ -2,7 +2,7 @@ import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
 import { handleIndexRequestError } from './utils';
 import { CollectionNameSchema, IndexNameSchema } from './types';
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 
 const CreateCollectionOptionsSchema = Type.Object(
   {
@@ -12,9 +12,7 @@ const CreateCollectionOptionsSchema = Type.Object(
   { additionalProperties: false }
 );
 
-export type CreateCollectionOptions = Static<
-  typeof CreateCollectionOptionsSchema
->;
+export type CreateCollectionOptions = { name: string; source: string };
 
 export const createCollection = (api: IndexOperationsApi) => {
   const validator = buildConfigValidator(

--- a/src/control/createCollection.ts
+++ b/src/control/createCollection.ts
@@ -2,6 +2,7 @@ import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
 import { handleIndexRequestError } from './utils';
 import { CollectionNameSchema, IndexNameSchema } from './types';
+import type { CollectionName, IndexName } from './types';
 import { Type } from '@sinclair/typebox';
 
 const CreateCollectionOptionsSchema = Type.Object(
@@ -12,7 +13,10 @@ const CreateCollectionOptionsSchema = Type.Object(
   { additionalProperties: false }
 );
 
-export type CreateCollectionOptions = { name: string; source: string };
+export type CreateCollectionOptions = {
+  name: CollectionName;
+  source: IndexName;
+};
 
 export const createCollection = (api: IndexOperationsApi) => {
   const validator = buildConfigValidator(

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -3,7 +3,7 @@ import { buildConfigValidator } from '../validator';
 import { debugLog } from '../utils';
 import { handleApiError } from '../errors';
 import { handleIndexRequestError } from './utils';
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 import {
   IndexNameSchema,
   DimensionSchema,
@@ -15,7 +15,17 @@ import {
   CollectionNameSchema,
 } from './types';
 
-export type CreateIndexOptions = Static<typeof CreateIndexOptionsSchema>;
+export type CreateIndexOptions = {
+  name: string;
+  dimension: number;
+  metric?: string;
+  pods?: number;
+  replicas?: number;
+  podType?: string;
+  metadataConfig?: { indexed: Array<string> };
+  sourceCollection?: string;
+  waitUntilReady?: boolean;
+};
 
 const CreateIndexOptionsSchema = Type.Object(
   {

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -14,9 +14,10 @@ import {
   MetadataConfigSchema,
   CollectionNameSchema,
 } from './types';
+import type { IndexName } from './types';
 
 export type CreateIndexOptions = {
-  name: string;
+  name: IndexName;
   dimension: number;
   metric?: string;
   pods?: number;

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -1,4 +1,4 @@
-import { Type, Static } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 
 const nonemptyString = Type.String({ minLength: 1 });
 const positiveInteger = Type.Integer({ minimum: 1 });
@@ -9,7 +9,7 @@ const positiveInteger = Type.Integer({ minimum: 1 });
 // no descriptive information is returned for an index named empty
 // string. To avoid this confusing case, we require lenth > 1.
 export const IndexNameSchema = nonemptyString;
-export type IndexName = Static<typeof IndexNameSchema>;
+export type IndexName = string;
 
 export const PodTypeSchema = nonemptyString;
 export const ReplicasSchema = positiveInteger;
@@ -29,4 +29,4 @@ export const MetadataConfigSchema = Type.Object(
 // no descriptive information is returned for an collection named empty
 // string. To avoid this confusing case, we require lenth > 1.
 export const CollectionNameSchema = nonemptyString;
-export type CollectionName = Static<typeof CollectionNameSchema>;
+export type CollectionName = string;

--- a/src/data/deleteMany.ts
+++ b/src/data/deleteMany.ts
@@ -1,7 +1,7 @@
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 import { handleApiError } from '../errors';
 import { buildConfigValidator } from '../validator';
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 import type { DeleteRequest } from '../pinecone-generated-ts-fetch/models/DeleteRequest';
 import { RecordIdSchema } from './types';
 
@@ -17,11 +17,11 @@ const DeleteManySchema = Type.Union([
   DeleteManyByFilterSchema,
 ]);
 
-export type DeleteManyByVectorIdOptions = Static<
-  typeof DeleteManyByRecordIdSchema
->;
-export type DeleteManyByFilterOptions = Static<typeof DeleteManyByFilterSchema>;
-export type DeleteManyOptions = Static<typeof DeleteManySchema>;
+export type DeleteManyByVectorIdOptions = Array<string>;
+export type DeleteManyByFilterOptions = object;
+export type DeleteManyOptions =
+  | DeleteManyByVectorIdOptions
+  | DeleteManyByFilterOptions;
 
 export const deleteMany = (
   apiProvider: VectorOperationsProvider,

--- a/src/data/deleteMany.ts
+++ b/src/data/deleteMany.ts
@@ -4,6 +4,7 @@ import { buildConfigValidator } from '../validator';
 import { Type } from '@sinclair/typebox';
 import type { DeleteRequest } from '../pinecone-generated-ts-fetch/models/DeleteRequest';
 import { RecordIdSchema } from './types';
+import type { RecordId } from './types';
 
 const DeleteManyByRecordIdSchema = Type.Array(RecordIdSchema);
 
@@ -17,7 +18,7 @@ const DeleteManySchema = Type.Union([
   DeleteManyByFilterSchema,
 ]);
 
-export type DeleteManyByVectorIdOptions = Array<string>;
+export type DeleteManyByVectorIdOptions = Array<RecordId>;
 export type DeleteManyByFilterOptions = object;
 export type DeleteManyOptions =
   | DeleteManyByVectorIdOptions

--- a/src/data/describeIndexStats.ts
+++ b/src/data/describeIndexStats.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '../errors';
 import { buildConfigValidator } from '../validator';
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 
 export type IndexStatsNamespaceSummary = {
@@ -20,10 +20,7 @@ const DescribeIndexStatsOptionsSchema = Type.Object(
   },
   { additionalProperties: false }
 );
-
-export type DescribeIndexStatsOptions = Static<
-  typeof DescribeIndexStatsOptionsSchema
->;
+export type DescribeIndexStatsOptions = { filter: object };
 
 export const describeIndexStats = (apiProvider: VectorOperationsProvider) => {
   const validator = buildConfigValidator(

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -3,10 +3,11 @@ import { buildConfigValidator } from '../validator';
 import {
   RecordIdSchema,
   RecordSparseValuesSchema,
+  RecordValues,
   RecordValuesSchema,
 } from './types';
 import type { PineconeRecord, RecordMetadata } from './types';
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 
 const shared = {
@@ -38,9 +39,15 @@ const QueryByVectorValues = Type.Object(
 
 const QuerySchema = Type.Union([QueryByRecordId, QueryByVectorValues]);
 
-export type QueryByRecordId = Static<typeof QueryByRecordId>;
-export type QueryByVectorValues = Static<typeof QueryByVectorValues>;
-export type QueryOptions = Static<typeof QuerySchema>;
+type QueryShared = {
+  topK: number;
+  includeValues?: boolean;
+  includeMetadata?: boolean;
+  filter?: object;
+};
+export type QueryByRecordId = QueryShared & { id: string };
+export type QueryByVectorValues = QueryShared & { vector: RecordValues };
+export type QueryOptions = QueryByRecordId | QueryByVectorValues;
 
 export interface ScoredPineconeRecord<T extends RecordMetadata = RecordMetadata>
   extends PineconeRecord<T> {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,4 +1,4 @@
-import { Static, Type } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 
 export const PineconeConfigurationSchema = Type.Object(
   {
@@ -8,7 +8,11 @@ export const PineconeConfigurationSchema = Type.Object(
   },
   { additionalProperties: false }
 );
-export type PineconeConfiguration = Static<typeof PineconeConfigurationSchema>;
+export type PineconeConfiguration = {
+  environment: string;
+  apiKey: string;
+  projectId?: string;
+};
 
 export const RecordIdSchema = Type.String({ minLength: 1 });
 export const RecordValuesSchema = Type.Array(Type.Number());
@@ -29,9 +33,12 @@ export const PineconeRecordSchema = Type.Object(
   { additionalProperties: false }
 );
 
-export type RecordId = Static<typeof RecordIdSchema>;
-export type RecordValues = Static<typeof RecordValuesSchema>;
-export type RecordSparseValues = Static<typeof RecordSparseValuesSchema>;
+export type RecordId = string;
+export type RecordValues = number[];
+export type RecordSparseValues = {
+  indices: Array<number>;
+  values: Array<number>;
+};
 export type RecordMetadataValue = string | boolean | number | Array<string>;
 export type RecordMetadata = Record<string, RecordMetadataValue>;
 export type PineconeRecord<T extends RecordMetadata = RecordMetadata> = {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -34,7 +34,7 @@ export const PineconeRecordSchema = Type.Object(
 );
 
 export type RecordId = string;
-export type RecordValues = number[];
+export type RecordValues = Array<number>;
 export type RecordSparseValues = {
   indices: Array<number>;
   values: Array<number>;


### PR DESCRIPTION
## Problem
We use `typebox` for runtime validation of arguments in the Node client. Currently, we're leveraging typebox's `Static<typeof schema>` utility for generating TypeScript types out of these runtime schemas. 

We've noticed this doesn't play well with documentation generation, and there have been some bug reports regarding issues  possibly related to typebox's generated types.

## Solution
Instead of relying on the typebox utility, use our own TypeScript types which are manually aligned with existing schemas.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
These are all typing changes so there shouldn't be any client code affected by these changes.

Make sure to run:
`npm run lint`