### PR TITLE
Spruce release workflows

### DIFF
--- a/.github/workflows/release-spruce-dev.yml
+++ b/.github/workflows/release-spruce-dev.yml
@@ -1,0 +1,46 @@
+name: 'Release: @spruceDev build'
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  version-and-release:
+    name: Release dev build to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: spruce
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Get recent changes
+        id: list-commits
+        run: |
+          recentCommits=$(git log --since=yesterday --oneline)
+          echo "commits=$recentCommits" >> "$GITHUB_OUTPUT"
+
+      - name: Abort if no recent changes
+        if: steps.list-commits.outputs.commits == ''
+        uses: andymckay/cancel-action@0.3
+
+      - name: 'Bump version, do not commit'
+        shell: bash
+        run: |
+          currentVersion=$(jq -r '.version' package.json)
+          timestamp=$(date +%Y%m%d%H%M%S)
+          devVersion="$currentVersion-spruceDev.$timestamp"
+          jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
+          jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
+          jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
+          jq --null-input --arg version "$devVersion" '{"name": "@pinecone-database/pinecone", "version": $version}' > src/version.json
+
+      - name: 'Publish to npm'
+        run: npm publish --tag spruceDev
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-spruce.yml
+++ b/.github/workflows/release-spruce.yml
@@ -1,0 +1,34 @@
+name: 'Release: @spruce build'
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  version-and-release:
+    name: Release dev build to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: spruce
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: 'Bump version, do not commit'
+        shell: bash
+        run: |
+          currentVersion=$(jq -r '.version' package.json)
+          timestamp=$(date +%Y%m%d%H%M%S)
+          devVersion="$currentVersion-spruce.$timestamp"
+          jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
+          jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
+          jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
+          jq --null-input --arg version "$devVersion" '{"name": "@pinecone-database/pinecone", "version": $version}' > src/version.json
+
+      - name: 'Publish to npm'
+        run: npm publish --tag spruce
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

We need a way to ship builds of the `spruce` branch.

## Solution

Copy & modify the existing release process for shipping dev builds of main using the `@next` tag.

In these new workflows, we will use the npm tag `@spruce` and `@spruceDev`.

- `@spruce` releases are for use in 3rd party testing
- `@spruceDev` releases are for use in internal testing

## Type of Change

- [x] Infrastructure change (CI configs, etc)
