### PR TITLE
Guard against empty hostUrl values in IndexHostSingleton cache

### DIFF
--- a/src/data/__tests__/indexHostSingleton.test.ts
+++ b/src/data/__tests__/indexHostSingleton.test.ts
@@ -1,3 +1,4 @@
+import { PineconeUnableToResolveHostError } from '../../errors';
 import { IndexHostSingleton } from '../indexHostSingleton';
 
 const mockDescribeIndex = jest.fn();
@@ -136,5 +137,18 @@ describe('IndexHostSingleton', () => {
     );
     expect(mockDescribeIndex).toHaveBeenCalledTimes(1);
     expect(host2).toBe('https://test-host');
+  });
+
+  test('_set throws an error if hostUrl is empty', async () => {
+    const pineconeConfig = { apiKey: 'test-key' };
+    try {
+      IndexHostSingleton._set(pineconeConfig, 'test-index', '');
+    } catch (e) {
+      const err = e as PineconeUnableToResolveHostError;
+      expect(err.name).toEqual('PineconeUnableToResolveHostError');
+      expect(err.message).toEqual(
+        'An invalid host URL was encountered. Please make sure the index exists and is in a ready state.'
+      );
+    }
   });
 });

--- a/src/data/indexHostSingleton.ts
+++ b/src/data/indexHostSingleton.ts
@@ -66,9 +66,7 @@ export const IndexHostSingleton = (function () {
     ) => {
       // prevent adding an empty hostUrl to the cache
       if (hostUrl === '') {
-        throw new PineconeUnableToResolveHostError(
-          'An invalid host URL was encountered. Please make sure the index exists and is in a ready state.'
-        );
+        return;
       }
 
       const cacheKey = key(config, indexName);

--- a/src/data/indexHostSingleton.ts
+++ b/src/data/indexHostSingleton.ts
@@ -1,5 +1,6 @@
 import { IndexOperationsApi } from '../pinecone-generated-ts-fetch';
 import type { PineconeConfiguration } from './types';
+import type { IndexName } from '../control';
 import { describeIndex, indexOperationsBuilder } from '../control';
 import { PineconeUnableToResolveHostError } from '../errors';
 
@@ -12,7 +13,7 @@ export const IndexHostSingleton = (function () {
 
   const _describeIndex = async (
     config: PineconeConfiguration,
-    indexName: string
+    indexName: IndexName
   ): Promise<string> => {
     if (!indexOperationsApi) {
       indexOperationsApi = indexOperationsBuilder(config);
@@ -40,7 +41,7 @@ export const IndexHostSingleton = (function () {
   return {
     getHostUrl: async function (
       config: PineconeConfiguration,
-      indexName: string
+      indexName: IndexName
     ) {
       const cacheKey = key(config, indexName);
       if (cacheKey in hostUrls) {
@@ -58,12 +59,23 @@ export const IndexHostSingleton = (function () {
       }
     },
 
-    _set: (config, indexName, hostUrl) => {
+    _set: (
+      config: PineconeConfiguration,
+      indexName: IndexName,
+      hostUrl: string
+    ) => {
+      // prevent adding an empty hostUrl to the cache
+      if (hostUrl === '') {
+        throw new PineconeUnableToResolveHostError(
+          'An invalid host URL was encountered. Please make sure the index exists and is in a ready state.'
+        );
+      }
+
       const cacheKey = key(config, indexName);
       hostUrls[cacheKey] = hostUrl;
     },
 
-    _delete: (config, indexName) => {
+    _delete: (config: PineconeConfiguration, indexName: IndexName) => {
       const cacheKey = key(config, indexName);
       delete hostUrls[cacheKey];
     },


### PR DESCRIPTION
## Problem
We use `indexHostSingleton` to cache API keys and index `host` addresses to avoid excessive `describeIndex` calls for determining an indexes address. Currently, `IndexHostSingleton._set()` is able to push an empty `''` `host` value into the cache. 

If an index is created and described quickly, this could lead to a situation where `host` is empty, which would break subsequent client calls to that index.

## Solution
Guard against empty `host` values being passed to the cache.

- Throw a `PineconeUnableToResolveHostError` inside `_set` in the event of an empty `hostUrl`
- Add unit test

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan
This one is tricky to test as you'd need a scenario where you call `client.CreateIndex({ ... })` followed quickly by `client.describeIndex('index')` before `host` is established. For now, testing that the client works as expected should be sufficient.
