### PR TITLE
[spruce] Update configureIndex and createCollection to return proper models, add assertWithRetries integration utility

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -120,6 +120,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: pinecone-io/semantic-search-example
+          ref: spruce
           path: semantic-search-example
       - name: Install and build client
         shell: bash

--- a/src/control/__tests__/configureIndex.test.ts
+++ b/src/control/__tests__/configureIndex.test.ts
@@ -7,9 +7,28 @@ import type {
 
 describe('configureIndex', () => {
   test('calls the openapi configure endpoint', async () => {
+    const indexModel = {
+      name: 'index-name',
+      dimension: 5,
+      metric: 'cosine',
+      host: 'https://index-host.com',
+      spec: {
+        pod: {
+          environment: 'us-east1-gcp',
+          replicas: 4,
+          shards: 1,
+          pods: 4,
+          podType: 'p2.x2',
+        },
+      },
+      status: {
+        ready: true,
+        state: 'Ready',
+      },
+    };
     const fakeConfigure: (
       req: ConfigureIndexOperationRequest
-    ) => Promise<IndexModel> = jest.fn();
+    ) => Promise<IndexModel> = jest.fn().mockResolvedValue(indexModel);
     const IOA = { configureIndex: fakeConfigure } as ManagePodIndexesApi;
 
     const returned = await configureIndex(IOA)('index-name', {
@@ -17,7 +36,7 @@ describe('configureIndex', () => {
       podType: 'p2.x2',
     });
 
-    expect(returned).toBe(void 0);
+    expect(returned).toBe(indexModel);
     expect(IOA.configureIndex).toHaveBeenCalledWith({
       indexName: 'index-name',
       configureIndexRequest: {

--- a/src/control/__tests__/createCollection.test.ts
+++ b/src/control/__tests__/createCollection.test.ts
@@ -173,13 +173,21 @@ describe('createCollection', () => {
   });
 
   test('calls the openapi create collection endpoint', async () => {
-    const IOA = setOpenAPIResponse(() => Promise.resolve(''));
+    const collectionModel = {
+      name: 'collection-name',
+      size: 12346,
+      status: 'Initializing',
+      dimension: 5,
+      recordCount: 50,
+      environment: 'us-east1-gcp',
+    };
+    const IOA = setOpenAPIResponse(() => Promise.resolve(collectionModel));
     const returned = await createCollection(IOA)({
       name: 'collection-name',
       source: 'index-name',
     });
 
-    expect(returned).toBe(void 0);
+    expect(returned).toEqual(collectionModel);
     expect(IOA.createCollection).toHaveBeenCalledWith({
       createCollectionRequest: {
         name: 'collection-name',

--- a/src/control/configureIndex.ts
+++ b/src/control/configureIndex.ts
@@ -1,5 +1,6 @@
 import {
   ManagePodIndexesApi,
+  IndexModel,
   ConfigureIndexRequestSpecPod,
 } from '../pinecone-generated-ts-fetch';
 import { PineconeArgumentError } from '../errors';
@@ -30,7 +31,7 @@ export const configureIndex = (api: ManagePodIndexesApi) => {
   return async (
     indexName: IndexName,
     options: ConfigureIndexRequestSpecPod
-  ): Promise<void> => {
+  ): Promise<IndexModel> => {
     indexNameValidator(indexName);
     patchRequestValidator(options);
 
@@ -40,10 +41,9 @@ export const configureIndex = (api: ManagePodIndexesApi) => {
       );
     }
 
-    await api.configureIndex({
+    return await api.configureIndex({
       indexName,
       configureIndexRequest: { spec: { pod: options } },
     });
-    return;
   };
 };

--- a/src/control/createCollection.ts
+++ b/src/control/createCollection.ts
@@ -1,6 +1,7 @@
 import {
-  ManagePodIndexesApi,
+  CollectionModel,
   CreateCollectionRequest,
+  ManagePodIndexesApi,
 } from '../pinecone-generated-ts-fetch';
 import { buildConfigValidator } from '../validator';
 import { CollectionNameSchema, IndexNameSchema } from './types';
@@ -20,10 +21,9 @@ export const createCollection = (api: ManagePodIndexesApi) => {
     'createCollection'
   );
 
-  return async (options: CreateCollectionRequest): Promise<void> => {
+  return async (options: CreateCollectionRequest): Promise<CollectionModel> => {
     validator(options);
 
-    await api.createCollection({ createCollectionRequest: options });
-    return;
+    return await api.createCollection({ createCollectionRequest: options });
   };
 };

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -4,6 +4,7 @@ import {
   generateRecords,
   INDEX_NAME,
   waitUntilRecordsReady,
+  assertWithRetries,
 } from '../test-helpers';
 
 describe('query', () => {
@@ -51,10 +52,12 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 2;
-    const results = await ns.query({ id: '0', topK });
-    expect(results.matches).toBeDefined();
+    const assertions = [
+      (results) => expect(results.matches).toBeDefined(),
+      (results) => expect(results.matches?.length).toEqual(topK),
+    ];
 
-    expect(results.matches?.length).toEqual(topK);
+    await assertWithRetries(() => ns.query({ id: '0', topK }), assertions);
   });
 
   test('query when topK is greater than number of records', async () => {
@@ -70,10 +73,12 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 5;
-    const results = await ns.query({ id: '0', topK });
-    expect(results.matches).toBeDefined();
+    const assertions = [
+      (results) => expect(results.matches).toBeDefined(),
+      (results) => expect(results.matches?.length).toEqual(numberOfRecords),
+    ];
 
-    expect(results.matches?.length).toEqual(numberOfRecords);
+    await assertWithRetries(() => ns.query({ id: '0', topK }), assertions);
   });
 
   test('with invalid id, returns empty results', async () => {
@@ -88,10 +93,12 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 2;
-    const results = await ns.query({ id: '100', topK });
-    expect(results.matches).toBeDefined();
+    const assertions = [
+      (results) => expect(results.matches).toBeDefined(),
+      (results) => expect(results.matches?.length).toEqual(0),
+    ];
 
-    expect(results.matches?.length).toEqual(0);
+    await assertWithRetries(() => ns.query({ id: '100', topK }), assertions);
   });
 
   test('query with vector values', async () => {
@@ -107,11 +114,18 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 1;
-    const results = await ns.query({
-      vector: [0.11, 0.22, 0.33, 0.44, 0.55],
-      topK,
-    });
-    expect(results.matches).toBeDefined();
-    expect(results.matches?.length).toEqual(topK);
+    const assertions = [
+      (results) => expect(results.matches).toBeDefined(),
+      (results) => expect(results.matches?.length).toEqual(topK),
+    ];
+
+    await assertWithRetries(
+      () =>
+        ns.query({
+          vector: [0.11, 0.22, 0.33, 0.44, 0.55],
+          topK,
+        }),
+      assertions
+    );
   });
 });

--- a/src/integration/data/upsertAndUpdate.test.ts
+++ b/src/integration/data/upsertAndUpdate.test.ts
@@ -4,7 +4,6 @@ import {
   randomString,
   generateRecords,
   INDEX_NAME,
-  sleep,
   waitUntilRecordsReady,
 } from '../test-helpers';
 

--- a/src/integration/test-helpers.ts
+++ b/src/integration/test-helpers.ts
@@ -123,3 +123,29 @@ export const waitUntilRecordsReady = async (
 
   return indexStats;
 };
+
+type Assertion = (result: any) => void;
+
+export const assertWithRetries = async (
+  asyncFn: () => Promise<any>,
+  assertions: Assertion[],
+  maxRetries: number = 5,
+  delay: number = 3000
+) => {
+  let attempts = 0;
+
+  while (attempts < maxRetries) {
+    try {
+      const result = await asyncFn();
+      assertions.forEach((assertion) => assertion(result));
+      return;
+    } catch (error) {
+      attempts++;
+      if (attempts < maxRetries) {
+        await sleep(delay);
+      } else {
+        throw error;
+      }
+    }
+  }
+};

--- a/src/integration/test-helpers.ts
+++ b/src/integration/test-helpers.ts
@@ -141,7 +141,7 @@ export const assertWithRetries = async (
       return;
     } catch (error) {
       attempts++;
-      if (attempts < maxRetries) {
+      if (attempts <= maxRetries) {
         await sleep(delay);
         // Double the delay for exponential backoff
         delay *= 2;

--- a/src/integration/test-helpers.ts
+++ b/src/integration/test-helpers.ts
@@ -143,6 +143,8 @@ export const assertWithRetries = async (
       attempts++;
       if (attempts < maxRetries) {
         await sleep(delay);
+        // Double the delay for exponential backoff
+        delay *= 2;
       } else {
         throw error;
       }


### PR DESCRIPTION
## Problem
There's a few different problems this PR is looking to address:
- The semantic search example app we use as a part of testing CI has been bumped to the latest SDK version in a `spruce` branch: https://github.com/pinecone-io/semantic-search-example/pull/10. We can target this branch to get CI passing again.
- The `configureIndex` and `createCollection` operations are now expected to return `IndexModel` and `CollectionModel` respectively which the code is not capturing.
- Our integration tests are still a bit flakey, especially regarding the `query` tests where it seems like freshness via query sometimes lags causing us to have to retry tests manually.

## Solution
- Update the `/workflows/testing` file to use the `spruce` branch for `semantic-search-example`.
- Update `configureIndex` and `createCollection` operations to return the expected models. Tweak relevant unit tests.
- Add a new `assertWithRetries` function in `test-helpers.ts`. This util takes in an async function and an array of assertions, and will retry a set number of times with a specific delay.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Check that CI is green across the board.

To run the integration tests which have been updated to use the new utility locally:
`TEST_ENV=node npx jest src/integration/data/query.test.ts -c jest.config.integration-node.js --runInBand --bail`
`TEST_ENV=edge npx jest src/integration/data/query.test.ts -c jest.config.integration-edge.js --runInBand --bail`
