### PR TITLE
Add new workflow to trigger building and publishing docs, fix release-prod docs step

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -1,0 +1,31 @@
+name: 'Build and publish documentation to sdk-docs'
+
+on:
+  workflow_dispatch: {}
+  workflow_call:
+    secrets:
+      SSH_DEPLOY_KEY:
+        required: true
+
+jobs:
+  build-and-deploy-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Generate TypeDoc documentation
+        uses: ./.github/actions/build-docs
+      - name: Push documentation artifacts to sdk-docs
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: docs
+          destination-github-username: pinecone-io
+          destination-repository-name: sdk-docs
+          user-email: clients@pinecone.io
+          target-branch: main
+          target-directory: typescript
+          commit-message: 'TypeScript: automated documentation build - pinecone-ts-client merge SHA: ${{ github.sha }}'

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -28,4 +28,4 @@ jobs:
           user-email: clients@pinecone.io
           target-branch: main
           target-directory: typescript
-          commit-message: 'TypeScript: automated documentation build - pinecone-ts-client merge SHA: ${{ github.sha }}'
+          commit-message: "TypeScript: automated documentation build \n\n pinecone-ts-client merge SHA: ${{ github.sha }}"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,24 +7,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build-and-deploy-documentation:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Generate TypeDoc documentation
-        uses: ./.github/actions/build-docs
-      - name: Push documentation artifacts to sdk-docs
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
-        with:
-          source-directory: docs
-          destination-github-username: pinecone-io
-          destination-repository-name: sdk-docs
-          user-email: clients@pinecone.io
-          target-branch: main
-          target-directory: typescript
-          commit-message: 'TypeScript: automated documentation build - pinecone-ts-client merge SHA: ${{ github.sha }}'
+  build-and-publish-docs:
+    name: Build and publish docs to sdk-docs
+    uses: ./.github/workflows/build-and-publish-docs.yml
+    secrets: inherit

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -57,5 +57,6 @@ jobs:
 
   build-and-publish-docs:
     name: Build and publish docs to sdk-docs
+    needs: version-and-release
     uses: ./.github/workflows/build-and-publish-docs.yml
     secrets: inherit

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -12,6 +12,14 @@ on:
           - 'patch' # bug fixes
           - 'minor' # new features, backwards compatible
           - 'major' # breaking changes
+      runTests:
+        description: 'Run tests before releasing'
+        required: true
+        type: choice
+        default: 'true'
+        options:
+          - 'true'
+          - 'false'
 
 # prevent concurrent releases
 concurrency:
@@ -19,14 +27,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # integration-tests:
-  #   if: ${{ github.event.inputs.runTests == 'true' }}
-  #   uses: ./.github/workflows/PR.yml
-  #   secrets: inherit
+  integration-tests:
+    if: ${{ github.event.inputs.runTests == 'true' }}
+    uses: ./.github/workflows/PR.yml
+    secrets: inherit
 
   version-and-release:
     name: Release to NPM
-    # needs: integration-tests
+    needs: integration-tests
     runs-on: ubuntu-latest
     outputs:
       tagName: ${{ steps.npm-release.outputs.release_tag }}
@@ -47,12 +55,7 @@ jobs:
           npm_token: ${{ secrets.NPM_TOKEN }}
       - run: echo "${{ steps.npm-release.outputs.release_tag }} was published"
 
-      - name: Generate TypeDoc documentation
-        uses: ./.github/actions/build-docs
-      - name: Deploy documentation to gh-pages
-        uses: s0/git-publish-subdir-action@develop
-        env:
-          REPO: self
-          BRANCH: gh-pages
-          FOLDER: docs
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+  build-and-publish-docs:
+    name: Build and publish docs to sdk-docs
+    uses: ./.github/workflows/build-and-publish-docs.yml
+    secrets: inherit


### PR DESCRIPTION
## Problem
We pushed a patch to fix up our npm release page. In doing this I realize the `release-prod` workflow is incorrectly still trying to push the built client docs to the `gh-pages` branch. It should be moving things to the `sdk-docs` repo like in `merge`.

## Solution

- Add new `build-and-publish-docs` workflow to allow triggering a fresh docs build and deploy off main separate from other workflows.
- Update `release-prod` to use this new workflow if the npm release completes. Also uncommented the test re-use with the boolean flag in that workflow as it surprised me it immediately pushed to npm without any other checks.
- Update other workflows to reuse `build-and-publish-docs`.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Infrastructure change (CI configs, etc)

## Test Plan
We'll have to test the release workflow by actually releasing, so give that a careful review. The docs workflow can be triggered and tested on its own.
