### PR TITLE
[spruce] Add a custom override for Index host

### DIFF
--- a/src/data/__tests__/vectorOperationsProvider.test.ts
+++ b/src/data/__tests__/vectorOperationsProvider.test.ts
@@ -45,13 +45,20 @@ describe('VectorOperationsProvider', () => {
       apiKey: 'test-api-key',
     };
     const indexHostUrl = 'http://index-host-url';
-    const provider = new VectorOperationsProvider(config, 'index-name', indexHostUrl);
+    const provider = new VectorOperationsProvider(
+      config,
+      'index-name',
+      indexHostUrl
+    );
 
     jest.spyOn(provider, 'buildVectorOperationsConfig');
 
     await provider.provide();
-    
+
     expect(IndexHostSingleton.getHostUrl).not.toHaveBeenCalled();
-    expect(provider.buildVectorOperationsConfig).toHaveBeenCalledWith({...config, hostUrl: indexHostUrl});
+    expect(provider.buildVectorOperationsConfig).toHaveBeenCalledWith({
+      ...config,
+      hostUrl: indexHostUrl,
+    });
   });
 });

--- a/src/data/__tests__/vectorOperationsProvider.test.ts
+++ b/src/data/__tests__/vectorOperationsProvider.test.ts
@@ -39,4 +39,19 @@ describe('VectorOperationsProvider', () => {
     expect(IndexHostSingleton.getHostUrl).toHaveBeenCalledTimes(1);
     expect(api).toEqual(api2);
   });
+
+  test('passing indexHostUrl skips hostUrl resolution', async () => {
+    const config = {
+      apiKey: 'test-api-key',
+    };
+    const indexHostUrl = 'http://index-host-url';
+    const provider = new VectorOperationsProvider(config, 'index-name', indexHostUrl);
+
+    jest.spyOn(provider, 'buildVectorOperationsConfig');
+
+    await provider.provide();
+    
+    expect(IndexHostSingleton.getHostUrl).not.toHaveBeenCalled();
+    expect(provider.buildVectorOperationsConfig).toHaveBeenCalledWith({...config, hostUrl: indexHostUrl});
+  });
 });

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -123,6 +123,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
 
     /** The namespace where operations will be performed. If not set, the default namespace of `''` will be used. */
     namespace: string;
+
+    /** An optional host address override for data operations. */
+    hostUrlOverride?: string;
   };
 
   /**
@@ -255,19 +258,26 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @param indexName - The name of the index that will receive operations from this {@link Index} instance.
    * @param config - The configuration from the Pinecone client.
    * @param namespace - The namespace for the index.
+   * @param hostUrlOverride - An optional override for the host address used for data operations.
    */
   constructor(
     indexName: string,
     config: PineconeConfiguration,
-    namespace = ''
+    namespace = '',
+    hostUrlOverride?: string
   ) {
     this.config = config;
     this.target = {
       index: indexName,
       namespace: namespace,
+      hostUrlOverride: hostUrlOverride,
     };
 
-    const apiProvider = new VectorOperationsProvider(config, indexName);
+    const apiProvider = new VectorOperationsProvider(
+      config,
+      indexName,
+      hostUrlOverride
+    );
 
     this._deleteAll = deleteAll(apiProvider, namespace);
     this._deleteMany = deleteMany(apiProvider, namespace);

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -125,7 +125,7 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
     namespace: string;
 
     /** An optional host address override for data operations. */
-    hostUrlOverride?: string;
+    indexHostUrl?: string;
   };
 
   /**
@@ -258,25 +258,25 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @param indexName - The name of the index that will receive operations from this {@link Index} instance.
    * @param config - The configuration from the Pinecone client.
    * @param namespace - The namespace for the index.
-   * @param hostUrlOverride - An optional override for the host address used for data operations.
+   * @param indexHostUrl - An optional override for the host address used for data operations.
    */
   constructor(
     indexName: string,
     config: PineconeConfiguration,
     namespace = '',
-    hostUrlOverride?: string
+    indexHostUrl?: string
   ) {
     this.config = config;
     this.target = {
       index: indexName,
       namespace: namespace,
-      hostUrlOverride: hostUrlOverride,
+      indexHostUrl: indexHostUrl,
     };
 
     const apiProvider = new VectorOperationsProvider(
       config,
       indexName,
-      hostUrlOverride
+      indexHostUrl
     );
 
     this._deleteAll = deleteAll(apiProvider, namespace);

--- a/src/data/vectorOperationsProvider.ts
+++ b/src/data/vectorOperationsProvider.ts
@@ -1,4 +1,4 @@
-import type { IndexConfiguration } from './types';
+import type { IndexConfiguration, PineconeConfiguration } from './types';
 import {
   Configuration,
   ConfigurationParameters,
@@ -12,28 +12,26 @@ export class VectorOperationsProvider {
   private config: IndexConfiguration;
   private indexName: string;
   private vectorOperations?: VectorOperationsApi;
-  private hostUrlOverride?: string;
 
   constructor(
-    config: IndexConfiguration,
+    config: PineconeConfiguration,
     indexName: string,
-    hostUrlOverride?: string
+    indexHostUrl?: string
   ) {
     this.config = config;
     this.indexName = indexName;
-    this.hostUrlOverride = hostUrlOverride;
+
+    // If an indexHostUrl has been passed set it, otherwise keep
+    // it undefined so that hostUrl is properly resolved
+    if (indexHostUrl) {
+      this.config.hostUrl = indexHostUrl; 
+    }
   }
 
   async provide() {
     if (this.vectorOperations) {
       return this.vectorOperations;
     }
-
-    // if an override has been passed set it, otherwise clear things
-    // out so that hostUrl is properly resolved
-    this.config.hostUrl = this.hostUrlOverride
-      ? this.hostUrlOverride
-      : undefined;
 
     if (this.config.hostUrl) {
       this.vectorOperations = this.buildVectorOperationsConfig(this.config);

--- a/src/data/vectorOperationsProvider.ts
+++ b/src/data/vectorOperationsProvider.ts
@@ -12,10 +12,16 @@ export class VectorOperationsProvider {
   private config: IndexConfiguration;
   private indexName: string;
   private vectorOperations?: VectorOperationsApi;
+  private hostUrlOverride?: string;
 
-  constructor(config: IndexConfiguration, indexName: string) {
+  constructor(
+    config: IndexConfiguration,
+    indexName: string,
+    hostUrlOverride?: string
+  ) {
     this.config = config;
     this.indexName = indexName;
+    this.hostUrlOverride = hostUrlOverride;
   }
 
   async provide() {
@@ -24,6 +30,9 @@ export class VectorOperationsProvider {
     }
 
     if (this.config.hostUrl) {
+      this.vectorOperations = this.buildVectorOperationsConfig(this.config);
+    } else if (this.hostUrlOverride) {
+      this.config.hostUrl = this.hostUrlOverride;
       this.vectorOperations = this.buildVectorOperationsConfig(this.config);
     } else {
       this.config.hostUrl = await IndexHostSingleton.getHostUrl(

--- a/src/data/vectorOperationsProvider.ts
+++ b/src/data/vectorOperationsProvider.ts
@@ -29,10 +29,13 @@ export class VectorOperationsProvider {
       return this.vectorOperations;
     }
 
+    // if an override has been passed set it, otherwise clear things
+    // out so that hostUrl is properly resolved
+    this.config.hostUrl = this.hostUrlOverride
+      ? this.hostUrlOverride
+      : undefined;
+
     if (this.config.hostUrl) {
-      this.vectorOperations = this.buildVectorOperationsConfig(this.config);
-    } else if (this.hostUrlOverride) {
-      this.config.hostUrl = this.hostUrlOverride;
       this.vectorOperations = this.buildVectorOperationsConfig(this.config);
     } else {
       this.config.hostUrl = await IndexHostSingleton.getHostUrl(

--- a/src/data/vectorOperationsProvider.ts
+++ b/src/data/vectorOperationsProvider.ts
@@ -24,7 +24,7 @@ export class VectorOperationsProvider {
     // If an indexHostUrl has been passed set it, otherwise keep
     // it undefined so that hostUrl is properly resolved
     if (indexHostUrl) {
-      this.config.hostUrl = indexHostUrl; 
+      this.config.hostUrl = indexHostUrl;
     }
   }
 

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -496,9 +496,9 @@ export class Pinecone {
    */
   index<T extends RecordMetadata = RecordMetadata>(
     indexName: string,
-    hostUrlOverride?: string
+    indexHostUrl?: string
   ) {
-    return new Index<T>(indexName, this.config, undefined, hostUrlOverride);
+    return new Index<T>(indexName, this.config, undefined, indexHostUrl);
   }
 
   /**
@@ -507,8 +507,8 @@ export class Pinecone {
   // Alias method to match the Python SDK capitalization
   Index<T extends RecordMetadata = RecordMetadata>(
     indexName: string,
-    hostUrlOverride?: string
+    indexHostUrl?: string
   ) {
-    return this.index<T>(indexName, hostUrlOverride);
+    return this.index<T>(indexName, indexHostUrl);
   }
 }

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -494,15 +494,21 @@ export class Pinecone {
    * @typeParam T - The type of the metadata object associated with each record.
    * @returns An {@link Index} object that can be used to perform data operations.
    */
-  index<T extends RecordMetadata = RecordMetadata>(indexName: string) {
-    return new Index<T>(indexName, this.config);
+  index<T extends RecordMetadata = RecordMetadata>(
+    indexName: string,
+    hostUrlOverride?: string
+  ) {
+    return new Index<T>(indexName, this.config, undefined, hostUrlOverride);
   }
 
   /**
    * {@inheritDoc index}
    */
   // Alias method to match the Python SDK capitalization
-  Index<T extends RecordMetadata = RecordMetadata>(indexName: string) {
-    return this.index<T>(indexName);
+  Index<T extends RecordMetadata = RecordMetadata>(
+    indexName: string,
+    hostUrlOverride?: string
+  ) {
+    return this.index<T>(indexName, hostUrlOverride);
   }
 }


### PR DESCRIPTION
## Problem
There are instances where we may want to provide a custom data plane host instead of relying on what we get back from `describeIndex`. This would possibly be useful in specific instances like integration tests or testing against staged environments.

## Solution
- Update `Index` and `VectorOperationsProvider` constructors to thread through an optional `indexHostUrl` value.
- In the `VectorOperationsProvider` constructor, check to see if we have a `indexHostUrl` and apply it to `hostUrl` if so, otherwise we let the standard flow resolve the `hostUrl`.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Test Plan
Pull this PR / branch down and use the repl to test passing a custom `indexHostUrl` through the `Index` constructor. This should fail unless you're providing a proper index host.

```
$ npm run repl
$ await init()

$ await client.index('my-index', 'https://my-custom-override.io').describeIndexStats()

// Uncaught:
// PineconeConnectionError: Request failed to reach Pinecone. This can occur for reasons such as incorrect configuration (environment, project id, index name), network problems that prevent the request from being completed, or a Pinecone API outage. Check your client configuration, check your network connection, and visit https://status.pinecone.io/ to see whether any outages are ongoing.
//     at /Users/austin/workspace/pinecone-ts-client/dist/errors/handling.js:77:43
//     at step (/Users/austin/workspace/pinecone-ts-client/dist/errors/handling.js:33:23)
//     at Object.next (/Users/austin/workspace/pinecone-ts-client/dist/errors/handling.js:14:53)
//     at /Users/austin/workspace/pinecone-ts-client/dist/errors/handling.js:8:71
//     at new Promise (<anonymous>)
//     at __awaiter (/Users/austin/workspace/pinecone-ts-client/dist/errors/handling.js:4:12)
//     at handleApiError (/Users/austin/workspace/pinecone-ts-client/dist/errors/handling.js:44:59)
//     at /Users/austin/workspace/pinecone-ts-client/dist/utils/middleware.js:138:78
//     at step (/Users/austin/workspace/pinecone-ts-client/dist/utils/middleware.js:33:23) {
//   cause: TypeError: fetch failed
//       at Object.fetch (node:internal/deps/undici/undici:11576:11)
//       at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
//     cause: Error: getaddrinfo ENOTFOUND my-custom-override.io
//         at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:108:26)
//         at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17) {
//       errno: -3008,
//       code: 'ENOTFOUND',
//       syscall: 'getaddrinfo',
//       hostname: 'my-custom-override.io'
//     }
//   }
// }
```
