### PR TITLE
[Docs] Update merge workflow to push generated artifacts to sdk-docs repo

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,10 +16,15 @@ jobs:
         uses: ./.github/actions/setup
       - name: Generate TypeDoc documentation
         uses: ./.github/actions/build-docs
-      - name: Deploy documentation to gh-pages
-        uses: s0/git-publish-subdir-action@develop
+      - name: Push documentation artifacts to sdk-docs
+        uses: cpina/github-action-push-to-another-repository@main
         env:
-          REPO: self
-          BRANCH: gh-pages
-          FOLDER: docs
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: docs
+          destination-github-username: pinecone-io
+          destination-repository-name: sdk-docs
+          user-email: clients@pinecone.io
+          target-branch: main
+          target-directory: typescript
+          commit-message: 'TypeScript: automated documentation build'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -27,4 +27,4 @@ jobs:
           user-email: clients@pinecone.io
           target-branch: main
           target-directory: typescript
-          commit-message: 'TypeScript: automated documentation build'
+          commit-message: 'TypeScript: automated documentation build - pinecone-ts-client merge SHA: ${{ github.sha }}'


### PR DESCRIPTION
## Problem
The current flow for building and deploying documentation for SDK clients takes place within each repository. Currently, `merge` workflows handle the docs build step, and pushing the contents of the generated `/docs` folder to a specific branch for each client: `gh-pages`. This branch is then used as the deployment source for GitHub pages.

There are several issues intrinsic in this:
- We have to manage each CI configuration and deployment on a per-repo basis.
- Applying custom sub-domains to our GitHub pages instances is difficult, and we would need to define a specific sub-domain for each repo.
- We're unable to share resources or assets across docs pages without duplicating things in each repo.

## Solution
Instead of having the CI workflows push documentation artifacts to a local branch, we can instead centralize our SDK documentation in a specific repo and allow workflows to commit docs updates directly to this repo. This allows us to deploy all our SDK documentation via one GitHub pages configuration. This also allows us to centralize all of our generated documentation, which could be useful in the future where we may move to a centralized docs-hosting solution that all the SDK repos need to feed into.

The changes in this PR are relatively small, and there was some pre-setup outside these changes:

### Pre-Setup
- Create new `pinecone-io/sdk-docs` private repo to house generated documentation artifacts.
- Add SSH deploy keys to `sdk-docs` and source repos (`pinecone-ts-client`, `pinecone-python-client`) to allow writing to the `sdk-docs` repo. [Documentation](https://cpina.github.io/push-to-another-repository-docs/setup-using-ssh-deploy-keys.html#setup-ssh-deploy-keys) on this step. It's recommended to use SSH deploy keys over a GitHub PAT token.
- SSH secrets within client repos are titled `SSH_DEPLOY_KEY`.

### This PR 
- Update `merge` workflow to use the `github-action-push-to-another-repository` action. [Action documentation](https://cpina.github.io/push-to-another-repository-docs/overview.html)

## Type of Change
- [X] Infrastructure change (CI configs, etc)

## Test Plan
I should have all the prerequisites set up to allow our CI workflow to push directly to `sdk-docs`. For this change we can merge and verify that the resulting `/docs` folder was correctly pushed to `sdk-docs/typescript`.
