### PR TITLE
Update README Reference Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the official Node.js client for [Pinecone](https://www.pinecone.io), wri
 
 ## Documentation
 
-- [**Reference Documentation**](https://pinecone-io.github.io/pinecone-ts-client/classes/Pinecone.html)
+- [**Reference Documentation**](https://sdk.pinecone.io/typescript/classes/Pinecone.html)
 - If you are upgrading from a `v0.x` beta client, check out the [**v1 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v1-migration.md).
 
 ### Example code


### PR DESCRIPTION
## Problem
An issue was filed calling out the broken **Reference Documentation** link in the `README.md` file: https://github.com/pinecone-io/pinecone-ts-client/issues/149

We recently updated our domain for hosting client reference docs: https://github.com/pinecone-io/pinecone-ts-client/pull/146

## Solution

Update the link to the new location and match previous routing: https://sdk.pinecone.io/typescript/classes/Pinecone.html

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Non-code change (docs, etc)

## Test Plan
Check that the **Reference Documentation** link in `README.md` navigates to the correct page.
