### PR TITLE
Fix <a /> styling in dark mode

### DIFF
--- a/assets/docs-styles.css
+++ b/assets/docs-styles.css
@@ -28,7 +28,7 @@
   --tsd-member-header-dark: #2b2e33;
   --p-code-border-dark: inherit;
   --color-alpha1-dark: inherit;
-  --color-alpha2-dark: #4fc1ff;
+  --color-alpha2-dark: inherit;
   --color-light1-dark: inherit;
   --color-body-dark: inherit;
 }

--- a/assets/docs-styles.css
+++ b/assets/docs-styles.css
@@ -28,7 +28,7 @@
   --tsd-member-header-dark: #2b2e33;
   --p-code-border-dark: inherit;
   --color-alpha1-dark: inherit;
-  --color-alpha2-dark: inherit;
+  --color-alpha2-dark: #4fc1ff;
   --color-light1-dark: inherit;
   --color-body-dark: inherit;
 }


### PR DESCRIPTION
## Problem
Currently, links in the TypeScript docs are the same color as all other text, so they're not easily visible unless you mouse over.

## Solution
Make sure we're applying a custom color rather than inheriting from typedoc.

|Before|After|
|-----|-----|
|![Screenshot 2023-10-19 at 6 11 30 PM](https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/29d64cf0-9ce6-49ab-bfad-acb8be3f02b4)|![Screenshot 2023-10-19 at 6 11 13 PM](https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/bcac9c04-e458-4c40-b53f-7f7781fabb27)|

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan
Generate the docs via `npm run docs:build` and make sure the dark mode is showing links as the proper color.
