### PR TITLE
Add docstrings to Index class properties and methods

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -48,6 +48,9 @@ export type {
   QueryShared,
 } from './query';
 
+/**
+ * @typeParam T - The type of metadata associated with each record.
+ */
 export class Index<T extends RecordMetadata = RecordMetadata> {
   private config: PineconeConfiguration;
   private target: {
@@ -55,9 +58,69 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
     namespace: string;
   };
 
+  /**
+   * Delete all records from the index.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').deleteAll();
+   * ```
+   * @returns A promise that resolves when the delete is completed.
+   */
   deleteAll: ReturnType<typeof deleteAll>;
+
+  /**
+   * Delete records from the index by either an array of ids, or a filter object.
+   * See [Filtering with metadata](https://docs.pinecone.io/docs/metadata-filtering#deleting-vectors-by-metadata-filter) for more on deleting records with filters.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').deleteMany(['record-1', 'record-2']);
+   *
+   * // or
+   * await pinecone.index('my-index').deleteMany({ filter: { genre: 'classical' }});
+   * ```
+   * @param options - An array of record id values or a filter object.
+   * @returns A promise that resolves when the delete is completed.
+   */
   deleteMany: ReturnType<typeof deleteMany>;
+
+  /**
+   * Delete a record from the index by id.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').deleteOne('record-1');
+   * ```
+   * @param options - The record is for deletion.
+   * @returns A promise that resolves when the delete is completed.
+   */
   deleteOne: ReturnType<typeof deleteOne>;
+
+  /**
+   * Describes the index's statistics such as total number of records, records per namespace, and the index's dimension size.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').describeIndexStats();
+   *
+   * // {
+   * //  namespaces: {
+   * //    '': { recordCount: 10 }
+   * //    foo: { recordCount: 2000 },
+   * //    bar: { recordCount: 2000 }
+   * //   },
+   * //   dimension: 1536,
+   * //   indexFullness: 0,
+   * //   totalRecordCount: 4010
+   * // }
+   * ```
+   * @returns A promise that resolve with the {@link IndexStatsDescription} when the operation is completed.
+   */
   describeIndexStats: ReturnType<typeof describeIndexStats>;
 
   private _fetchCommand: FetchCommand<T>;
@@ -65,6 +128,20 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
   private _updateCommand: UpdateCommand<T>;
   private _upsertCommand: UpsertCommand<T>;
 
+  /**
+   * Instantiation of Index is handled by {@link Pinecone}
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * const index = pinecone.index('my-index');
+   * ```
+   *
+   * @constructor
+   * @param indexName - The name of the index being configured.
+   * @param config - The configuration from the Pinecone client.
+   * @param namespace - The namespace for the index.
+   */
   constructor(
     indexName: string,
     config: PineconeConfiguration,
@@ -89,22 +166,91 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
     this._upsertCommand = new UpsertCommand<T>(apiProvider, namespace);
   }
 
+  /**
+   * Returns an {@link Index} targeting the specified namespace. By default, all operations take place inside the default namespace ''.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * const indexNamed = pinecone.index('my-index').namespace('my-namespace');
+   * ```
+   *
+   * @param namespace - The namespace to target within the index.
+   */
   namespace(namespace: string): Index<T> {
     return new Index<T>(this.target.index, this.config, namespace);
   }
 
+  /**
+   * Upsert records to the index.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').upsert([{
+   *  id: 'record-1',
+   *  values: [0.176, 0.345, 0.263],
+   * },{
+   *  id: 'record-2',
+   *  values: [0.176, 0.345, 0.263],
+   * }])
+   * ```
+   *
+   * @param data - An array of {@link PineconeRecord} objects to upsert.
+   * @returns A promise that resolves when the upsert is completed.
+   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
+   */
   async upsert(data: Array<PineconeRecord<T>>) {
     return await this._upsertCommand.run(data);
   }
 
+  /**
+   * Fetch records from the index.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').fetch(['record-1', 'record-2']);
+   * ```
+   * @param options - The {@link FetchOptions} for the operation.
+   * @returns A promise that resolves with the {@link FetchResponse} when the fetch is completed.
+   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
+   */
   async fetch(options: FetchOptions) {
     return await this._fetchCommand.run(options);
   }
 
+  /**
+   * Query records from the index by id or vector values.
+   *
+   * @example
+   * ```js
+   * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').query({ topK: 3, id: 'record-1'});
+   *
+   * // or
+   * await pinecone.index('my-index').query({ topK: 3, vector: [0.176, 0.345, 0.263] });
+   * ```
+   *
+   * @param options - The {@link QueryOptions} for the operation.
+   * @returns A promise that resolves with the {@link QueryResponse} when the query is completed.
+   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
+   */
   async query(options: QueryOptions) {
     return await this._queryCommand.run(options);
   }
 
+  /**
+   * Update a record in the index by id.
+   *
+   * @param options - The {@link UpdateOptions} for the operation.
+   * @returns A promise that resolves when the update is completed.
+   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
+   */
   async update(options: UpdateOptions<T>) {
     return await this._updateCommand.run(options);
   }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -59,12 +59,37 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
   };
 
   /**
-   * Delete all records from the index.
+   * Delete all records from the targeted namespace. To delete all records from across all namespaces,
+   * delete the index using {@link Pinecone.deleteIndex} and create a new one using {@link Pinecone.createIndex}.
    *
    * @example
    * ```js
    * const pinecone = new Pinecone();
+   * await pinecone.index('my-index').describeIndexStats();
+   *
+   * // {
+   * //  namespaces: {
+   * //    '': { recordCount: 10 },
+   * //   foo: { recordCount: 1 }
+   * //   },
+   * //   dimension: 8,
+   * //   indexFullness: 0,
+   * //   totalRecordCount: 11
+   * // }
+   *
    * await pinecone.index('my-index').deleteAll();
+   *
+   * // Records in default namespace '' are now gone, but records in namespace 'foo' are not modified.
+   * await client.index('my-index').describeIndexStats();
+   * // {
+   * //  namespaces: {
+   * //   foo: { recordCount: 1 }
+   * //   },
+   * //   dimension: 8,
+   * //   indexFullness: 0,
+   * //   totalRecordCount: 1
+   * // }
+   *
    * ```
    * @returns A promise that resolves when the delete is completed.
    */
@@ -72,7 +97,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
 
   /**
    * Delete records from the index by either an array of ids, or a filter object.
-   * See [Filtering with metadata](https://docs.pinecone.io/docs/metadata-filtering#deleting-vectors-by-metadata-filter) for more on deleting records with filters.
+   * See [Filtering with metadata](https://docs.pinecone.io/docs/metadata-filtering#deleting-vectors-by-metadata-filter)
+   * for more on deleting records with filters.
    *
    * @example
    * ```js
@@ -80,10 +106,11 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * await pinecone.index('my-index').deleteMany(['record-1', 'record-2']);
    *
    * // or
-   * await pinecone.index('my-index').deleteMany({ filter: { genre: 'classical' }});
+   * await pinecone.index('my-index').deleteMany({ genre: 'classical' });
    * ```
    * @param options - An array of record id values or a filter object.
    * @returns A promise that resolves when the delete is completed.
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   deleteMany: ReturnType<typeof deleteMany>;
 
@@ -95,8 +122,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * const pinecone = new Pinecone();
    * await pinecone.index('my-index').deleteOne('record-1');
    * ```
-   * @param options - The record is for deletion.
+   * @param id - The id of the record to delete.
    * @returns A promise that resolves when the delete is completed.
+   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   deleteOne: ReturnType<typeof deleteOne>;
 
@@ -119,7 +147,7 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * //   totalRecordCount: 4010
    * // }
    * ```
-   * @returns A promise that resolve with the {@link IndexStatsDescription} when the operation is completed.
+   * @returns A promise that resolve with the {@link IndexStatsDescription} value when the operation is completed.
    */
   describeIndexStats: ReturnType<typeof describeIndexStats>;
 
@@ -138,7 +166,7 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```
    *
    * @constructor
-   * @param indexName - The name of the index being configured.
+   * @param indexName - The name of the index that will receive operations from this {@link Index} instance.
    * @param config - The configuration from the Pinecone client.
    * @param namespace - The namespace for the index.
    */
@@ -223,7 +251,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
   }
 
   /**
-   * Query records from the index by id or vector values.
+   * Query records from the index. Query is used to find the `topK` records in the index whose vector values are most
+   * similar to the vector values of the query according to the distance metric you have configured for your index.
+   * See [Query data](https://docs.pinecone.io/docs/query-data) for more on querying.
    *
    * @example
    * ```js

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -324,10 +324,20 @@ export class Pinecone {
     return this.config;
   }
 
+  /**
+   * Targets a specific index for performing data operations.
+   *
+   * @param indexName - The name of the index to target.
+   * @typeParam T - The type of the metadata object associated with each record.
+   * @returns An {@link Index} object that can be used to perform data operations.
+   */
   index<T extends RecordMetadata = RecordMetadata>(indexName: string) {
     return new Index<T>(indexName, this.config);
   }
 
+  /**
+   * {@inheritDoc index}
+   */
   // Alias method to match the Python SDK capitalization
   Index<T extends RecordMetadata = RecordMetadata>(indexName: string) {
     return this.index<T>(indexName);


### PR DESCRIPTION
## Problem
Now that we're generating and deploying documentation for the Node SDK, we need to fill in docstrings on the `Index` class properties and methods. My thinking is we should have detailed docstrings for all the top-level entry points for the client, and we're currently missing the data plane.

## Solution
Add docstrings to `/src/data/index.ts`. 
New comments for: the constructor, `deleteAll`, `deleteMany`, `deleteOne`, `describeIndexStats`, `fetch`, `namespace`, `query`, `update`, `upsert`.

### Considerations 
I kept things fairly minimal on this first pass as I wanted to get some feedback. I was cribbing a lot from the `README.md` file, and I wasn't sure how in-depth we wanted to go in terms of inline examples, etc. Definitely open to feedback on how granular we'd like to get in terms of docstring contents.

## Type of Change
- [X] Non-code change (docs, etc)

## Test Plan
There are no direct code changes in this patch so testing should be confined to making sure the docs-build CI job is green, and we're not seeing a bunch of errors around the docs generation process.

You can checkout the branch locally and run the docs command manually to generate things, and then navigate to `./docs/index.html` to validate the output.

`npm run docs:build`

|Before - Node SDK Index Page|After - Node SDK Index Page|
| --- | --- |
|![Screenshot 2023-09-15 at 5 29 59 PM](https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/ed664ffa-b511-4590-95dd-7770f9011903)|![Screenshot 2023-09-15 at 5 29 44 PM](https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/f3f71eb8-e8fd-4ec5-923c-bd0a3a7e30de)|

