### PR TITLE
[spruce] Update data plane integration tests

### DIFF
--- a/src/data/deleteOne.ts
+++ b/src/data/deleteOne.ts
@@ -16,7 +16,7 @@ export const deleteOne = (
 ) => {
   const validator = buildConfigValidator(RecordIdSchema, 'deleteOne');
 
-  return async (options: RecordId): Promise<void> => {
+  return async (options: DeleteOneOptions): Promise<void> => {
     validator(options);
 
     const api = await apiProvider.provide();

--- a/src/integration/data/delete.test.ts
+++ b/src/integration/data/delete.test.ts
@@ -1,10 +1,18 @@
 import { Pinecone, Index } from '../../index';
-import { randomString, generateRecords } from '../test-helpers';
+import {
+  randomString,
+  generateRecords,
+  INDEX_NAME,
+  sleep,
+  waitUntilRecordsReady,
+} from '../test-helpers';
 
-// TODO: Un-skip when freshness layer is ready
-describe.skip('deleteMany', () => {
-  const INDEX_NAME = 'ts-integration';
-  let pinecone: Pinecone, index: Index, ns: Index, namespace: string;
+describe('delete', () => {
+  let pinecone: Pinecone,
+    index: Index,
+    ns: Index,
+    namespace: string,
+    recordIds: string[];
 
   beforeEach(async () => {
     pinecone = new Pinecone();
@@ -14,12 +22,9 @@ describe.skip('deleteMany', () => {
       dimension: 5,
       metric: 'cosine',
       spec: {
-        pod: {
-          environment: 'us-west1-gcp',
-          replicas: 1,
-          shards: 1,
-          podType: 'p1.x1',
-          pods: 1,
+        serverless: {
+          region: 'us-west-2',
+          cloud: 'aws',
         },
       },
       waitUntilReady: true,
@@ -32,12 +37,56 @@ describe.skip('deleteMany', () => {
   });
 
   afterAll(async () => {
-    await pinecone.listIndexes();
-    await ns.deleteAll();
+    await ns.deleteMany(recordIds);
   });
 
-  test.skip('verify deleteMany with ids', async () => {
+  test('verify delete with id', async () => {
+    const recordToUpsert = generateRecords(5, 1);
+    recordIds = recordToUpsert.map((r) => r.id);
+    expect(recordToUpsert).toHaveLength(1);
+    expect(recordToUpsert[0].id).toEqual(recordIds[0]);
+
+    await ns.upsert(recordToUpsert);
+
+    // Await record freshness, and check record upserted
+    let stats = await waitUntilRecordsReady(ns, namespace, recordIds);
+    if (stats.namespaces) {
+      expect(stats.namespaces[namespace].recordCount).toEqual(1);
+    } else {
+      fail('Expected namespaces to be defined');
+    }
+
+    // Look more closely at one of the records to make sure values set
+    const fetchResult = await ns.fetch(['0']);
+    const records = fetchResult.records;
+    if (records) {
+      expect(records['0'].id).toEqual('0');
+      expect(records['0'].values.length).toEqual(5);
+    } else {
+      fail(
+        'Did not find expected records. Fetch result was ' +
+          JSON.stringify(fetchResult)
+      );
+    }
+
+    // Try deleting the record
+    await ns.deleteOne('0');
+    await sleep(1000);
+
+    // Verify the record is removed
+    stats = await ns.describeIndexStats();
+    if (stats.namespaces) {
+      expect(stats.namespaces[namespace]).toBeUndefined();
+    } else {
+      // no-op. This shouldn't actually happen unless there
+      // are leftover namespaces from previous runs that
+      // failed or stopped without proper cleanup.
+    }
+  });
+
+  test('verify deleteMany with ids', async () => {
     const recordsToUpsert = generateRecords(5, 3);
+    recordIds = recordsToUpsert.map((r) => r.id);
     expect(recordsToUpsert).toHaveLength(3);
     expect(recordsToUpsert[0].id).toEqual('0');
     expect(recordsToUpsert[1].id).toEqual('1');
@@ -45,8 +94,8 @@ describe.skip('deleteMany', () => {
 
     await ns.upsert(recordsToUpsert);
 
-    // Check records got upserted
-    let stats = await ns.describeIndexStats();
+    // Await record freshness, and check records upserted
+    let stats = await waitUntilRecordsReady(ns, namespace, recordIds);
     if (stats.namespaces) {
       expect(stats.namespaces[namespace].recordCount).toEqual(3);
     } else {
@@ -66,8 +115,9 @@ describe.skip('deleteMany', () => {
       );
     }
 
-    // Try deleting 2 of 3 vectors
+    // Try deleting 2 of 3 records
     await ns.deleteMany(['0', '2']);
+    await sleep(1000);
     stats = await ns.describeIndexStats();
     if (stats.namespaces) {
       expect(stats.namespaces[namespace].recordCount).toEqual(1);
@@ -90,15 +140,16 @@ describe.skip('deleteMany', () => {
       );
     }
 
-    // deleting non-existent indexes should not throw
+    // deleting non-existent records should not throw
     await ns.deleteMany(['0', '1', '2', '3']);
+    await sleep(1000);
 
     // Verify all are now removed
     stats = await ns.describeIndexStats();
     if (stats.namespaces) {
       expect(stats.namespaces[namespace]).toBeUndefined();
     } else {
-      // no-op. This should actually happen unless there
+      // no-op. This shouldn't actually happen unless there
       // are leftover namespaces from previous runs that
       // failed or stopped without proper cleanup.
     }

--- a/src/integration/data/fetch.test.ts
+++ b/src/integration/data/fetch.test.ts
@@ -1,0 +1,59 @@
+import { Pinecone, Index } from '../../index';
+import {
+  generateRecords,
+  randomString,
+  INDEX_NAME,
+  waitUntilRecordsReady,
+} from '../test-helpers';
+
+describe('fetch', () => {
+  let pinecone: Pinecone,
+    index: Index,
+    ns: Index,
+    namespace: string,
+    recordIds: string[];
+
+  beforeEach(async () => {
+    pinecone = new Pinecone();
+
+    await pinecone.createIndex({
+      name: INDEX_NAME,
+      dimension: 5,
+      metric: 'cosine',
+      spec: {
+        serverless: {
+          region: 'us-west-2',
+          cloud: 'aws',
+        },
+      },
+      waitUntilReady: true,
+      suppressConflicts: true,
+    });
+
+    namespace = randomString(16);
+    index = pinecone.index(INDEX_NAME);
+    ns = index.namespace(namespace);
+    recordIds = [];
+  });
+
+  afterEach(async () => {
+    await ns.deleteMany(recordIds);
+  });
+
+  test('fetch by id', async () => {
+    const recordsToUpsert = generateRecords(5, 3);
+    recordIds = recordsToUpsert.map((r) => r.id);
+    expect(recordsToUpsert).toHaveLength(3);
+    expect(recordsToUpsert[0].id).toEqual('0');
+    expect(recordsToUpsert[1].id).toEqual('1');
+    expect(recordsToUpsert[2].id).toEqual('2');
+
+    await ns.upsert(recordsToUpsert);
+    await waitUntilRecordsReady(ns, namespace, recordIds);
+
+    const results = await ns.fetch(['0', '1', '2']);
+    expect(results.records['0']).toBeDefined();
+    expect(results.records['1']).toBeDefined();
+    expect(results.records['2']).toBeDefined();
+  });
+});

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -50,7 +50,7 @@ describe('query', () => {
 
     await ns.upsert(recordsToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
-    sleep(2000);
+    await sleep(1500);
     const topK = 2;
     const results = await ns.query({ id: '0', topK });
     expect(results.matches).toBeDefined();
@@ -69,7 +69,7 @@ describe('query', () => {
 
     await ns.upsert(recordsToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
-    sleep(2000);
+    await sleep(1500);
     const topK = 5;
     const results = await ns.query({ id: '0', topK });
     console.log('Query Results: ', results);
@@ -107,7 +107,7 @@ describe('query', () => {
 
     await ns.upsert(recordsToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
-    sleep(2000);
+    await sleep(1500);
     const topK = 1;
     const results = await ns.query({
       vector: [0.11, 0.22, 0.33, 0.44, 0.55],

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -50,7 +50,7 @@ describe('query', () => {
 
     await ns.upsert(recordsToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
-    await sleep(1500);
+    // await sleep(1500);
     const topK = 2;
     const results = await ns.query({ id: '0', topK });
     expect(results.matches).toBeDefined();
@@ -69,7 +69,7 @@ describe('query', () => {
 
     await ns.upsert(recordsToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
-    await sleep(1500);
+    // await sleep(1500);
     const topK = 5;
     const results = await ns.query({ id: '0', topK });
     console.log('Query Results: ', results);
@@ -107,7 +107,7 @@ describe('query', () => {
 
     await ns.upsert(recordsToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
-    await sleep(1500);
+    // await sleep(1500);
     const topK = 1;
     const results = await ns.query({
       vector: [0.11, 0.22, 0.33, 0.44, 0.55],

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -1,10 +1,18 @@
 import { Pinecone, Index } from '../../index';
-import { randomString, generateRecords } from '../test-helpers';
+import {
+  randomString,
+  generateRecords,
+  INDEX_NAME,
+  sleep,
+  waitUntilRecordsReady,
+} from '../test-helpers';
 
-// TODO: Un-skip when freshness layer is ready
-describe.skip('query', () => {
-  const INDEX_NAME = 'ts-integration';
-  let pinecone: Pinecone, index: Index, ns: Index, namespace: string;
+describe('query', () => {
+  let pinecone: Pinecone,
+    index: Index,
+    ns: Index,
+    namespace: string,
+    recordIds: string[];
 
   beforeEach(async () => {
     pinecone = new Pinecone();
@@ -14,12 +22,9 @@ describe.skip('query', () => {
       dimension: 5,
       metric: 'cosine',
       spec: {
-        pod: {
-          environment: 'us-west1-gcp',
-          replicas: 1,
-          shards: 1,
-          podType: 'p1.x1',
-          pods: 1,
+        serverless: {
+          region: 'us-west-2',
+          cloud: 'aws',
         },
       },
       waitUntilReady: true,
@@ -32,21 +37,20 @@ describe.skip('query', () => {
   });
 
   afterEach(async () => {
-    await ns.deleteAll();
+    await ns.deleteMany(recordIds);
   });
 
-  test.skip('query by id', async () => {
+  test('query by id', async () => {
     const recordsToUpsert = generateRecords(5, 3);
+    recordIds = recordsToUpsert.map((r) => r.id);
     expect(recordsToUpsert).toHaveLength(3);
-
-    // These assertions are just to show what ids were
-    // used in the generated records
     expect(recordsToUpsert[0].id).toEqual('0');
     expect(recordsToUpsert[1].id).toEqual('1');
     expect(recordsToUpsert[2].id).toEqual('2');
 
     await ns.upsert(recordsToUpsert);
-
+    await waitUntilRecordsReady(ns, namespace, recordIds);
+    sleep(2000);
     const topK = 2;
     const results = await ns.query({ id: '0', topK });
     expect(results.matches).toBeDefined();
@@ -54,31 +58,36 @@ describe.skip('query', () => {
     expect(results.matches?.length).toEqual(topK);
   });
 
-  test.skip('query when topK is greater than number of records', async () => {
+  test('query when topK is greater than number of records', async () => {
     const numberOfRecords = 3;
     const recordsToUpsert = generateRecords(5, numberOfRecords);
+    recordIds = recordsToUpsert.map((r) => r.id);
     expect(recordsToUpsert).toHaveLength(3);
     expect(recordsToUpsert[0].id).toEqual('0');
     expect(recordsToUpsert[1].id).toEqual('1');
     expect(recordsToUpsert[2].id).toEqual('2');
 
     await ns.upsert(recordsToUpsert);
-
+    await waitUntilRecordsReady(ns, namespace, recordIds);
+    sleep(2000);
     const topK = 5;
     const results = await ns.query({ id: '0', topK });
+    console.log('Query Results: ', results);
     expect(results.matches).toBeDefined();
 
     expect(results.matches?.length).toEqual(numberOfRecords);
   });
 
-  test.skip('with invalid id, returns empty results', async () => {
+  test('with invalid id, returns empty results', async () => {
     const recordsToUpsert = generateRecords(5, 3);
+    recordIds = recordsToUpsert.map((r) => r.id);
     expect(recordsToUpsert).toHaveLength(3);
     expect(recordsToUpsert[0].id).toEqual('0');
     expect(recordsToUpsert[1].id).toEqual('1');
     expect(recordsToUpsert[2].id).toEqual('2');
 
     await ns.upsert(recordsToUpsert);
+    await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 2;
     const results = await ns.query({ id: '100', topK });
@@ -87,16 +96,18 @@ describe.skip('query', () => {
     expect(results.matches?.length).toEqual(0);
   });
 
-  test.skip('query with vector values', async () => {
+  test('query with vector values', async () => {
     const numberOfRecords = 3;
     const recordsToUpsert = generateRecords(5, numberOfRecords);
+    recordIds = recordsToUpsert.map((r) => r.id);
     expect(recordsToUpsert).toHaveLength(3);
     expect(recordsToUpsert[0].id).toEqual('0');
     expect(recordsToUpsert[1].id).toEqual('1');
     expect(recordsToUpsert[2].id).toEqual('2');
 
     await ns.upsert(recordsToUpsert);
-
+    await waitUntilRecordsReady(ns, namespace, recordIds);
+    sleep(2000);
     const topK = 1;
     const results = await ns.query({
       vector: [0.11, 0.22, 0.33, 0.44, 0.55],

--- a/src/integration/data/upsertAndUpdate.test.ts
+++ b/src/integration/data/upsertAndUpdate.test.ts
@@ -48,7 +48,7 @@ describe('upsert and update', () => {
 
     await ns.upsert(recordToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
-    await sleep(1500);
+    // await sleep(1500);
 
     // Fetch and inspect records to validate upsert
     const fetchResult = await ns.fetch(recordIds);
@@ -74,7 +74,7 @@ describe('upsert and update', () => {
       values: newValues,
       metadata: newMetadata,
     });
-    await sleep(1500);
+    await sleep(3000);
 
     // Fetch and validate update
     const updatedFetchResult = await ns.fetch(['0']);

--- a/src/integration/data/upsertAndUpdate.test.ts
+++ b/src/integration/data/upsertAndUpdate.test.ts
@@ -1,0 +1,95 @@
+import { Pinecone, Index } from '../../index';
+import {
+  randomString,
+  generateRecords,
+  INDEX_NAME,
+  sleep,
+  waitUntilRecordsReady,
+} from '../test-helpers';
+
+describe('upsert and update', () => {
+  let pinecone: Pinecone,
+    index: Index,
+    ns: Index,
+    namespace: string,
+    recordIds: string[];
+
+  beforeEach(async () => {
+    pinecone = new Pinecone();
+
+    await pinecone.createIndex({
+      name: INDEX_NAME,
+      dimension: 5,
+      metric: 'cosine',
+      spec: {
+        serverless: {
+          region: 'us-west-2',
+          cloud: 'aws',
+        },
+      },
+      waitUntilReady: true,
+      suppressConflicts: true,
+    });
+
+    namespace = randomString(16);
+    index = pinecone.index(INDEX_NAME);
+    ns = index.namespace(namespace);
+  });
+
+  afterEach(async () => {
+    await ns.deleteMany(recordIds);
+  });
+
+  test('verify upsert and update', async () => {
+    const recordToUpsert = generateRecords(5, 1, false, true);
+    recordIds = recordToUpsert.map((r) => r.id);
+    expect(recordToUpsert).toHaveLength(1);
+    expect(recordToUpsert[0].id).toEqual('0');
+
+    await ns.upsert(recordToUpsert);
+    await waitUntilRecordsReady(ns, namespace, recordIds);
+    await sleep(1500);
+
+    // Fetch and inspect records to validate upsert
+    const fetchResult = await ns.fetch(recordIds);
+    const records = fetchResult.records;
+    if (records) {
+      expect(records['0']).toBeDefined();
+      expect(records['0'].values).toEqual(recordToUpsert[0].values);
+      expect(records['0'].metadata).toEqual(recordToUpsert[0].metadata);
+    } else {
+      fail(
+        'Did not find expected records. Fetch result was ' +
+          JSON.stringify(fetchResult)
+      );
+    }
+
+    const oldMetadata = records['0'].metadata;
+
+    // Update record values
+    const newValues = [0.5, 0.4, 0.3, 0.2, 0.1];
+    const newMetadata = { flavor: 'chocolate' };
+    await ns.update({
+      id: '0',
+      values: newValues,
+      metadata: newMetadata,
+    });
+    await sleep(1500);
+
+    // Fetch and validate update
+    const updatedFetchResult = await ns.fetch(['0']);
+    if (Object.keys(updatedFetchResult.records).length > 0) {
+      const updatedRecord = updatedFetchResult.records['0'];
+      expect(updatedRecord.values).toEqual(newValues);
+      expect(updatedRecord.metadata).toEqual({
+        ...oldMetadata,
+        ...newMetadata,
+      });
+    } else {
+      fail(
+        'Did not find expected updated record. Fetch result was ' +
+          JSON.stringify(updatedFetchResult)
+      );
+    }
+  });
+});

--- a/src/integration/test-helpers.ts
+++ b/src/integration/test-helpers.ts
@@ -6,18 +6,11 @@ import type {
 } from '../index';
 import { Pinecone, Index } from '../index';
 
-const metadataKeys = ['genre', 'year'];
 const metadataMap = {
-  [metadataKeys[0]]: [
-    'action',
-    'comedy',
-    'drama',
-    'horror',
-    'romance',
-    'thriller',
-  ],
-  [metadataKeys[1]]: [2010, 2011, 2012, 2013, 2014, 2015],
+  genre: ['action', 'comedy', 'drama', 'horror', 'romance', 'thriller'],
+  year: [2010, 2011, 2012, 2013, 2014, 2015],
 };
+const metadataKeys = Object.keys(metadataMap);
 
 export const INDEX_NAME = 'ts-integration';
 

--- a/src/integration/test-helpers.ts
+++ b/src/integration/test-helpers.ts
@@ -1,5 +1,25 @@
-import type { PineconeRecord, RecordSparseValues } from '../index';
-import { Pinecone } from '../index';
+import type {
+  IndexStatsDescription,
+  PineconeRecord,
+  RecordSparseValues,
+  RecordMetadata,
+} from '../index';
+import { Pinecone, Index } from '../index';
+
+const metadataKeys = ['genre', 'year'];
+const metadataMap = {
+  [metadataKeys[0]]: [
+    'action',
+    'comedy',
+    'drama',
+    'horror',
+    'romance',
+    'thriller',
+  ],
+  [metadataKeys[1]]: [2010, 2011, 2012, 2013, 2014, 2015],
+};
+
+export const INDEX_NAME = 'ts-integration';
 
 export const randomString = (length) => {
   const characters =
@@ -17,13 +37,14 @@ export const randomString = (length) => {
 export const generateRecords = (
   dimension: number,
   quantity: number,
-  withSparseValues?: boolean
+  withSparseValues?: boolean,
+  withMetadata?: boolean
 ): PineconeRecord[] => {
-  const vectors: PineconeRecord[] = [];
+  const records: PineconeRecord[] = [];
   for (let i = 0; i < quantity; i++) {
     const values: number[] = [];
     for (let j = 0; j < dimension; j++) {
-      values.push(Math.random());
+      values.push(parseFloat(Math.random().toFixed(5)));
     }
     let vector: PineconeRecord = {
       id: i.toString(),
@@ -35,10 +56,15 @@ export const generateRecords = (
         sparseValues: generateSparseValues(dimension),
       };
     }
-
-    vectors.push(vector);
+    if (withMetadata) {
+      vector = {
+        ...vector,
+        metadata: generateMetadata(),
+      };
+    }
+    records.push(vector);
   }
-  return vectors;
+  return records;
 };
 
 export const generateSparseValues = (dimension: number): RecordSparseValues => {
@@ -50,6 +76,15 @@ export const generateSparseValues = (dimension: number): RecordSparseValues => {
   }
   const sparseValues: RecordSparseValues = { indices, values };
   return sparseValues;
+};
+
+export const generateMetadata = (): RecordMetadata => {
+  const metaKey = metadataKeys[Math.floor(Math.random() * metadataKeys.length)];
+  const metaValue =
+    metadataMap[metaKey][
+      Math.floor(Math.random() * metadataMap[metaKey].length)
+    ];
+  return { [metaKey]: metaValue };
 };
 
 export const randomIndexName = (testName: string): string => {
@@ -71,4 +106,24 @@ export const waitUntilReady = async (indexName: string) => {
     await sleep(sleepIntervalMs);
     description = await p.describeIndex(indexName);
   }
+};
+
+export const waitUntilRecordsReady = async (
+  index: Index,
+  namespace: string,
+  recordIds: string[]
+): Promise<IndexStatsDescription> => {
+  const sleepIntervalMs = 3000;
+  let indexStats = await index.describeIndexStats();
+
+  while (
+    indexStats.namespaces &&
+    !indexStats.namespaces[namespace] &&
+    indexStats.namespaces[namespace]?.recordCount !== recordIds.length
+  ) {
+    await sleep(sleepIntervalMs);
+    indexStats = await index.describeIndexStats();
+  }
+
+  return indexStats;
 };

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -26,4 +26,6 @@ var pinecone = require('../dist');
     console.log(`Deleting index ${index.name}`);
     await p.deleteIndex(index.name);
   }
+
+  process.exit();
 })();


### PR DESCRIPTION
## Problem
After the updates to the OpenAPI spec and generated core, dataplane tests were essentially broken. A lot of `createIndex()` requests required updates to the shape of the payload. We were also missing coverage for explicit tests involving `fetch` and `update`.

## Solution

- Update existing `deleteMany.test.ts` and `query.test.ts` suites to work properly with the new schema. Mostly involved updating `spec`.
- Add new `waitUntilReady()` helper to `test-helpers` to allow us to poll for freshness after upserting data. This is needed as there's a somewhat variable delay in how long it takes for records to be queryable.
- Minor cleanup in `test-helpers`, move the `INDEX_NAME` global variable into here, add support for generating metadata.
- Add new `fetch.test.ts` and `upsertAndUpdate.test.ts` suites. `fetch` and `upsert` is somewhat tested in other areas as we use those calls to perform other integration tests, but I thought it might be nice to have explicit categories for these as well.

## Type of Change
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Integration tests should be green in CI for both `node` and `edge`:
<img width="883" alt="Screenshot 2023-12-07 at 10 53 20 AM" src="https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/ce73c05d-9394-41eb-9bde-90b0a6fbe74b">

To run locally you can pull this branch down and kick off the integration tests:
`npm run tests:integration:node`
`npm run tests:integration:edge`