### PR TITLE
[Bugfix] Implement next.js fetch compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   testPathIgnorePatterns: ['src/integration'],
   testTimeout: 100000,
   verbose: true,
-  detectOpenHandles: true,
+  detectOpenHandles: false,
   collectCoverageFrom: [
     '<rootDir>/src/**/*.ts',
     '!**/src/pinecone-generated-ts-fetch/**',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^18.11.17",
         "ajv": "^8.12.0",
         "cross-fetch": "^3.1.5",
+        "encoding": "^0.1.13",
         "typescript": "^4.9.4"
       },
       "devDependencies": {
@@ -2295,6 +2296,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "dev": true,
@@ -3298,6 +3307,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -5049,6 +5069,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/node": "^18.11.17",
     "ajv": "^8.12.0",
     "cross-fetch": "^3.1.5",
+    "encoding": "^0.1.13",
     "typescript": "^4.9.4"
   }
 }

--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -1,14 +1,17 @@
 import { Pinecone } from '../pinecone';
 import type { PineconeConfiguration } from '../data';
-import crossFetch from 'cross-fetch';
+import * as utils from '../utils';
 
-jest.mock('cross-fetch', () => {
+const fakeFetch = jest.fn();
+
+jest.mock('../utils', () => {
+  const realUtils = jest.requireActual('../utils');
+
   return {
-    __esModule: true,
-    default: jest.fn(),
+    ...realUtils,
+    getFetch: () => fakeFetch,
   };
 });
-
 jest.mock('../data/fetch');
 jest.mock('../data/upsert');
 
@@ -83,7 +86,7 @@ describe('Pinecone', () => {
           new Pinecone({
             environment: 'test-env',
             apiKey: 'test-key',
-            fetchApi: crossFetch,
+            fetchApi: utils.getFetch({} as PineconeConfiguration),
           } as PineconeConfiguration);
         }).not.toThrow();
       });
@@ -106,17 +109,6 @@ describe('Pinecone', () => {
         expect(client.getConfig().environment).toEqual('test-env');
         expect(client.getConfig().apiKey).toEqual('test-api');
         expect(client.getConfig().projectId).toEqual(undefined);
-      });
-
-      test('should read projectId and skip whoami if provided', () => {
-        process.env.PINECONE_ENVIRONMENT = 'test-env';
-        process.env.PINECONE_API_KEY = 'test-api';
-        process.env.PINECONE_PROJECT_ID = 'test-project';
-
-        const client = new Pinecone();
-
-        expect(client.getConfig().projectId).toEqual('test-project');
-        expect(crossFetch).not.toHaveBeenCalled();
       });
 
       test('config object should take precedence when both config object and environment variables are provided', () => {

--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -77,6 +77,18 @@ describe('Pinecone', () => {
       });
     });
 
+    describe('optional properties', () => {
+      test('should not throw when optional properties provided: fetchAPI', () => {
+        expect(() => {
+          new Pinecone({
+            environment: 'test-env',
+            apiKey: 'test-key',
+            fetchApi: crossFetch,
+          } as PineconeConfiguration);
+        }).not.toThrow();
+      });
+    });
+
     describe('configuration with environment variables', () => {
       beforeEach(() => {
         delete process.env.PINECONE_ENVIRONMENT;

--- a/src/data/projectIdSingleton.ts
+++ b/src/data/projectIdSingleton.ts
@@ -5,8 +5,7 @@ import {
   mapHttpStatusError,
 } from '../errors';
 import type { PineconeConfiguration } from './types';
-import { buildUserAgent } from '../utils';
-import fetch from 'cross-fetch';
+import { buildUserAgent, getFetch } from '../utils';
 
 // We only ever want to call whoami a maximum of once per API key, even if there
 // are multiple instantiations of the Index class. So we use a singleton here
@@ -18,6 +17,7 @@ export const ProjectIdSingleton = (function () {
     options: PineconeConfiguration
   ): Promise<string> => {
     const { apiKey, environment } = options;
+    const fetch = getFetch(options);
     const { url, request } = _buildWhoamiRequest(environment, apiKey);
 
     let response: Response;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,10 +1,18 @@
 import { Type } from '@sinclair/typebox';
+import type { FetchAPI } from '../pinecone-generated-ts-fetch';
 
 export const PineconeConfigurationSchema = Type.Object(
   {
     environment: Type.String({ minLength: 1 }),
     apiKey: Type.String({ minLength: 1 }),
     projectId: Type.Optional(Type.String({ minLength: 1 })),
+
+    // fetchApi is a complex type that I don't really want to recreate in the
+    // form of a json schema (seems difficult and error prone). So we will
+    // rely on TypeScript to guide people in the right direction here.
+    // But declaring it here as Type.Any() is needed to avoid getting caught
+    // in the additionalProperties check.
+    fetchApi: Type.Optional(Type.Any()),
   },
   { additionalProperties: false }
 );
@@ -12,6 +20,7 @@ export type PineconeConfiguration = {
   environment: string;
   apiKey: string;
   projectId?: string;
+  fetchApi?: FetchAPI;
 };
 
 export const RecordIdSchema = Type.String({ minLength: 1 });

--- a/src/data/vectorOperationsProvider.ts
+++ b/src/data/vectorOperationsProvider.ts
@@ -4,9 +4,8 @@ import {
   ConfigurationParameters,
   VectorOperationsApi,
 } from '../pinecone-generated-ts-fetch';
-import { queryParamsStringify, buildUserAgent } from '../utils';
+import { queryParamsStringify, buildUserAgent, getFetch } from '../utils';
 import { ProjectIdSingleton } from './projectIdSingleton';
-import fetch from 'cross-fetch';
 
 const basePath = (config: PineconeConfiguration, indexName: string) =>
   `https://${indexName}-${config.projectId}.svc.${config.environment}.pinecone.io`;
@@ -52,7 +51,7 @@ export class VectorOperationsProvider {
       headers: {
         'User-Agent': buildUserAgent(false),
       },
-      fetchApi: fetch,
+      fetchApi: getFetch(config),
     };
 
     const indexConfiguration = new Configuration(indexConfigurationParameters);

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export type {
   RecordValues,
   ScoredPineconeRecord,
 } from './data';
+export type { FetchAPI } from './pinecone-generated-ts-fetch';
 
 // Legacy exports for backwards compatibility
 export { PineconeClient } from './v0';

--- a/src/integration/data/deleteMany.test.ts
+++ b/src/integration/data/deleteMany.test.ts
@@ -1,9 +1,5 @@
 import { Pinecone, Index } from '../../index';
-import {
-  randomString,
-  createIndexIfDoesNotExist,
-  generateRecords,
-} from '../test-helpers';
+import { randomString, generateRecords } from '../test-helpers';
 
 describe('deleteMany', () => {
   const INDEX_NAME = 'ts-integration';
@@ -12,7 +8,12 @@ describe('deleteMany', () => {
   beforeAll(async () => {
     pinecone = new Pinecone();
 
-    await createIndexIfDoesNotExist(pinecone, INDEX_NAME);
+    await pinecone.createIndex({
+      name: INDEX_NAME,
+      dimension: 5,
+      waitUntilReady: true,
+      suppressConflicts: true,
+    });
 
     namespace = randomString(16);
     index = pinecone.index(INDEX_NAME);

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -1,0 +1,103 @@
+import { Pinecone, Index } from '../../index';
+import { randomString, generateRecords } from '../test-helpers';
+
+describe('query', () => {
+  const INDEX_NAME = 'ts-integration';
+  let pinecone: Pinecone, index: Index, ns: Index, namespace: string;
+
+  beforeAll(async () => {
+    pinecone = new Pinecone();
+
+    await pinecone.createIndex({
+      name: INDEX_NAME,
+      dimension: 5,
+      waitUntilReady: true,
+      suppressConflicts: true,
+    });
+
+    namespace = randomString(16);
+    index = pinecone.index(INDEX_NAME);
+    ns = index.namespace(namespace);
+  });
+
+  afterEach(async () => {
+    await ns.deleteAll();
+  });
+
+  test('query by id', async () => {
+    const recordsToUpsert = generateRecords(5, 3);
+    expect(recordsToUpsert).toHaveLength(3);
+    expect(recordsToUpsert[0].id).toEqual('0');
+    expect(recordsToUpsert[1].id).toEqual('1');
+    expect(recordsToUpsert[2].id).toEqual('2');
+
+    await ns.upsert(recordsToUpsert);
+
+    // Check records got upserted
+    const stats = await ns.describeIndexStats();
+    if (stats.namespaces) {
+      expect(stats.namespaces[namespace].recordCount).toEqual(3);
+    } else {
+      fail('Expected namespaces to be defined');
+    }
+
+    const topK = 2;
+    const results = await ns.query({ id: '0', topK });
+    expect(results.matches).toBeDefined();
+
+    expect(results.matches?.length).toEqual(topK);
+  });
+
+  test('query when topK is greater than number of records', async () => {
+    const numberOfRecords = 3;
+    const recordsToUpsert = generateRecords(5, numberOfRecords);
+    expect(recordsToUpsert).toHaveLength(3);
+    expect(recordsToUpsert[0].id).toEqual('0');
+    expect(recordsToUpsert[1].id).toEqual('1');
+    expect(recordsToUpsert[2].id).toEqual('2');
+
+    await ns.upsert(recordsToUpsert);
+
+    const topK = 5;
+    const results = await ns.query({ id: '0', topK });
+    expect(results.matches).toBeDefined();
+
+    expect(results.matches?.length).toEqual(numberOfRecords);
+  });
+
+  test('with invalid id, returns empty results', async () => {
+    const recordsToUpsert = generateRecords(5, 3);
+    expect(recordsToUpsert).toHaveLength(3);
+    expect(recordsToUpsert[0].id).toEqual('0');
+    expect(recordsToUpsert[1].id).toEqual('1');
+    expect(recordsToUpsert[2].id).toEqual('2');
+
+    await ns.upsert(recordsToUpsert);
+
+    const topK = 2;
+    const results = await ns.query({ id: '100', topK });
+    expect(results.matches).toBeDefined();
+
+    expect(results.matches?.length).toEqual(0);
+  });
+
+  test('query with vector values', async () => {
+    const numberOfRecords = 3;
+    const recordsToUpsert = generateRecords(5, numberOfRecords);
+    expect(recordsToUpsert).toHaveLength(3);
+    expect(recordsToUpsert[0].id).toEqual('0');
+    expect(recordsToUpsert[1].id).toEqual('1');
+    expect(recordsToUpsert[2].id).toEqual('2');
+
+    await ns.upsert(recordsToUpsert);
+
+    const topK = 1;
+    const results = await ns.query({
+      vector: [0.11, 0.22, 0.33, 0.44, 0.55],
+      topK,
+    });
+    expect(results.matches).toBeDefined();
+
+    expect(results.matches?.length).toEqual(topK);
+  });
+});

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -27,19 +27,14 @@ describe('query', () => {
   test('query by id', async () => {
     const recordsToUpsert = generateRecords(5, 3);
     expect(recordsToUpsert).toHaveLength(3);
+
+    // These assertions are just to show what ids were
+    // used in the generated records
     expect(recordsToUpsert[0].id).toEqual('0');
     expect(recordsToUpsert[1].id).toEqual('1');
     expect(recordsToUpsert[2].id).toEqual('2');
 
     await ns.upsert(recordsToUpsert);
-
-    // Check records got upserted
-    const stats = await ns.describeIndexStats();
-    if (stats.namespaces) {
-      expect(stats.namespaces[namespace].recordCount).toEqual(3);
-    } else {
-      fail('Expected namespaces to be defined');
-    }
 
     const topK = 2;
     const results = await ns.query({ id: '0', topK });
@@ -97,7 +92,6 @@ describe('query', () => {
       topK,
     });
     expect(results.matches).toBeDefined();
-
     expect(results.matches?.length).toEqual(topK);
   });
 });

--- a/src/integration/test-helpers.ts
+++ b/src/integration/test-helpers.ts
@@ -1,4 +1,3 @@
-import { Pinecone } from '../index';
 import type { PineconeRecord, RecordSparseValues } from '../index';
 
 export const randomString = (length) => {
@@ -12,26 +11,6 @@ export const randomString = (length) => {
   }
 
   return result;
-};
-
-export const createIndexIfDoesNotExist = async (
-  pinecone: Pinecone,
-  indexName: string
-) => {
-  const indexList = await pinecone.listIndexes();
-  let found = false;
-  indexList.forEach((i) => {
-    if (i.name === indexName) {
-      found = true;
-    }
-  });
-  if (!found) {
-    await pinecone.createIndex({
-      name: indexName,
-      dimension: 5,
-      waitUntilReady: true,
-    });
-  }
 };
 
 export const generateRecords = (

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -20,9 +20,8 @@ import {
 } from './errors';
 import { Index, PineconeConfigurationSchema } from './data';
 import { buildValidator } from './validator';
-import { queryParamsStringify, buildUserAgent } from './utils';
+import { queryParamsStringify, buildUserAgent, getFetch } from './utils';
 import type { PineconeConfiguration, RecordMetadata } from './data';
-import fetch from 'cross-fetch';
 
 /**
  * @example
@@ -44,6 +43,7 @@ export class Pinecone {
    * @param options.apiKey - The API key for your Pinecone project. You can find this in the [Pinecone console](https://app.pinecone.io).
    * @param options.environment - The environment for your Pinecone project. You can find this in the [Pinecone console](https://app.pinecone.io).
    * @param options.projectId - The project ID for your Pinecone project. This optional field can be passed, but if it is not then it will be automatically fetched when needed.
+   * @param options.fetchApi - Optional configuration field for specifying the fetch implementation. If not specified, the client will look for fetch in the global scope and if none is found it will fall back to a cross-fetch polyfill.
    */
   constructor(options?: PineconeConfiguration) {
     if (options === undefined) {
@@ -63,7 +63,7 @@ export class Pinecone {
       headers: {
         'User-Agent': buildUserAgent(false),
       },
-      fetchApi: fetch,
+      fetchApi: getFetch(options),
     };
     const api = new IndexOperationsApi(new ApiConfiguration(apiConfig));
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -5,12 +5,12 @@ export const getFetch = (config: PineconeConfiguration) => {
   if (config.fetchApi) {
     // User-provided fetch implementation, if any, takes precedence.
     return config.fetchApi;
-  } else if (fetch) {
+  } else if (global.fetch) {
     // If a fetch implementation is already present in the global
     // scope, use that. This should prevent confusing failures in
     // nextjs projects where @vercel/fetch is mandated and
     // other implementations are stubbed out.
-    return fetch;
+    return global.fetch;
   } else {
     // Use polyfill as last resort
     return crossFetch;

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,18 @@
+import crossFetch from 'cross-fetch';
+import type { PineconeConfiguration } from '../data';
+
+export const getFetch = (config: PineconeConfiguration) => {
+  if (config.fetchApi) {
+    // User-provided fetch implementation, if any, takes precedence.
+    return config.fetchApi;
+  } else if (fetch) {
+    // If a fetch implementation is already present in the global
+    // scope, use that. This should prevent confusing failures in
+    // nextjs projects where @vercel/fetch is mandated and
+    // other implementations are stubbed out.
+    return fetch;
+  } else {
+    // Use polyfill as last resort
+    return crossFetch;
+  }
+};

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -12,7 +12,7 @@ export const getFetch = (config: PineconeConfiguration) => {
     // other implementations are stubbed out.
     return global.fetch;
   } else {
-    // Use polyfill as last resort
+    // Use ponyfill as last resort
     return crossFetch;
   }
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { debugLog } from './debugLog';
 import { queryParamsStringify } from './queryParamsStringify';
 import { buildUserAgent } from './user-agent';
+import { getFetch } from './fetch';
 
-export { debugLog, queryParamsStringify, buildUserAgent };
+export { debugLog, queryParamsStringify, buildUserAgent, getFetch };


### PR DESCRIPTION
## Problem

Next.js seems to stub out the cross-fetch polyfill which has the effect of silently breaking code which depends on cross-fetch to make API requests.

Related bugs: 
- #124 
- v1 migration problems in https://github.com/pinecone-io/pinecone-vercel-starter/pull/14

## Solution

I have added a `getFetch` utility which looks for a `fetch` implementation already loaded in the global scope and returns the cross-fetch implementation only as a last resort. 

- Now when using our client library in a next.js project, this should result in the `@vercel/fetch` implementation being used in favor of the disabled polyfill. 
- When using this client library in other environments where next.js is not being used, it still activates the cross-fetch polyfill.
- Also, I've exposed an experimental configuration option for anyone who wants to pass in a different fetch implementation to use. This could open up some flexibility for people with specific network configurations who need the ability to configure the http client being used in some way. If the user provides a fetch implementation through the `fetchApi` config option, it will take priority over a fetch in the global scope or the cross-fetch polyfill.

### Other changes

- Added additional integration tests for `query` method
- Added an explicit dependency on the `encoding` module to resolve a warning message [similar to this one](https://github.com/vercel/next.js/discussions/54109)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

I am currently testing this change in the context of work-in-progress to migrate our vercel-starter example to using the v1 version of the client. https://github.com/pinecone-io/pinecone-vercel-starter/pull/14

- Checkout the PR branch from pinecone-vercel-starter in a sibling directory
- Install my local changes to this client with `npm install ../pinecone-ts-client`
- Try to run the starter project with `npm run dev`
- Attempt to use the sample app and observe it progresses beyond the error related broken cross-fetch