### PR TITLE
[Fix] Expose environment vars in integration test cleanup job

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,3 +16,6 @@ jobs:
         uses: ./.github/actions/setup
       - name: Cleanup
         run: npm run test:integration:cleanup
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}


### PR DESCRIPTION
## Problem

The nightly cleanup job errored because I did not properly expose the environment variables it needs.

## Solution

Wire up the environment variables.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

See the cleanup job [succeed](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/6470956881/job/17568308642).
