### PR TITLE
Resolve typescript compilation problems

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,3 +67,58 @@ jobs:
         env:
           CI: true
         run: npm run test:unit -- --coverage
+
+  typescript-compilation-tests:
+    name: TS compile
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tsVersion:
+          [
+            '~4.1.0',
+            '~4.2.0',
+            '~4.3.0',
+            '~4.4.0',
+            '~4.5.0',
+            '~4.6.0',
+            '~4.7.0',
+            '~4.8.0',
+            '~4.9.0',
+            '~5.0.0',
+            '~5.1.0',
+            '~5.2.0',
+            'latest',
+          ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install npm packages
+        run: |
+          npm install --ignore-scripts
+        shell: bash
+      - name: Build typescript for pinecone
+        run: npm run build
+        shell: bash
+      - name: install, compile, and run sample app
+        shell: bash
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
+        run: |
+          set -x
+          cd ..
+          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
+          cd ts-compilation-test
+          npm install typescript@${{matrix.tsVersion}} --no-cache
+          npm install '../pinecone-ts-client' --no-cache
+          cat package.json
+          cat package-lock.json
+          npm run tsc-version
+          npm run build
+          npm run start

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,17 @@
-node_modules/
-dist/
-scrap
+# Secrets
 .env
-src/run.ts
+
+# Generated files
+coverage/
+dist/
+docs/
+node_modules/
+ts-compilation-test/package-lock.json
+ts-compilation-test/node_modules/
+ts-compilation-test/lib/
+
+# Clutter
 .vscode
 .DS_Store
 scratch
-docs/
-coverage/
+scrap

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ ts-compilation-test/lib/
 .vscode
 .DS_Store
 scratch
-scrap

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This is the official Node.js client for Pinecone, written in TypeScript.
 
 If you are upgrading from a `v0.x` beta client, check out the [**v1 Migration Guide**](./v1-migration.md).
 
+## Prerequisites
+
+The Pinecone TypeScript client is compatible with TypeScript 4.1 and greater.
+
 ## Installation
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,16 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edge-runtime/jest-environment": "^2.3.3",
         "@edge-runtime/types": "^2.2.3",
-        "@sinclair/typebox": "^0.28.15",
-        "@types/web": "^0.0.99",
+        "@sinclair/typebox": "^0.29.0",
+        "@types/node": "^18.11.17",
         "ajv": "^8.12.0",
-        "cross-fetch": "^3.1.5"
+        "cross-fetch": "^3.1.5",
+        "typescript": "^4.9.4"
       },
       "devDependencies": {
-        "@jest/globals": "^29.3.1",
+        "@edge-runtime/jest-environment": "^2.3.3",
         "@types/jest": "^29.5.0",
-        "@types/node": "^18.11.17",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
         "dotenv": "^16.0.3",
@@ -28,10 +27,7 @@
         "jest": "^29.5.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.0.5",
-        "ts-node": "^10.9.1",
-        "typedoc": "^0.24.8",
-        "typescript": "^4.9.4",
-        "unique-names-generator": "^4.7.1"
+        "typedoc": "^0.24.8"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -51,6 +47,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
@@ -245,6 +242,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.19.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -273,6 +271,7 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -285,6 +284,7 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -295,6 +295,7 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -307,6 +308,7 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -314,10 +316,12 @@
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -325,6 +329,7 @@
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -332,6 +337,7 @@
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -570,6 +576,8 @@
       "version": "0.8.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -581,6 +589,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@edge-runtime/jest-environment/-/jest-environment-2.3.3.tgz",
       "integrity": "sha512-mJmhbCZLsS9fHa6ayM6yOOLIujVujknGT35bajtDARjCo3Ga24MLT0faw9LwjmqutX5MGs5pFkgAyEhiT98nAQ==",
+      "dev": true,
       "dependencies": {
         "@edge-runtime/vm": "3.1.3",
         "@jest/environment": "29.5.0",
@@ -615,6 +624,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.1.3.tgz",
       "integrity": "sha512-LkEtuVtT1kgOEghxFAEJZ+BeIpGz3XfI2l1Ts74HXzd3JneMmmx6RRkNiEE85DVBpuvv9d8KB1u+lc1CHTmz/g==",
+      "dev": true,
       "dependencies": {
         "@edge-runtime/primitives": "4.0.1"
       },
@@ -865,6 +875,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.5.0",
@@ -901,6 +912,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -981,6 +993,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.25.16"
@@ -991,6 +1004,7 @@
     },
     "node_modules/@jest/schemas/node_modules/@sinclair/typebox": {
       "version": "0.25.24",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/source-map": {
@@ -1079,6 +1093,7 @@
     },
     "node_modules/@jest/types": {
       "version": "29.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -1170,11 +1185,13 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.28.15",
-      "license": "MIT"
+      "version": "0.29.6",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
+      "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "2.0.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -1182,6 +1199,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
@@ -1190,22 +1208,30 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -1254,10 +1280,12 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -1265,6 +1293,7 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -1309,14 +1338,12 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/web": {
-      "version": "0.0.99",
-      "license": "Apache-2.0"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.17",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -1324,6 +1351,7 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1637,6 +1665,8 @@
       "version": "8.2.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1685,6 +1715,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1711,7 +1742,9 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -1912,6 +1945,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -2017,6 +2051,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2039,6 +2074,7 @@
     },
     "node_modules/ci-info": {
       "version": "3.7.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2078,6 +2114,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2088,6 +2125,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2103,7 +2141,9 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -2188,6 +2228,8 @@
       "version": "4.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2359,6 +2401,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2898,6 +2941,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3149,6 +3193,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/grapheme-splitter": {
@@ -3185,6 +3230,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3478,6 +3524,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3933,6 +3980,7 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -3951,6 +3999,7 @@
     },
     "node_modules/jest-mock": {
       "version": "29.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4144,6 +4193,7 @@
     },
     "node_modules/jest-util": {
       "version": "29.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4232,6 +4282,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4414,6 +4465,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
@@ -4727,6 +4779,7 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4779,6 +4832,7 @@
     },
     "node_modules/pretty-format": {
       "version": "29.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -4791,6 +4845,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4855,6 +4910,7 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
@@ -5059,6 +5115,7 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5088,6 +5145,7 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -5206,6 +5264,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5259,6 +5318,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -5347,6 +5407,8 @@
       "version": "10.9.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5453,6 +5515,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5530,8 +5593,8 @@
     },
     "node_modules/typescript": {
       "version": "4.9.4",
-      "dev": true,
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5553,14 +5616,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/unique-names-generator": {
-      "version": "4.7.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -5598,7 +5653,9 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -5793,6 +5850,8 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
     "node": ">=14.0.0"
   },
   "devDependencies": {
-    "@jest/globals": "^29.3.1",
+    "@edge-runtime/jest-environment": "^2.3.3",
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "dotenv": "^16.0.3",
@@ -38,21 +37,18 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.8",
     "ts-jest": "^29.0.5",
-    "ts-node": "^10.9.1",
-    "typedoc": "^0.24.8",
-    "typescript": "^4.9.4",
-    "unique-names-generator": "^4.7.1"
+    "typedoc": "^0.24.8"
   },
   "types": "dist/index.d.ts",
   "files": [
     "/dist"
   ],
   "dependencies": {
-    "@edge-runtime/jest-environment": "^2.3.3",
     "@edge-runtime/types": "^2.2.3",
-    "@sinclair/typebox": "^0.28.15",
-    "@types/web": "^0.0.99",
+    "@sinclair/typebox": "^0.29.0",
+    "@types/node": "^18.11.17",
     "ajv": "^8.12.0",
-    "cross-fetch": "^3.1.5"
+    "cross-fetch": "^3.1.5",
+    "typescript": "^4.9.4"
   }
 }

--- a/src/control/deleteCollection.ts
+++ b/src/control/deleteCollection.ts
@@ -1,7 +1,8 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
 import { handleCollectionRequestError } from './utils';
-import { CollectionNameSchema, type CollectionName } from './types';
+import { CollectionNameSchema } from './types';
+import type { CollectionName } from './types';
 
 export type DeleteCollectionOptions = CollectionName;
 

--- a/src/control/describeCollection.ts
+++ b/src/control/describeCollection.ts
@@ -1,7 +1,8 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
 import { handleCollectionRequestError } from './utils';
-import { CollectionNameSchema, type CollectionName } from './types';
+import { CollectionNameSchema } from './types';
+import type { CollectionName } from './types';
 
 export type DescribeCollectionOptions = CollectionName;
 export type CollectionDescription = {

--- a/src/control/describeIndex.ts
+++ b/src/control/describeIndex.ts
@@ -2,7 +2,8 @@ import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
 import type { IndexMeta } from '../pinecone-generated-ts-fetch';
 import { handleIndexRequestError } from './utils';
-import { IndexNameSchema, type IndexName } from './types';
+import { IndexNameSchema } from './types';
+import type { IndexName } from './types';
 
 export type DescribeIndexOptions = IndexName;
 export type IndexDescription = IndexMeta;

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -1,34 +1,29 @@
 // Index Operations
-export { configureIndex, type ConfigureIndexOptions } from './configureIndex';
-export { createIndex, type CreateIndexOptions } from './createIndex';
-export { deleteIndex, type DeleteIndexOptions } from './deleteIndex';
-export {
-  describeIndex,
-  type DescribeIndexOptions,
-  type IndexDescription,
-} from './describeIndex';
-export {
-  listIndexes,
-  type IndexList,
-  type PartialIndexDescription,
-} from './listIndexes';
+export { configureIndex } from './configureIndex';
+export type { ConfigureIndexOptions } from './configureIndex';
+export { createIndex } from './createIndex';
+export type { CreateIndexOptions } from './createIndex';
+export { deleteIndex } from './deleteIndex';
+export type { DeleteIndexOptions } from './deleteIndex';
+export { describeIndex } from './describeIndex';
+export type { DescribeIndexOptions, IndexDescription } from './describeIndex';
+export { listIndexes } from './listIndexes';
+export type { IndexList, PartialIndexDescription } from './listIndexes';
 
 // Collection Operations
-export {
-  createCollection,
-  type CreateCollectionOptions,
-} from './createCollection';
-export {
-  deleteCollection,
-  type DeleteCollectionOptions,
-} from './deleteCollection';
-export {
-  describeCollection,
-  type DescribeCollectionOptions,
-  type CollectionDescription,
+export { createCollection } from './createCollection';
+export type { CreateCollectionOptions } from './createCollection';
+
+export { deleteCollection } from './deleteCollection';
+export type { DeleteCollectionOptions } from './deleteCollection';
+
+export { describeCollection } from './describeCollection';
+export type {
+  DescribeCollectionOptions,
+  CollectionDescription,
 } from './describeCollection';
-export {
-  listCollections,
-  type CollectionList,
-  type PartialCollectionDescription,
+export { listCollections } from './listCollections';
+export type {
+  CollectionList,
+  PartialCollectionDescription,
 } from './listCollections';

--- a/src/data/__tests__/upsert.test.ts
+++ b/src/data/__tests__/upsert.test.ts
@@ -3,10 +3,8 @@ import {
   PineconeBadRequestError,
   PineconeInternalServerError,
 } from '../../errors';
-import {
-  VectorOperationsApi,
-  type UpsertOperationRequest,
-} from '../../pinecone-generated-ts-fetch';
+import { VectorOperationsApi } from '../../pinecone-generated-ts-fetch';
+import type { UpsertOperationRequest } from '../../pinecone-generated-ts-fetch';
 import { VectorOperationsProvider } from '../vectorOperationsProvider';
 
 const setupResponse = (response, isSuccess) => {

--- a/src/data/deleteOne.ts
+++ b/src/data/deleteOne.ts
@@ -1,7 +1,8 @@
 import { VectorOperationsProvider } from './vectorOperationsProvider';
 import { handleApiError } from '../errors';
 import { buildConfigValidator } from '../validator';
-import { RecordIdSchema, type RecordId } from './types';
+import { RecordIdSchema } from './types';
+import type { RecordId } from './types';
 
 export type DeleteOneOptions = RecordId;
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,7 +1,10 @@
 import { UpsertCommand } from './upsert';
-import { FetchCommand, type FetchOptions } from './fetch';
-import { UpdateCommand, type UpdateOptions } from './update';
-import { QueryCommand, type QueryOptions } from './query';
+import { FetchCommand } from './fetch';
+import type { FetchOptions } from './fetch';
+import { UpdateCommand } from './update';
+import type { UpdateOptions } from './update';
+import { QueryCommand } from './query';
+import type { QueryOptions } from './query';
 import { deleteOne } from './deleteOne';
 import { deleteMany } from './deleteMany';
 import { deleteAll } from './deleteAll';

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -6,10 +6,12 @@ import {
   RecordIdSchema,
   RecordValuesSchema,
   RecordSparseValuesSchema,
-  type RecordId,
-  type RecordValues,
-  type RecordSparseValues,
-  type RecordMetadata,
+} from './types';
+import type {
+  RecordId,
+  RecordValues,
+  RecordSparseValues,
+  RecordMetadata,
 } from './types';
 
 const UpdateRecordOptionsSchema = Type.Object(

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -35,10 +35,12 @@ async function streamToArrayBuffer(
       break;
     }
 
-    const newResult = new Uint8Array(result.length + value.length);
-    newResult.set(result);
-    newResult.set(value, result.length);
-    result = newResult;
+    if (value) {
+      const newResult = new Uint8Array(result.length + value.length);
+      newResult.set(result);
+      newResult.set(value, result.length);
+      result = newResult;  
+    }
   }
   return result;
 }

--- a/ts-compilation-test/package.json
+++ b/ts-compilation-test/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "build": "tsc",
+    "tsc-version": "tsc -v",
+    "start": "node lib/index.js"
+  }
+}

--- a/ts-compilation-test/src/index.ts
+++ b/ts-compilation-test/src/index.ts
@@ -1,0 +1,8 @@
+import { Pinecone } from '@pinecone-database/pinecone';
+
+const p = new Pinecone();
+
+(async () => {
+  const indexList = await p.listIndexes();
+  console.log(`Available indexes: ${JSON.stringify(indexList)}`);
+})();

--- a/ts-compilation-test/tsconfig.json
+++ b/ts-compilation-test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017"
+  },
+  "compileOnSave": true,
+  "include": ["src"]
+}


### PR DESCRIPTION
## Problem

Several users have reported issues with typescript compilation

This PR addresses:
- #102
- #105 

## Solution

### Clean up unused dependencies to resolve web-related type errors

I started by deleting dependencies and running tests to see what dependencies were no longer in use. I was able to delete these:
- @types/web
- @jest/globals
- unique-names-generator

Removing `@types/web` seems to have resolved the majority of Typescript issues related to conflicts with web types in `lib.dom.d.ts`. Since I was already in there mucking with dependencies, I went ahead and shuffled a few things between dependencies/devDependencies just to align with my current understanding of things. 

### TS1005 (Typescript versions <=4.4)

People on older typescript versions report seeing many errors like this:

```
Error: ../pinecone-ts-client/dist/control/index.d.ts(1,31): error TS1005: ',' expected.
```

These errors were caused by using import statements that combined type and value imports onto one line. This syntax was evidently not supported in versions of typescript prior to 4.4.

Resolving these issues involved refactoring about 30 import statements along these lines:
```diff
-import { IndexNameSchema, type IndexName } from './types';
+import { IndexNameSchema } from './types';
+import type { IndexName } from './types';
```

### Typebox errors (Typescript >= 5.1)

The `@sinclair/typebox` dependency is causing issues with very recent versions of typescript.

```
../node_modules/@sinclair/typebox/typebox.d.ts:179:167 - error TS2589: Type instantiation is excessively deep and possibly infinite.

179 ] extends [TArray, TNumber] ? AssertType<T['items']> : K extends TTemplateLiteral ? TIndexReduce<T, TTemplateLiteralKeyRest<K>> : K extends TUnion<TLiteral<Key>[]> ? TIndexReduce<T, TUnionLiteralKeyRest<K>> : K extends TLiteral<Key> ? TIndexReduce<T, [K['const']]> : TNever;
```

### New CI job: `typescript-compilation-tests`

To verify this compilation issue doesn't come up again, I added a new github actions job along with a version matrix. It tests every major version of typescript back to version 4.1 (released [fall 2020](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/)) along with a version of pinecone, then checks whether it can successfully `tsc`. I ran these with the v1.0.0 pinecone release to see the jobs fail as reported, then updated it to install the latest code in this branch and saw them pass. This will be part of CI for every PR from now on.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)

## Test Plan

Should see new compilation tests passing in CI. There are now 13 different checks running in CI to exercise compilation with major versions of TypeScript.

## Follow-up

Probably we should add a lint rule to prevent us adding back any mixed type/value imports.