### PR TITLE
Add merge .github workflow to build and deploy docs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,14 +1,13 @@
 name: 'Merge to main'
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch: {}
-  pull_request:
-    types:
-      - closed
 
 jobs:
   build-and-deploy-documentation:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,30 @@
+name: 'Merge to main'
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types:
+      - closed
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  build-and-deploy-documentation:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Generate TypeDoc documentation
+        uses: ./.github/actions/build-docs
+      - name: Deploy documentation to gh-pages
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: gh-pages
+          FOLDER: docs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
     types:
       - closed
-  workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   build-and-deploy-documentation:


### PR DESCRIPTION
## Problem
We're working to improve documentation for the SDK clients by automating the process of generating and deploying documentation. Specifically, this needs to happen on every merge to `main`.

## Solution

- Create a new `.github/workflows/merge.yml` file that will be triggered specifically on closed PRs that are merged to `main`. For now this explicitly handles the documentation pieces, but more steps could be added in the future if there are other CI processes we want to trigger on merge.
- Reuse the `build-docs` action setup in the previous PR (#106) for generation.
- Use the `s0/git-publish-subdir-action` to push the documentation artifact to a specific branch that will house current client documentation: `gh-pages`.

**Note:** I went back and forth on either adding a new workflow explicitly for merging, or hooking into the existing `.github/workflows/pr.yml` and using `if: github.event.pull_request.merged == true` to split the deployment behavior out. I'm still open to this solution if we'd prefer to keep it simple.

It also feels like we're running the `build-docs` step a lot across the `pr.yml` and now `merge.yml` workflows. Maybe this is ok since we're only using the output in merge, but wanted to call it out in case there's some work that could be done there passing things around between jobs, etc.

## Type of Change
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Make sure CI is green.

After this merges I can make the adjustments to the repository settings to pull & publish from `gh-pages`, and we can validate the docs are built correctly at https://pinecone-io.github.io/pinecone-ts-client. 
