### PR TITLE
[spruce] Update IndexHostSingleton with responses from listIndexes

### DIFF
--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -22,17 +22,44 @@ jest.mock('../control', () => {
   return {
     ...realControl,
     describeIndex: () =>
-      jest.fn().mockImplementation(() =>
-        Promise.resolve({
-          name: 'fake-index',
-          dimension: 1,
-          metric: 'cosine',
-          host: fakeHost,
-          spec: { serverless: { cloud: 'aws', region: 'us-east-1' } },
-          status: { ready: true, state: 'Ready' },
-        })
-      ),
-    deleteIndex: () => jest.fn().mockImplementation(() => Promise.resolve()),
+      jest.fn().mockResolvedValue({
+        name: 'fake-index',
+        dimension: 1,
+        metric: 'cosine',
+        host: fakeHost,
+        spec: { serverless: { cloud: 'aws', region: 'us-east-1' } },
+        status: { ready: true, state: 'Ready' },
+      }),
+    deleteIndex: () => jest.fn().mockResolvedValue(undefined),
+    listIndexes: () =>
+      jest.fn().mockResolvedValue({
+        indexes: [
+          {
+            name: 'fake-index1',
+            dimension: 1,
+            metric: 'cosine',
+            host: fakeHost,
+            spec: { serverless: { cloud: 'aws', region: 'us-east-1' } },
+            status: { ready: true, state: 'Ready' },
+          },
+          {
+            name: 'fake-index2',
+            dimension: 1,
+            metric: 'cosine',
+            host: fakeHost,
+            spec: { serverless: { cloud: 'aws', region: 'us-east-1' } },
+            status: { ready: true, state: 'Ready' },
+          },
+          {
+            name: 'fake-index3',
+            dimension: 1,
+            metric: 'cosine',
+            host: fakeHost,
+            spec: { serverless: { cloud: 'aws', region: 'us-east-1' } },
+            status: { ready: true, state: 'Ready' },
+          },
+        ],
+      }),
   };
 });
 
@@ -163,6 +190,30 @@ describe('Pinecone', () => {
       expect(IndexHostSingleton._set).toHaveBeenCalledWith(
         { apiKey: 'foo' },
         'test-index',
+        fakeHost
+      );
+    });
+
+    test('listIndexes triggers calling IndexHostSingleton._set', async () => {
+      const p = new Pinecone({ apiKey: 'foo' });
+      await p.listIndexes();
+
+      expect(IndexHostSingleton._set).toHaveBeenNthCalledWith(
+        1,
+        { apiKey: 'foo' },
+        'fake-index1',
+        fakeHost
+      );
+      expect(IndexHostSingleton._set).toHaveBeenNthCalledWith(
+        2,
+        { apiKey: 'foo' },
+        'fake-index2',
+        fakeHost
+      );
+      expect(IndexHostSingleton._set).toHaveBeenNthCalledWith(
+        3,
+        { apiKey: 'foo' },
+        'fake-index3',
         fakeHost
       );
     });

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -224,8 +224,19 @@ export class Pinecone {
    *
    * @returns A promise that resolves to an array of index names
    */
-  listIndexes() {
-    return this._listIndexes();
+  async listIndexes() {
+    const indexList = await this._listIndexes();
+
+    // For any listIndexes calls we want to update the IndexHostSingleton cache.
+    // This prevents unneeded calls to describeIndex for resolving the host for vector operations.
+    if (indexList.indexes && indexList.indexes.length > 0) {
+      for (let i = 0; i < indexList.indexes.length; i++) {
+        const index = indexList.indexes[i];
+        IndexHostSingleton._set(this.config, index.name, index.host);
+      }
+    }
+
+    return Promise.resolve(indexList);
   }
 
   /**


### PR DESCRIPTION
## Problem
We currently use calls to `describeIndex` and `deleteIndex` to interact with the `IndexHostSingleton` cache proactively. This allows bypassing the need for the singleton to call `describeIndex` to retrieve the host for data plane operations. We should be able to do the same thing with `listIndexes` now that the response includes the full `IndexModel`.

## Solution

- Update `listIndexes` in the `Pinecone` class to call `IndexHostSingleton._set(...)` for indexes that are listed.
- Add new unit test to cover behavior.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Test Plan
The new unit test should cover making sure we're calling `IndexHostSingleton._set()` for `listIndexes` responses.

You can also pull this down and run locally by adding a `console.log()` in `IndexHostSingleton._set()` to check the `hostUrls` map. You can use the `PINECONE_DEBUG` and `PINECONE_DEBUG_CURL` environment variables to verify that calling `listIndexes()` before making dataplane operations results in no unnecessary calls to `describeIndex` by the cache.
