### PR TITLE
Move non-runtime related deps to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,16 @@
       "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edge-runtime/types": "^2.2.3",
         "@sinclair/typebox": "^0.29.0",
-        "@types/node": "^18.11.17",
         "ajv": "^8.12.0",
         "cross-fetch": "^3.1.5",
-        "encoding": "^0.1.13",
-        "typescript": "^4.9.4"
+        "encoding": "^0.1.13"
       },
       "devDependencies": {
         "@edge-runtime/jest-environment": "^2.3.3",
+        "@edge-runtime/types": "^2.2.3",
         "@types/jest": "^29.5.0",
+        "@types/node": "^18.11.17",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
         "dotenv": "^16.0.3",
@@ -30,7 +29,8 @@
         "jest-skipped-reporter": "^0.0.5",
         "prettier": "^2.8.8",
         "ts-jest": "^29.0.5",
-        "typedoc": "^0.24.8"
+        "typedoc": "^0.24.8",
+        "typescript": "^4.9.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -608,6 +608,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.0.1.tgz",
       "integrity": "sha512-hxWUzx1SeyOed/Ea9Z6y6tyFKSj8gQWIdLilybTR2ene1IthLZE01A1SLGoch1szUdhFlUwpWDaYBYQw00lj2g==",
+      "dev": true,
       "engines": {
         "node": ">=16"
       }
@@ -616,6 +617,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@edge-runtime/types/-/types-2.2.3.tgz",
       "integrity": "sha512-zL0ENQWwdocECEQXVopGTfnqI0tJ8wzDOCoQymoc8MLRz+Zw2V1W0ex9vczniTUzB+H/P7ubMgx3GFzLp3NPBg==",
+      "dev": true,
       "dependencies": {
         "@edge-runtime/primitives": "4.0.1"
       },
@@ -1326,6 +1328,7 @@
     },
     "node_modules/@types/node": {
       "version": "18.11.17",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prettier": {
@@ -7377,6 +7380,7 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "^2.3.3",
+    "@edge-runtime/types": "^2.2.3",
     "@types/jest": "^29.5.0",
+    "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "dotenv": "^16.0.3",
@@ -40,19 +42,17 @@
     "jest-skipped-reporter": "^0.0.5",
     "prettier": "^2.8.8",
     "ts-jest": "^29.0.5",
-    "typedoc": "^0.24.8"
+    "typedoc": "^0.24.8",
+    "typescript": "^4.9.4"
   },
   "types": "dist/index.d.ts",
   "files": [
     "/dist"
   ],
   "dependencies": {
-    "@edge-runtime/types": "^2.2.3",
     "@sinclair/typebox": "^0.29.0",
-    "@types/node": "^18.11.17",
     "ajv": "^8.12.0",
     "cross-fetch": "^3.1.5",
-    "encoding": "^0.1.13",
-    "typescript": "^4.9.4"
+    "encoding": "^0.1.13"
   }
 }


### PR DESCRIPTION
## Problem

The purpose of this change is to significantly reduce the size of the package when installed. The issue is fully described in #174.

## Solution

The solution is to move the non-runtime related dependencies into the `devDependencies` section of the `package.json` file so that npm doesn't try to install them in a nested `node_modules` folder.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [x] None of the above: dependency tweaks

## Test Plan

The code compiled and the unit checks passed. The packages moved are either entirely type declaration files (i.e., `<name>.d.ts`) and/or needed only for compilation (and would be likely be included in the parent package anyway if actually needed). That said, if there's any doubts, we'd know for sure if it'd work after pruning the dev dependencies and trying it out.