### PR TITLE
Update typedoc.json configurations and type exports

### DIFF
--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -27,3 +27,5 @@ export type {
   CollectionList,
   PartialCollectionDescription,
 } from './listCollections';
+
+export type { CollectionName, IndexName } from './types';

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -1,4 +1,5 @@
 // Index Operations
+export type { IndexName } from './types';
 export { configureIndex } from './configureIndex';
 export type { ConfigureIndexOptions } from './configureIndex';
 export { createIndex } from './createIndex';
@@ -11,6 +12,7 @@ export { listIndexes } from './listIndexes';
 export type { IndexList, PartialIndexDescription } from './listIndexes';
 
 // Collection Operations
+export type { CollectionName } from './types';
 export { createCollection } from './createCollection';
 export type { CreateCollectionOptions } from './createCollection';
 
@@ -27,5 +29,3 @@ export type {
   CollectionList,
   PartialCollectionDescription,
 } from './listCollections';
-
-export type { CollectionName, IndexName } from './types';

--- a/src/data/deleteMany.ts
+++ b/src/data/deleteMany.ts
@@ -18,10 +18,10 @@ const DeleteManySchema = Type.Union([
   DeleteManyByFilterSchema,
 ]);
 
-export type DeleteManyByVectorIdOptions = Array<RecordId>;
+export type DeleteManyByRecordIdOptions = Array<RecordId>;
 export type DeleteManyByFilterOptions = object;
 export type DeleteManyOptions =
-  | DeleteManyByVectorIdOptions
+  | DeleteManyByRecordIdOptions
   | DeleteManyByFilterOptions;
 
 export const deleteMany = (

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -26,7 +26,11 @@ export type {
   RecordMetadataValue,
 } from './types';
 export { PineconeConfigurationSchema } from './types';
-export type { DeleteManyOptions } from './deleteMany';
+export type {
+  DeleteManyOptions,
+  DeleteManyByFilterOptions,
+  DeleteManyByVectorIdOptions,
+} from './deleteMany';
 export type { DeleteOneOptions } from './deleteOne';
 export type {
   DescribeIndexStatsOptions,
@@ -41,6 +45,7 @@ export type {
   QueryByVectorValues,
   QueryOptions,
   QueryResponse,
+  QueryShared,
 } from './query';
 
 export class Index<T extends RecordMetadata = RecordMetadata> {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -29,7 +29,7 @@ export { PineconeConfigurationSchema } from './types';
 export type {
   DeleteManyOptions,
   DeleteManyByFilterOptions,
-  DeleteManyByVectorIdOptions,
+  DeleteManyByRecordIdOptions,
 } from './deleteMany';
 export type { DeleteOneOptions } from './deleteOne';
 export type {

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -39,7 +39,7 @@ const QueryByVectorValues = Type.Object(
 
 const QuerySchema = Type.Union([QueryByRecordId, QueryByVectorValues]);
 
-type QueryShared = {
+export type QueryShared = {
   topK: number;
   includeValues?: boolean;
   includeMetadata?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export type {
   PartialCollectionDescription,
 } from './control';
 export type {
+  DeleteManyByFilterOptions,
+  DeleteManyByVectorIdOptions,
   DeleteManyOptions,
   DeleteOneOptions,
   DescribeIndexStatsOptions,
@@ -36,6 +38,7 @@ export type {
   QueryByVectorValues,
   QueryOptions,
   QueryResponse,
+  QueryShared,
   RecordId,
   RecordMetadata,
   RecordMetadataValue,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type {
 } from './control';
 export type {
   DeleteManyByFilterOptions,
-  DeleteManyByVectorIdOptions,
+  DeleteManyByRecordIdOptions,
   DeleteManyOptions,
   DeleteOneOptions,
   DescribeIndexStatsOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * as Errors from './errors';
 export type {
   CollectionDescription,
   CollectionList,
+  CollectionName,
   ConfigureIndexOptions,
   CreateCollectionOptions,
   CreateIndexOptions,
@@ -16,6 +17,7 @@ export type {
   DescribeIndexOptions,
   IndexDescription,
   IndexList,
+  IndexName,
   PartialIndexDescription,
   PartialCollectionDescription,
 } from './control';

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -211,7 +211,7 @@ export class Pinecone {
    * @param options.sourceCollection - If creating an index from a collection, you can specify the name of the collection here.
    * @see [Distance metrics](https://docs.pinecone.io/docs/indexes#distance-metrics)
    * @see [Pod types and sizes](https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes)
-   * @throws {@link PineconeArgumentError} when invalid arguments are provided.
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are provided.
    *
    * @returns A promise that resolves when the request to create the index is completed. Note that the index is not immediately ready to use. You can use the `describeIndex` function to check the status of the index.
    */
@@ -227,7 +227,7 @@ export class Pinecone {
    *
    * @param indexName - The name of the index to delete.
    * @returns A promise that resolves when the request to delete the index is completed.
-   * @throws {@link PineconeArgumentError} when invalid arguments are provided
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are provided
    */
   deleteIndex: ReturnType<typeof deleteIndex>;
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,7 @@
 {
-  // Comments are supported, like tsconfig.json
   "entryPoints": ["src/index.ts"],
+  "exclude": ["**/v0/*"],
+  "hideGenerator": true,
+  "includeVersion": true,
   "out": "docs"
 }


### PR DESCRIPTION
## Problem
There are some basic configurations for TypeDoc we can provide to clean up some of the documentation output. There were also a number of warnings being output when running the utility calling out internals that are represented in documentation, but not included due to not being available as an export at the top level.

## Solution

- Update `typedoc.json` config to exclude `/v0/` code paths, include the version number in the output, and hide the generator tagline at the bottom of the page.
- Update the `{@link PineconeArgumentError}` doc strings to `{@link Errors.PineconeArgumentError` to properly pull in the references.
- Export missing types: `IndexName`, `CollectionName`, `DeleteManyByVectorIdOptions`, `DeleteManyByFilterOptions`, and `QueryShared`.

## Type of Change
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Make sure CI is green.
Validate documentation after it's been built and deployed: https://pinecone-io.github.io/pinecone-ts-client/

The documentation CI step should also still show warnings for some of the `pinecone-generated-ts-fetch` internals, and a few of the index classes. I'm honestly unsure if those should be exported, and exporting them at the top level pulled in additional pieces into warnings so it may need a more thorough pass.

Current warnings should look like this:
<img width="1484" alt="Screenshot 2023-09-14 at 4 39 59 PM" src="https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/0a9568c3-1a50-40c2-a44b-c73e12aac618">
