### PR TITLE
Add support for Edge Runtime

### DIFF
--- a/.github/actions/npm-release/action.yml
+++ b/.github/actions/npm-release/action.yml
@@ -25,9 +25,16 @@ runs:
       run: |
         git config --global user.email "${{ inputs.git_email }}"
         git config --global user.name "${{ inputs.git_username }}"
-    - name: 'Bump version and commit'
+    - name: 'Bump version'
       shell: bash
-      run: npm version ${{ inputs.releaseType }} -m '[skip ci] Publish release %s'
+      run: npm version ${{ inputs.releaseType }} --no-git-tag-version
+    - name: 'Commit and tag version changes'
+      shell: bash
+      run: |
+        git add .
+        newVersion=$(jq -r '.version' package.json)
+        git commit -m "[skip ci] Publish release v$newVersion"
+        git tag "v$newVersion"
     - name: 'Output release tag'
       shell: bash
       id: release-tag-step

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,9 @@ jobs:
   run-integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jest_env: ['node', 'edge']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -50,7 +53,7 @@ jobs:
           CI: true
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
-        run: npm run test:integration
+        run: npm run test:integration:${{ matrix.jest_env }}
 
   unit-tests:
     name: Run unit tests

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -35,6 +35,7 @@ jobs:
           jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
           jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
           jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
+          jq --null-input --arg version "$devVersion" '{"name": "@pinecone-database/pinecone", "version": $version}' > src/version.json
 
       - name: 'Publish to npm'
         run: npm publish --tag next

--- a/jest.config.edge.js
+++ b/jest.config.edge.js
@@ -1,0 +1,6 @@
+const config = require('./jest.config');
+
+module.exports = {
+  ...config,
+  testEnvironment: '@edge-runtime/jest-environment',
+};

--- a/jest.config.integration-edge.js
+++ b/jest.config.integration-edge.js
@@ -1,4 +1,4 @@
-const config = require('./jest.config');
+const config = require('./jest.config.integration-node');
 
 module.exports = {
   ...config,

--- a/jest.config.integration-node.js
+++ b/jest.config.integration-node.js
@@ -1,0 +1,8 @@
+const config = require('./jest.config');
+
+module.exports = {
+  ...config,
+  setupFilesAfterEnv: ['./utils/globalIntegrationTestSetup.ts'],
+  testPathIgnorePatterns: [],
+  testEnvironment: 'node',
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,12 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   reporters: [['github-actions', { silent: false }], 'default'],
+  setupFilesAfterEnv: ['./utils/globalUnitTestSetup.ts'],
   transform: {
     '^.+\\.ts?$': 'ts-jest',
   },
   transformIgnorePatterns: ['<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ['src/integration'],
   testTimeout: 100000,
   verbose: true,
   detectOpenHandles: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@edge-runtime/jest-environment": "^2.3.3",
+        "@edge-runtime/types": "^2.2.3",
         "@sinclair/typebox": "^0.28.15",
         "@types/web": "^0.0.99",
         "ajv": "^8.12.0",
@@ -49,7 +51,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
@@ -244,7 +245,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.19.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -273,7 +273,6 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -286,7 +285,6 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -297,7 +295,6 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -310,7 +307,6 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -318,12 +314,10 @@
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -331,7 +325,6 @@
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -339,7 +332,6 @@
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -585,6 +577,51 @@
         "node": ">=12"
       }
     },
+    "node_modules/@edge-runtime/jest-environment": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/jest-environment/-/jest-environment-2.3.3.tgz",
+      "integrity": "sha512-mJmhbCZLsS9fHa6ayM6yOOLIujVujknGT35bajtDARjCo3Ga24MLT0faw9LwjmqutX5MGs5pFkgAyEhiT98nAQ==",
+      "dependencies": {
+        "@edge-runtime/vm": "3.1.3",
+        "@jest/environment": "29.5.0",
+        "@jest/fake-timers": "29.5.0",
+        "jest-mock": "29.5.0",
+        "jest-util": "29.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/primitives": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.0.1.tgz",
+      "integrity": "sha512-hxWUzx1SeyOed/Ea9Z6y6tyFKSj8gQWIdLilybTR2ene1IthLZE01A1SLGoch1szUdhFlUwpWDaYBYQw00lj2g==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/types": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/types/-/types-2.2.3.tgz",
+      "integrity": "sha512-zL0ENQWwdocECEQXVopGTfnqI0tJ8wzDOCoQymoc8MLRz+Zw2V1W0ex9vczniTUzB+H/P7ubMgx3GFzLp3NPBg==",
+      "dependencies": {
+        "@edge-runtime/primitives": "4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/vm": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.1.3.tgz",
+      "integrity": "sha512-LkEtuVtT1kgOEghxFAEJZ+BeIpGz3XfI2l1Ts74HXzd3JneMmmx6RRkNiEE85DVBpuvv9d8KB1u+lc1CHTmz/g==",
+      "dependencies": {
+        "@edge-runtime/primitives": "4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -828,7 +865,6 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.5.0",
@@ -865,7 +901,6 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -946,7 +981,6 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.4.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.25.16"
@@ -957,7 +991,6 @@
     },
     "node_modules/@jest/schemas/node_modules/@sinclair/typebox": {
       "version": "0.25.24",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/source-map": {
@@ -1046,7 +1079,6 @@
     },
     "node_modules/@jest/types": {
       "version": "29.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -1143,7 +1175,6 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "2.0.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -1151,7 +1182,6 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
@@ -1224,12 +1254,10 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -1237,7 +1265,6 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -1267,7 +1294,6 @@
     },
     "node_modules/@types/node": {
       "version": "18.11.17",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prettier": {
@@ -1283,7 +1309,6 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/web": {
@@ -1292,7 +1317,6 @@
     },
     "node_modules/@types/yargs": {
       "version": "17.0.17",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -1300,7 +1324,6 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1662,7 +1685,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1890,7 +1912,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -1996,7 +2017,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2019,7 +2039,6 @@
     },
     "node_modules/ci-info": {
       "version": "3.7.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2059,7 +2078,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2070,7 +2088,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2342,7 +2359,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2882,7 +2898,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3134,7 +3149,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/grapheme-splitter": {
@@ -3171,7 +3185,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3465,7 +3478,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3921,7 +3933,6 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -3940,7 +3951,6 @@
     },
     "node_modules/jest-mock": {
       "version": "29.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4134,7 +4144,6 @@
     },
     "node_modules/jest-util": {
       "version": "29.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4223,7 +4232,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4406,7 +4414,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
@@ -4720,7 +4727,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4773,7 +4779,6 @@
     },
     "node_modules/pretty-format": {
       "version": "29.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -4786,7 +4791,6 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4851,7 +4855,6 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
@@ -5056,7 +5059,6 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5086,7 +5088,6 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -5205,7 +5206,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5259,7 +5259,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -5454,7 +5453,6 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "format": "prettier --write .",
     "lint": "eslint src/ --ext .ts",
     "repl": "npm run build && node utils/replInit.ts",
-    "test:integration:node": "jest tests/integration/ --setupFilesAfterEnv ./utils/globalIntegrationTestSetup.ts",
-    "test:integration:edge": "jest tests/integration/ --setupFilesAfterEnv ./utils/globalIntegrationTestSetup.ts -c jest.config.edge.js",
-    "test:unit": "jest src/ --setupFilesAfterEnv ./utils/globalUnitTestSetup.ts --testPathIgnorePatterns src/integration"
+    "test:integration:node": "jest src/integration/ -c jest.config.integration-node.js",
+    "test:integration:edge": "jest src/integration/ -c jest.config.integration-edge.js",
+    "test:unit": "jest src/"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "rm -rf dist/ && tsc",
+    "version": "jq --null-input --arg version $npm_package_version '{\"name\": \"@pinecone-database/pinecone\", \"version\": $version}' > src/version.json",
     "docs:build": "typedoc",
     "format": "prettier --write .",
     "lint": "eslint src/ --ext .ts",
     "repl": "npm run build && node utils/replInit.ts",
-    "test:integration": "jest src/integration --setupFilesAfterEnv ./utils/globalIntegrationTestSetup.ts",
+    "test:integration:node": "jest tests/integration/ --setupFilesAfterEnv ./utils/globalIntegrationTestSetup.ts",
+    "test:integration:edge": "jest tests/integration/ --setupFilesAfterEnv ./utils/globalIntegrationTestSetup.ts -c jest.config.edge.js",
     "test:unit": "jest src/ --setupFilesAfterEnv ./utils/globalUnitTestSetup.ts --testPathIgnorePatterns src/integration"
   },
   "engines": {
@@ -46,6 +48,8 @@
     "/dist"
   ],
   "dependencies": {
+    "@edge-runtime/jest-environment": "^2.3.3",
+    "@edge-runtime/types": "^2.2.3",
     "@sinclair/typebox": "^0.28.15",
     "@types/web": "^0.0.99",
     "ajv": "^8.12.0",

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,0 +1,6 @@
+export const isEdge = () => {
+  // This is the recommended way to detect
+  // running in the Edge Runtime according
+  // to Vercel docs.
+  return typeof EdgeRuntime === 'string';
+};

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -1,0 +1,11 @@
+import * as os from 'os';
+
+export const getOSInfo = () => {
+  // If available, capture information about the OS
+  if (os && os.release && os.platform && os.arch) {
+    const platform = os.platform();
+    const platformVersion = os.release();
+    const arch = os.arch();
+    return `${platform} ${platformVersion}, ${arch}`;
+  }
+};

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,23 +1,23 @@
-import * as fs from 'fs';
-import * as os from 'os';
-
-const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+import { getOSInfo } from './os';
+import { isEdge } from './environment';
+import * as packageInfo from '../version.json';
 
 export const buildUserAgent = (isLegacy: boolean) => {
   // We always want to include the package name and version
   // along with the langauge name to help distinguish these
   // requests from those emitted by other clients
   const userAgentParts = [
-    `${packageJson.name} v${packageJson.version}`,
+    `${packageInfo.name} v${packageInfo.version}`,
     'lang=typescript',
   ];
 
-  // If available, capture information about the OS
-  if (os && os.release && os.platform && os.arch) {
-    const platform = os.platform();
-    const platformVersion = os.release();
-    const arch = os.arch();
-    userAgentParts.push(`${platform} ${platformVersion}, ${arch}`);
+  if (!isEdge()) {
+    const osInfo = getOSInfo();
+    if (osInfo) {
+      userAgentParts.push(osInfo);
+    }
+  } else {
+    userAgentParts.push('Edge Runtime');
   }
 
   // If available, capture information about the Node.js version

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,6 +1,7 @@
 import Ajv from 'ajv';
 import type { ErrorObject } from 'ajv';
 import { PineconeArgumentError } from './errors';
+import { isEdge } from './utils/environment';
 
 const prepend = (prefix: string, message: string) => {
   return `${prefix} ${message}`;
@@ -224,6 +225,11 @@ export const errorFormatter = (subject: string, errors: Array<ErrorObject>) => {
 };
 
 export const buildValidator = (errorMessagePrefix: string, schema: any) => {
+  if (isEdge()) {
+    // Ajv schema compilation does not work in the Edge Runtime.
+    return (data: any) => {}; // eslint-disable-line
+  }
+
   if (
     process &&
     process.env &&

--- a/src/version.json
+++ b/src/version.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pinecone-database/pinecone",
+  "version": "1.0.0"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,9 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node", "jest"],
-    "noImplicitAny": false
+    "types": ["node", "jest", "@edge-runtime/types"],
+    "noImplicitAny": false,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Problem

People attempting to use this library in Vercel's [Edge Runtime](https://edge-runtime.vercel.app/) are hitting runtime exceptions due to reliance on some node utilities that are not available.

This addresses issue #108 

## Solution

- Setup new `npm run test:integration:edge` which runs integration tests using a special jest context designed to highlight when code is using dependencies that are not available on edge.
- Integrate this test run into CI

Code changes to get these tests passing:
- Add an `isEdge()` utility that looks for a global var, `EdgeRuntime` to detect whether execution is happening in the Edge Runtime.
- Use that util to guard things which won't work in Edge. Things not supported in Edge:
  - Pulling `os` info for the user-agent string. This info can just be omitted from the user-agent.
  - Using `fs` to read `package.json` version, also for the user-agent string. The version number is the most important thing in the user-agent so I do need some other way of getting that info. Importing json as a module is possible in es6, but I was getting typescript build errors when trying to grab package.json directly because that file is outside of the tsconfig `rootDir`. So, I adjusted the publish steps to dump version info to a place it can be safely referenced, `src/version.json`.
  - Runtime validation using AJV. The code generation that happens in the `compile` step causes Edge to blow up. So we skip runtime validations for Edge for now. If they are developing with TypeScript, these should be largely unnecessary anyway.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Infrastructure change (CI configs, etc)

## Test Plan

- New CI job for edge integration tests should be green.
- For changes to publish jobs, I did some local testing to explore what the npm version command does and test the jq commands. But won't know for sure that this is all correct,  though, until trying to ship a release.