### PR TITLE
Check for `process` existence before accessing it

### DIFF
--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -152,7 +152,7 @@ export class Pinecone {
    * @returns A {@link PineconeConfiguration} object populated with values found in environment variables.
    */
   _readEnvironmentConfig(): PineconeConfiguration {
-    if (!process || !process.env) {
+    if (typeof process === 'undefined' || process || !process.env) {
       throw new PineconeEnvironmentVarsNotSupportedError(
         'Your execution environment does not support reading environment variables from process.env, so a configuration object is required when calling new Pinecone()'
       );

--- a/src/utils/debugLog.ts
+++ b/src/utils/debugLog.ts
@@ -1,5 +1,5 @@
 export const debugLog = (str: string) => {
-  if (process && process.env && process.env.PINECONE_DEBUG) {
+  if (typeof process !== 'undefined' && process && process.env && process.env.PINECONE_DEBUG) {
     console.log(str);
   }
 };

--- a/src/utils/middleware.ts
+++ b/src/utils/middleware.ts
@@ -20,7 +20,7 @@ const chalk = (str, color) => {
  *
  * Api-Key headers will be redacted.
  */
-if (process && process.env && process.env.PINECONE_DEBUG) {
+if (typeof process !== 'undefined' && process && process.env && process.env.PINECONE_DEBUG) {
   const debugLogMiddleware = {
     pre: async (context) => {
       console.debug(
@@ -54,7 +54,7 @@ if (process && process.env && process.env.PINECONE_DEBUG) {
  * curl commands for each request. These commands will include the API key and
  * other sensitive information, so be careful when using this option.
  */
-if (process && process.env && process.env.PINECONE_DEBUG_CURL) {
+if (typeof process !== 'undefined' && process && process.env && process.env.PINECONE_DEBUG_CURL) {
   const debugCurlMiddleware = {
     post: async (context) => {
       let headers = `-H "Api-Key: ${(context.init.headers || {})['Api-Key']}"`;

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -15,7 +15,7 @@ export const buildUserAgent = (isLegacy: boolean) => {
   }
 
   // If available, capture information about the Node.js version
-  if (process && process.version) {
+  if (typeof process !== 'undefined' && process && process.version) {
     userAgentParts.push(`node ${process.version}`);
   }
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -231,6 +231,7 @@ export const buildValidator = (errorMessagePrefix: string, schema: any) => {
   }
 
   if (
+    typeof process !== 'undefined' &&
     process &&
     process.env &&
     process.env.PINECONE_DISABLE_RUNTIME_VALIDATIONS


### PR DESCRIPTION
## Problem

On some edge platforms (specifically Cloudflare Workers), `process` does not exist at all, so checking `!process` isn't enough and causes a runtime error / crash.

## Solution

I added a `typeof process` check before any `process` access occurs so that the Pinecone client works on non-Node runtimes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

No test changes should be necessary, as this is just a more strict `!process` check.
