### PR TITLE
[spruce] Normalize host URLs with and without protocol prefix

### DIFF
--- a/src/control/indexOperationsBuilder.ts
+++ b/src/control/indexOperationsBuilder.ts
@@ -2,7 +2,12 @@ import {
   ManagePodIndexesApi,
   Configuration,
 } from '../pinecone-generated-ts-fetch';
-import { queryParamsStringify, buildUserAgent, getFetch } from '../utils';
+import {
+  queryParamsStringify,
+  buildUserAgent,
+  getFetch,
+  normalizeUrl,
+} from '../utils';
 import { middleware } from '../utils/middleware';
 import type { PineconeConfiguration } from '../data/types';
 import type { ConfigurationParameters as IndexOperationsApiConfigurationParameters } from '../pinecone-generated-ts-fetch';
@@ -11,7 +16,8 @@ export const indexOperationsBuilder = (
   config: PineconeConfiguration
 ): ManagePodIndexesApi => {
   const { apiKey } = config;
-  const controllerPath = config.controllerHostUrl || 'https://api.pinecone.io';
+  const controllerPath =
+    normalizeUrl(config.controllerHostUrl) || 'https://api.pinecone.io';
   const headers = config.additionalHeaders || null;
   const apiConfig: IndexOperationsApiConfigurationParameters = {
     basePath: controllerPath,

--- a/src/data/vectorOperationsProvider.ts
+++ b/src/data/vectorOperationsProvider.ts
@@ -4,7 +4,12 @@ import {
   ConfigurationParameters,
   VectorOperationsApi,
 } from '../pinecone-generated-ts-fetch';
-import { queryParamsStringify, buildUserAgent, getFetch } from '../utils';
+import {
+  queryParamsStringify,
+  buildUserAgent,
+  getFetch,
+  normalizeUrl,
+} from '../utils';
 import { IndexHostSingleton } from './indexHostSingleton';
 import { middleware } from '../utils/middleware';
 
@@ -21,7 +26,7 @@ export class VectorOperationsProvider {
   ) {
     this.config = config;
     this.indexName = indexName;
-    this.indexHostUrl = indexHostUrl;
+    this.indexHostUrl = normalizeUrl(indexHostUrl);
   }
 
   async provide() {

--- a/src/utils/__tests__/normalizeUrl.test.ts
+++ b/src/utils/__tests__/normalizeUrl.test.ts
@@ -20,8 +20,8 @@ describe('normalizeUrl', () => {
   });
 
   test('keeps https:// protocol if present', () => {
-    expect(normalizeUrl('http://index-name-abcdef.svc.pinecone.io')).toBe(
-      'http://index-name-abcdef.svc.pinecone.io'
+    expect(normalizeUrl('https://index-name-abcdef.svc.pinecone.io')).toBe(
+      'https://index-name-abcdef.svc.pinecone.io'
     );
   });
 });

--- a/src/utils/__tests__/normalizeUrl.test.ts
+++ b/src/utils/__tests__/normalizeUrl.test.ts
@@ -1,0 +1,27 @@
+import { normalizeUrl } from '../normalizeUrl';
+
+describe('normalizeUrl', () => {
+  test('empty string and undefined return undefined', () => {
+    expect(normalizeUrl('')).toBe(undefined);
+    expect(normalizeUrl('   ')).toBe(undefined);
+    expect(normalizeUrl()).toBe(undefined);
+  });
+
+  test('adds https:// to url if no protocol present', () => {
+    expect(normalizeUrl('index-name-abcdef.svc.pinecone.io')).toBe(
+      'https://index-name-abcdef.svc.pinecone.io'
+    );
+  });
+
+  test('keeps http:// protocol if present', () => {
+    expect(normalizeUrl('http://index-name-abcdef.svc.pinecone.io')).toBe(
+      'http://index-name-abcdef.svc.pinecone.io'
+    );
+  });
+
+  test('keeps https:// protocol if present', () => {
+    expect(normalizeUrl('http://index-name-abcdef.svc.pinecone.io')).toBe(
+      'http://index-name-abcdef.svc.pinecone.io'
+    );
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,13 @@
 import { debugLog } from './debugLog';
+import { normalizeUrl } from './normalizeUrl';
 import { queryParamsStringify } from './queryParamsStringify';
 import { buildUserAgent } from './user-agent';
 import { getFetch } from './fetch';
 
-export { debugLog, queryParamsStringify, buildUserAgent, getFetch };
+export {
+  debugLog,
+  normalizeUrl,
+  queryParamsStringify,
+  buildUserAgent,
+  getFetch,
+};

--- a/src/utils/normalizeUrl.ts
+++ b/src/utils/normalizeUrl.ts
@@ -1,0 +1,11 @@
+export function normalizeUrl(url?: string): string | undefined {
+  if (!url || url.trim().length === 0) {
+    return;
+  }
+
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    return 'https://' + url;
+  }
+
+  return url;
+}


### PR DESCRIPTION
## Problem
We want the client to be flexible enough to allow providing `controllerHostUrl` and `indexHostUrl` with or without the `https://` protocol. This is useful because the `describeIndex` response includes host without the prefix, and we're already prepending it there.

## Solution
- Added a new utility method called `normalizeUrl()`.
- Use `normalizeUrl` in `indexOperationsBuilder`, `vectorOperationsProvider`, and `IndexHostSingleton`. Updating `indexOperationsBuilder` and `vectorOperationsProvider` covers the cases where users are providing custom hosts for control or data plane operations. The `IndexHostSingleton` update replaces the old `hostWithHttps` utility, and we normalize the host before storing it in the cache.
- Added unit tests for `normalizeUrl()`.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Test Plan
Verify unit tests and CI pass as expected. The client should continue to work as expected when resolving data plane URLs for index operations, etc.

You can verify manually by providing either a `controllerHostUrl` or an `indexHostUrl` either with or without the prefix:

```
const pinecone = new Pinecone({ apiKey: 'your-api-key', controllerHostUrl: '123-456.svc.io' });

// perform control plane operations, url should be normalized

const index = pinecone.index('test-index', 'index-url-123.svc.pinecone.io');

// perform data plane operations, url should be normalized
```
