### PR TITLE
Add @spruce release to user-agent

### DIFF
--- a/.github/workflows/release-spruce-dev.yml
+++ b/.github/workflows/release-spruce-dev.yml
@@ -34,10 +34,11 @@ jobs:
           currentVersion=$(jq -r '.version' package.json)
           timestamp=$(date +%Y%m%d%H%M%S)
           devVersion="$currentVersion-spruceDev.$timestamp"
+          release="@spruceDev"
           jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
           jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
           jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
-          jq --null-input --arg version "$devVersion" '{"name": "@pinecone-database/pinecone", "version": $version}' > src/version.json
+          jq --null-input --arg version "$devVersion" --arg release "$release" '{"name": "@pinecone-database/pinecone", "version": $version, "release": $release}' > src/version.json
 
       - name: 'Publish to npm'
         run: npm publish --tag spruceDev

--- a/.github/workflows/release-spruce-dev.yml
+++ b/.github/workflows/release-spruce-dev.yml
@@ -34,11 +34,10 @@ jobs:
           currentVersion=$(jq -r '.version' package.json)
           timestamp=$(date +%Y%m%d%H%M%S)
           devVersion="$currentVersion-spruceDev.$timestamp"
-          release="@spruceDev"
           jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
           jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
           jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
-          jq --null-input --arg version "$devVersion" --arg release "$release" '{"name": "@pinecone-database/pinecone", "version": $version, "release": $release}' > src/version.json
+          jq --null-input --arg version "$devVersion" --arg release "@spruce" '{"name": "@pinecone-database/pinecone", "version": $version, "release": $release}' > src/version.json
 
       - name: 'Publish to npm'
         run: npm publish --tag spruceDev

--- a/.github/workflows/release-spruce.yml
+++ b/.github/workflows/release-spruce.yml
@@ -22,11 +22,10 @@ jobs:
           currentVersion=$(jq -r '.version' package.json)
           timestamp=$(date +%Y%m%d%H%M%S)
           devVersion="$currentVersion-spruce.$timestamp"
-          release="@spruce"
           jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
           jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
           jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
-          jq --null-input --arg version "$devVersion" --arg release "$release" '{"name": "@pinecone-database/pinecone", "version": $version, "release": $release}' > src/version.json
+          jq --null-input --arg version "$devVersion" --arg release "@spruce" '{"name": "@pinecone-database/pinecone", "version": $version, "release": $release}' > src/version.json
 
       - name: 'Publish to npm'
         run: npm publish --tag spruce

--- a/.github/workflows/release-spruce.yml
+++ b/.github/workflows/release-spruce.yml
@@ -22,10 +22,11 @@ jobs:
           currentVersion=$(jq -r '.version' package.json)
           timestamp=$(date +%Y%m%d%H%M%S)
           devVersion="$currentVersion-spruce.$timestamp"
+          release="@spruce"
           jq --arg newVersion "$devVersion" '.version = $newVersion' package.json > package.tmp && mv package.tmp package.json
           jq --arg newVersion "$devVersion" '.version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
           jq --arg newVersion "$devVersion" '.packages[""].version = $newVersion' package-lock.json > package-lock.tmp && mv package-lock.tmp package-lock.json
-          jq --null-input --arg version "$devVersion" '{"name": "@pinecone-database/pinecone", "version": $version}' > src/version.json
+          jq --null-input --arg version "$devVersion" --arg release "$release" '{"name": "@pinecone-database/pinecone", "version": $version, "release": $release}' > src/version.json
 
       - name: 'Publish to npm'
         run: npm publish --tag spruce

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -10,15 +10,9 @@ export const buildUserAgent = (isLegacy: boolean) => {
     'lang=typescript',
   ];
 
-  // If there is a PINECONE_RELEASE_VERSION environment variable
-  // set append to the user agent
-  if (
-    typeof process !== 'undefined' &&
-    process &&
-    process.env &&
-    process.env.PINECONE_RELEASE_VERSION
-  ) {
-    userAgentParts.push(`release=${process.env.PINECONE_RELEASE_VERSION}`);
+  // If there's a release in packageInfo, append to the user agent
+  if (packageInfo.release && packageInfo.release !== '') {
+    userAgentParts.push(`release=${packageInfo.release}`);
   }
 
   if (isEdge()) {

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -10,9 +10,15 @@ export const buildUserAgent = (isLegacy: boolean) => {
     'lang=typescript',
   ];
 
-  // If the @spruce release is in use, add that to the user agent
-  if (packageInfo.release) {
-    userAgentParts.push(`release=${packageInfo.release}`);
+  // If there is a PINECONE_RELEASE_VERSION environment variable
+  // set append to the user agent
+  if (
+    typeof process !== 'undefined' &&
+    process &&
+    process.env &&
+    process.env.PINECONE_RELEASE_VERSION
+  ) {
+    userAgentParts.push(`release=${process.env.PINECONE_RELEASE_VERSION}`);
   }
 
   if (isEdge()) {

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -10,6 +10,11 @@ export const buildUserAgent = (isLegacy: boolean) => {
     'lang=typescript',
   ];
 
+  // If the @spruce release is in use, add that to the user agent
+  if (packageInfo.release) {
+    userAgentParts.push(`release=${packageInfo.release}`);
+  }
+
   if (isEdge()) {
     userAgentParts.push('Edge Runtime');
   }

--- a/src/version.json
+++ b/src/version.json
@@ -1,4 +1,5 @@
 {
   "name": "@pinecone-database/pinecone",
-  "version": "1.1.2"
+  "version": "1.1.2",
+  "release": "@spruce"
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,4 +1,5 @@
 {
   "name": "@pinecone-database/pinecone",
-  "version": "1.1.2"
+  "version": "1.1.2",
+  "release": ""
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,4 @@
 {
   "name": "@pinecone-database/pinecone",
-  "version": "1.1.2",
-  "release": "@spruce"
+  "version": "1.1.2"
 }


### PR DESCRIPTION
_This revision is dependent on a previous branches / PRs. These will need to be reviewed and merged first:_ 
- https://github.com/pinecone-io/pinecone-ts-client/pull/153
- https://github.com/pinecone-io/pinecone-ts-client/pull/154

## Problem
We want to be able to track usage specific to the spruce release of the client.

## Solution
- Update `buildUserAgent` logic to check for `packageInfo.release`, and append to the user agent if present.
- Update `release-spruce-dev` and `release-spruce` workflows to add `@spruce` to `version.json` during these specific releases.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Test Plan
We will need to release through either the `release-spruce` or `release-spruce-dev` workflows and validate the `version.json` file has the proper info, and the `release` is appended to the user agent header.
