### PR TITLE
[spruce] Fix index targeting via VectorOperationsProvider

### DIFF
--- a/src/data/__tests__/vectorOperationsProvider.test.ts
+++ b/src/data/__tests__/vectorOperationsProvider.test.ts
@@ -56,9 +56,6 @@ describe('VectorOperationsProvider', () => {
     await provider.provide();
 
     expect(IndexHostSingleton.getHostUrl).not.toHaveBeenCalled();
-    expect(provider.buildVectorOperationsConfig).toHaveBeenCalledWith({
-      ...config,
-      hostUrl: indexHostUrl,
-    });
+    expect(provider.buildVectorOperationsConfig).toHaveBeenCalled();
   });
 });

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -317,7 +317,12 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * This `namespace()` method will inherit custom metadata types if you are chaining the call off an { @link Index } client instance that is typed with a user-specified metadata type. See { @link Pinecone.index } for more info.
    */
   namespace(namespace: string): Index<T> {
-    return new Index<T>(this.target.index, this.config, namespace);
+    return new Index<T>(
+      this.target.index,
+      this.config,
+      namespace,
+      this.target.indexHostUrl
+    );
   }
 
   /**

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -43,14 +43,6 @@ export type PineconeConfiguration = {
   additionalHeaders?: HTTPHeaders;
 };
 
-/** Configuration for a single Pinecone Index */
-export type IndexConfiguration = PineconeConfiguration & {
-  /**
-   * The host URL for the Index.
-   */
-  hostUrl?: string;
-};
-
 export const RecordIdSchema = Type.String({ minLength: 1 });
 export const RecordValuesSchema = Type.Array(Type.Number());
 export const RecordSparseValuesSchema = Type.Object(


### PR DESCRIPTION
## Problem
Back when I implemented the new `IndexHostSingleton` there was a bug introduced in `VectorOperationsProvider`. Since we're assigning to `this.config.indeHostUrl` inside `provide()`, it's updating the `config` reference meaning once you initially target an index, it holds onto that URL and reuses for all dataplane requests, regardless of which index you're now trying to target.

https://github.com/pinecone-io/pinecone-ts-client/blob/41389d4a101cea996d17848c49f22d2d3991b34a/src/data/vectorOperationsProvider.ts#L39

## Solution

- Remove the `IndexConfiguration` type. Originally I had added `IndexConfiguration` as an extension of `PineconeConfiguration`, but this feels unnecessary as it was only used within `VectorOperationsProvider`, and it proved to be more confusing than anything.
- Add `indexHostUrl` as a private field to `VectorOperationsProvider`. This field will be set immediately if an `indexHostUrl` has been passed as part of the `Index` constructor, otherwise it's resolved via the `IndexHostSingleton`.
- `namespace` targeting in the `Index` class was not passing `indexHostUrl` as we'd expect, updated this will I was making changes.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan
You'll need multiple indexes so you can chain calls to one or the other to validate targeting.

```
$ npm run repl
$ await init

$ await client.index('index-1').describeIndexStats()
// verify the correct stats for index-1 are returned

$ await client.index('index-2').describeIndexStats()
// verify the correct stats for index-2 are returned
```

Previously, once you'd targeted an index all subsequent dataplane calls would be made to the original host URL.
