### PR TITLE
Add docs build and deploy to release-prod workflow

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -46,3 +46,13 @@ jobs:
           releaseType: ${{ github.event.inputs.releaseType }}
           npm_token: ${{ secrets.NPM_TOKEN }}
       - run: echo "${{ steps.npm-release.outputs.release_tag }} was published"
+
+      - name: Generate TypeDoc documentation
+        uses: ./.github/actions/build-docs
+      - name: Deploy documentation to gh-pages
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: gh-pages
+          FOLDER: docs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Problem
Yesterday @jhamon released a new version of the TypeScript SDK: v1.1.0. After completing the upgrade the client's documentation was out of sync, showing v1.0.1 instead of the latest: https://pinecone-io.github.io/pinecone-ts-client/

The issue is the `release-prod` workflow makes changes to the `package.json` version and pushes this with `[skip ci]` in the commit message, which doesn't trigger any of our merge/commit workflows: https://github.com/pinecone-io/pinecone-ts-client/blob/6a753e38c4d268c73217dd4fed9ba5748d675007/.github/actions/npm-release/action.yml#L36

## Solution
To keep the client's documentation in sync, we can add the documentation generation steps to `release-prod.yml`. This will ensure documentation is properly re-generated after a version bump.

We shouldn't need to make any changes around `release-dev.yml` as we don't actually commit anything to the repo in this workflow.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
We're unable to test the `release-prod.yml` workflow without actually releasing, but the addition to the workflow file is identical to what's currently in `merge.yml`. 

Pushing these changes should also trigger a merge run which should fix up the current mismatch in the docs.