### PR TITLE
Clean up unit tests, todos, assertWithRetries

### DIFF
--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -9,17 +9,17 @@ import { PineconeArgumentError } from '../../errors';
 import { ManageIndexesApi } from '../../pinecone-generated-ts-fetch';
 
 describe('configureIndex argument validations', () => {
-  let MPIA: ManageIndexesApi;
+  let MIA: ManageIndexesApi;
   beforeEach(() => {
-    MPIA = { configureIndex: jest.fn() };
+    MIA = { configureIndex: jest.fn() };
     jest.mock('../../pinecone-generated-ts-fetch', () => ({
-      IndexOperationsApi: MPIA,
+      IndexOperationsApi: MIA,
     }));
   });
 
   describe('required configurations', () => {
     test('should throw if index name is not provided', async () => {
-      const toThrow = async () => await configureIndex(MPIA)();
+      const toThrow = async () => await configureIndex(MIA)();
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -29,7 +29,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if index name is not a string', async () => {
       const toThrow = async () =>
-        await configureIndex(MPIA)(1, { replicas: 10 });
+        await configureIndex(MIA)(1, { replicas: 10 });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -39,7 +39,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if index name is empty string', async () => {
       const toThrow = async () =>
-        await configureIndex(MPIA)('', { replicas: 2 });
+        await configureIndex(MIA)('', { replicas: 2 });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -49,7 +49,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if spec and pod are not provided', async () => {
       const toThrowSpec = async () =>
-        await configureIndex(MPIA)('index-name', {});
+        await configureIndex(MIA)('index-name', {});
 
       expect(toThrowSpec).rejects.toThrowError(PineconeArgumentError);
       expect(toThrowSpec).rejects.toThrowError(
@@ -59,7 +59,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if replicas is not a number', async () => {
       const toThrow = async () =>
-        await configureIndex(MPIA)('index-name', { replicas: '10' });
+        await configureIndex(MIA)('index-name', { replicas: '10' });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -69,7 +69,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if podType is not a string', async () => {
       const toThrow = async () =>
-        await configureIndex(MPIA)('index-name', { podType: 10.5 });
+        await configureIndex(MIA)('index-name', { podType: 10.5 });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -79,7 +79,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if replicas is not a positive integer', async () => {
       const toThrow = async () =>
-        await configureIndex(MPIA)('index-name', { replicas: 0 });
+        await configureIndex(MIA)('index-name', { replicas: 0 });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(

--- a/src/control/__tests__/createIndex.test.ts
+++ b/src/control/__tests__/createIndex.test.ts
@@ -40,18 +40,18 @@ const setupCreateIndexResponse = (
   const fakeDescribeIndex: (req: DescribeIndexRequest) => Promise<IndexModel> =
     describeIndexMock;
 
-  const MPIA = {
+  const MIA = {
     createIndex: fakeCreateIndex,
     describeIndex: fakeDescribeIndex,
   } as ManageIndexesApi;
 
-  return MPIA;
+  return MIA;
 };
 
 describe('createIndex', () => {
   test('calls the openapi create index endpoint, passing name, dimension, metric, and spec', async () => {
-    const MPIA = setupCreateIndexResponse(undefined, undefined);
-    const returned = await createIndex(MPIA)({
+    const MIA = setupCreateIndexResponse(undefined, undefined);
+    const returned = await createIndex(MIA)({
       name: 'index-name',
       dimension: 10,
       metric: 'cosine',
@@ -65,7 +65,7 @@ describe('createIndex', () => {
     });
 
     expect(returned).toEqual(void 0);
-    expect(MPIA.createIndex).toHaveBeenCalledWith({
+    expect(MIA.createIndex).toHaveBeenCalledWith({
       createIndexRequest: {
         name: 'index-name',
         dimension: 10,
@@ -82,8 +82,8 @@ describe('createIndex', () => {
   });
 
   test('default metric to "cosine" if not specified', async () => {
-    const MPIA = setupCreateIndexResponse(undefined, undefined);
-    const returned = await createIndex(MPIA)({
+    const MIA = setupCreateIndexResponse(undefined, undefined);
+    const returned = await createIndex(MIA)({
       name: 'index-name',
       dimension: 10,
       spec: {
@@ -96,7 +96,7 @@ describe('createIndex', () => {
     });
 
     expect(returned).toEqual(void 0);
-    expect(MPIA.createIndex).toHaveBeenCalledWith({
+    expect(MIA.createIndex).toHaveBeenCalledWith({
       createIndexRequest: {
         name: 'index-name',
         dimension: 10,
@@ -121,13 +121,13 @@ describe('createIndex', () => {
     });
 
     test('when passed waitUntilReady, calls the create index endpoint and begins polling describeIndex', async () => {
-      const MPIA = setupCreateIndexResponse(undefined, [
+      const MIA = setupCreateIndexResponse(undefined, [
         {
           status: { ready: true, state: 'Ready' },
         },
       ]);
 
-      const returned = await createIndex(MPIA)({
+      const returned = await createIndex(MIA)({
         name: 'index-name',
         dimension: 10,
         metric: 'cosine',
@@ -142,7 +142,7 @@ describe('createIndex', () => {
       });
 
       expect(returned).toEqual({ status: { ready: true, state: 'Ready' } });
-      expect(MPIA.createIndex).toHaveBeenCalledWith({
+      expect(MIA.createIndex).toHaveBeenCalledWith({
         createIndexRequest: {
           name: 'index-name',
           dimension: 10,
@@ -157,7 +157,7 @@ describe('createIndex', () => {
           waitUntilReady: true,
         },
       });
-      expect(MPIA.describeIndex).toHaveBeenCalledWith({
+      expect(MIA.describeIndex).toHaveBeenCalledWith({
         indexName: 'index-name',
       });
     });

--- a/src/control/__tests__/createIndex.validation.test.ts
+++ b/src/control/__tests__/createIndex.validation.test.ts
@@ -8,19 +8,18 @@ import { createIndex } from '../createIndex';
 import { PineconeArgumentError } from '../../errors';
 import { ManageIndexesApi } from '../../pinecone-generated-ts-fetch';
 
-// TODO: Update tests to cover all nested properties inside spec once validator.ts is updated
 describe('createIndex argument validations', () => {
-  let MPIA: ManageIndexesApi;
+  let MIA: ManageIndexesApi;
   beforeEach(() => {
-    MPIA = { createIndex: jest.fn() };
+    MIA = { createIndex: jest.fn() };
     jest.mock('../../pinecone-generated-ts-fetch', () => ({
-      ManageIndexesApi: MPIA,
+      ManageIndexesApi: MIA,
     }));
   });
 
   describe('required configurations', () => {
     test('should throw if index name is not provided', async () => {
-      const toThrow = async () => await createIndex(MPIA)();
+      const toThrow = async () => await createIndex(MIA)();
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -30,7 +29,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if index name is not a string', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 12,
           dimension: 10,
           metric: 'cosine',
@@ -45,7 +44,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if index name is empty string', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: '',
           dimension: 10,
           metric: 'cosine',
@@ -60,7 +59,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if dimension is not provided', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           metric: 'cosine',
           spec: { serverless: { cloud: 'aws', region: 'us-east-1' } },
@@ -74,7 +73,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if dimension is not a number', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: '10',
           metric: 'cosine',
@@ -89,7 +88,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if dimension is float', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10.5,
           metric: 'cosine',
@@ -104,7 +103,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if dimension is not a positive integer', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: -10,
           metric: 'cosine',
@@ -119,7 +118,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if region is not provided', () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -138,7 +137,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if region is not a string', () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -151,7 +150,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/properties/serverless/properties/region' must be string."
       );
@@ -159,7 +157,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if cloud is not provided', () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -178,7 +176,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if cloud is not a string', () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -191,7 +189,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/serverless/cloud' must be equal to one of: 'gcp', 'aws', 'azure'."
       );
@@ -199,7 +196,7 @@ describe('createIndex argument validations', () => {
 
     test('should throw if cloud is not one of the expected strings', () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -212,7 +209,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/serverless/cloud' must be equal to one of: 'gcp', 'aws', 'azure'."
       );
@@ -222,7 +218,7 @@ describe('createIndex argument validations', () => {
   describe('optional configurations', () => {
     test('metric: should throw if not a string', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 10,
@@ -237,7 +233,7 @@ describe('createIndex argument validations', () => {
 
     test('metric: should throw if not one of the predefined literals', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'foo',
@@ -252,7 +248,7 @@ describe('createIndex argument validations', () => {
 
     test('replicas: should throw if not an integer', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -268,7 +264,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/properties/pod/properties/replicas' must be integer."
       );
@@ -276,7 +271,7 @@ describe('createIndex argument validations', () => {
 
     test('replicas: should throw if not a positive integer', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -292,7 +287,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had validation errors: property 'spec/properties/pod/properties/replicas' must be >= 1."
       );
@@ -300,7 +294,7 @@ describe('createIndex argument validations', () => {
 
     test('podType: should throw if not a string', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -316,7 +310,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/properties/pod/properties/podType' must be string."
       );
@@ -324,7 +317,7 @@ describe('createIndex argument validations', () => {
 
     test('podType: should throw if not a valid pod type', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -340,7 +333,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had validation errors: property 'spec/properties/pod/properties/podType' must not be blank."
       );
@@ -348,7 +340,7 @@ describe('createIndex argument validations', () => {
 
     test('pods: should throw if not an integer', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -364,7 +356,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/properties/pod/properties/pods' must be integer."
       );
@@ -372,7 +363,7 @@ describe('createIndex argument validations', () => {
 
     test('pods: should throw if not a positive integer', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -388,7 +379,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had validation errors: property 'spec/properties/pod/properties/pods' must be >= 1."
       );
@@ -396,7 +386,7 @@ describe('createIndex argument validations', () => {
 
     test('metadataConfig: should throw if not an object', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -413,7 +403,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/properties/pod/properties/metadataConfig' must be object."
       );
@@ -421,7 +410,7 @@ describe('createIndex argument validations', () => {
 
     test('sourceCollection: should throw if not a string', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -438,7 +427,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had type errors: property 'spec/properties/pod/properties/sourceCollection' must be string."
       );
@@ -446,7 +434,7 @@ describe('createIndex argument validations', () => {
 
     test('sourceCollection: should throw if blank string', async () => {
       const toThrow = async () =>
-        await createIndex(MPIA)({
+        await createIndex(MIA)({
           name: 'index-name',
           dimension: 10,
           metric: 'cosine',
@@ -463,7 +451,6 @@ describe('createIndex argument validations', () => {
         });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
-      // TODO: Update validator.ts to handle nested object properties
       expect(toThrow).rejects.toThrowError(
         "The argument to createIndex had validation errors: property 'spec/properties/pod/properties/sourceCollection' must not be blank."
       );

--- a/src/integration/control/configureIndex.test.ts
+++ b/src/integration/control/configureIndex.test.ts
@@ -2,7 +2,7 @@ import { BasePineconeError } from '../../errors';
 import { Pinecone } from '../../index';
 import { randomIndexName, waitUntilReady } from '../test-helpers';
 
-// TODO: Uncomment when configure_index / pod indexes implemented
+// TODO: Re-enable
 describe.skip('configure index', () => {
   let indexName;
   let pinecone: Pinecone;

--- a/src/integration/control/createIndex.test.ts
+++ b/src/integration/control/createIndex.test.ts
@@ -150,7 +150,7 @@ describe('create index', () => {
       }
     });
 
-    // TODO: Uncomment when pod index is supported
+    // TODO: Re-enable
     test.skip('create from non-existent collection', async () => {
       try {
         await pinecone.createIndex({

--- a/src/integration/data/delete.test.ts
+++ b/src/integration/data/delete.test.ts
@@ -57,30 +57,28 @@ describe('delete', () => {
     }
 
     // Look more closely at one of the records to make sure values set
-    const fetchAssertions = [
-      (results) => {
-        if (results.records) {
-          expect(results.records['0'].id).toEqual('0');
-          expect(results.records['0'].values.length).toEqual(5);
-        } else {
-          fail(
-            'Did not find expected records. Fetch result was ' +
-              JSON.stringify(results)
-          );
-        }
-      },
-    ];
+    const fetchAssertions = (results) => {
+      if (results.records) {
+        expect(results.records['0'].id).toEqual('0');
+        expect(results.records['0'].values.length).toEqual(5);
+      } else {
+        fail(
+          'Did not find expected records. Fetch result was ' +
+            JSON.stringify(results)
+        );
+      }
+    };
+
     assertWithRetries(() => ns.fetch(['0']), fetchAssertions);
 
     // Try deleting the record
     await ns.deleteOne('0');
 
     // Verify the record is removed
-    const deleteAssertions = [
-      (stats) => {
-        expect(stats.namespaces[namespace]).toBeUndefined();
-      },
-    ];
+    const deleteAssertions = (stats) => {
+      expect(stats.namespaces[namespace]).toBeUndefined();
+    };
+
     assertWithRetries(() => ns.describeIndexStats(), deleteAssertions);
   });
 
@@ -103,68 +101,64 @@ describe('delete', () => {
     }
 
     // Look more closely at one of the records to make sure values set
-    const fetchAssertions = [
-      (results) => {
-        if (results.records) {
-          expect(results.records['0'].id).toEqual('0');
-          expect(results.records['0'].values.length).toEqual(5);
-        } else {
-          fail(
-            'Did not find expected records. Fetch result was ' +
-              JSON.stringify(results)
-          );
-        }
-      },
-    ];
+    const fetchAssertions = (results) => {
+      if (results.records) {
+        expect(results.records['0'].id).toEqual('0');
+        expect(results.records['0'].values.length).toEqual(5);
+      } else {
+        fail(
+          'Did not find expected records. Fetch result was ' +
+            JSON.stringify(results)
+        );
+      }
+    };
+
     assertWithRetries(() => ns.fetch(['0']), fetchAssertions);
 
     // Try deleting 2 of 3 records
     await ns.deleteMany(['0', '2']);
 
-    const deleteAssertions = [
-      (stats) => {
-        if (stats.namespaces) {
-          expect(stats.namespaces[namespace].recordCount).toEqual(1);
-        } else {
-          fail(
-            'Expected namespaces to be defined (second call). Stats were ' +
-              JSON.stringify(stats)
-          );
-        }
-      },
-    ];
+    const deleteAssertions = (stats) => {
+      if (stats.namespaces) {
+        expect(stats.namespaces[namespace].recordCount).toEqual(1);
+      } else {
+        fail(
+          'Expected namespaces to be defined (second call). Stats were ' +
+            JSON.stringify(stats)
+        );
+      }
+    };
+
     assertWithRetries(() => ns.describeIndexStats(), deleteAssertions);
 
     // Check that record id='1' still exists
-    const fetchAssertions2 = [
-      (results) => {
-        if (results.records2) {
-          expect(results.records2['1']).not.toBeUndefined();
-        } else {
-          fail(
-            'Expected record 2 to be defined. Fetch result was ' +
-              JSON.stringify(results)
-          );
-        }
-      },
-    ];
+    const fetchAssertions2 = (results) => {
+      if (results.records2) {
+        expect(results.records2['1']).not.toBeUndefined();
+      } else {
+        fail(
+          'Expected record 2 to be defined. Fetch result was ' +
+            JSON.stringify(results)
+        );
+      }
+    };
+
     assertWithRetries(() => ns.fetch(['1']), fetchAssertions2);
 
     // deleting non-existent records should not throw
     await ns.deleteMany(['0', '1', '2', '3']);
 
     // Verify all are now removed
-    const deleteAssertions2 = [
-      (stats) => {
-        if (stats.namespaces) {
-          expect(stats.namespaces[namespace]).toBeUndefined();
-        } else {
-          // no-op. This shouldn't actually happen unless there
-          // are leftover namespaces from previous runs that
-          // failed or stopped without proper cleanup.
-        }
-      },
-    ];
+    const deleteAssertions2 = (stats) => {
+      if (stats.namespaces) {
+        expect(stats.namespaces[namespace]).toBeUndefined();
+      } else {
+        // no-op. This shouldn't actually happen unless there
+        // are leftover namespaces from previous runs that
+        // failed or stopped without proper cleanup.
+      }
+    };
+
     assertWithRetries(() => ns.describeIndexStats(), deleteAssertions2);
   });
 });

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -52,13 +52,11 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 2;
-    const assertions = [
-      (results) => {
-        expect(results.matches).toBeDefined();
-        expect(results.matches?.length).toEqual(topK);
-        expect(results.usage.readUnits).toBeDefined();
-      },
-    ];
+    const assertions = (results) => {
+      expect(results.matches).toBeDefined();
+      expect(results.matches?.length).toEqual(topK);
+      expect(results.usage.readUnits).toBeDefined();
+    };
 
     await assertWithRetries(() => ns.query({ id: '0', topK }), assertions);
   });
@@ -76,13 +74,11 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 5;
-    const assertions = [
-      (results) => {
-        expect(results.matches).toBeDefined();
-        expect(results.matches?.length).toEqual(numberOfRecords);
-        expect(results.usage.readUnits).toBeDefined();
-      },
-    ];
+    const assertions = (results) => {
+      expect(results.matches).toBeDefined();
+      expect(results.matches?.length).toEqual(numberOfRecords);
+      expect(results.usage.readUnits).toBeDefined();
+    };
 
     await assertWithRetries(() => ns.query({ id: '0', topK }), assertions);
   });
@@ -99,12 +95,10 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 2;
-    const assertions = [
-      (results) => {
-        expect(results.matches).toBeDefined();
-        expect(results.matches?.length).toEqual(0);
-      },
-    ];
+    const assertions = (results) => {
+      expect(results.matches).toBeDefined();
+      expect(results.matches?.length).toEqual(0);
+    };
 
     await assertWithRetries(() => ns.query({ id: '100', topK }), assertions);
   });
@@ -122,13 +116,11 @@ describe('query', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     const topK = 1;
-    const assertions = [
-      (results) => {
-        expect(results.matches).toBeDefined();
-        expect(results.matches?.length).toEqual(topK);
-        expect(results.usage.readUnits).toBeDefined();
-      },
-    ];
+    const assertions = (results) => {
+      expect(results.matches).toBeDefined();
+      expect(results.matches?.length).toEqual(topK);
+      expect(results.usage.readUnits).toBeDefined();
+    };
 
     await assertWithRetries(
       () =>
@@ -146,13 +138,12 @@ describe('query', () => {
 
     const queryVec = Array.from({ length: 5 }, () => Math.random());
 
-    const assertions = [
-      (results) => {
-        expect(results.matches).toBeDefined();
-        expect(results.matches?.length).toEqual(2);
-        expect(results.usage.readUnits).toBeDefined();
-      },
-    ];
+    const assertions = (results) => {
+      expect(results.matches).toBeDefined();
+      expect(results.matches?.length).toEqual(2);
+      expect(results.usage.readUnits).toBeDefined();
+    };
+
     await assertWithRetries(
       () =>
         ns.query({

--- a/src/integration/data/upsertAndUpdate.test.ts
+++ b/src/integration/data/upsertAndUpdate.test.ts
@@ -51,15 +51,14 @@ describe('upsert and update', () => {
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
     // Fetch and inspect records to validate upsert
-    const preUpdateAssertions = [
-      (response) => expect(response.records['0']).toBeDefined(),
-      (response) =>
-        expect(response.records['0'].values).toEqual(recordToUpsert[0].values),
-      (response) =>
-        expect(response.records['0'].metadata).toEqual(
-          recordToUpsert[0].metadata
-        ),
-    ];
+    const preUpdateAssertions = (response) => {
+      expect(response.records['0']).toBeDefined();
+      expect(response.records['0'].values).toEqual(recordToUpsert[0].values);
+      expect(response.records['0'].metadata).toEqual(
+        recordToUpsert[0].metadata
+      );
+    };
+
     await assertWithRetries(() => ns.fetch(recordIds), preUpdateAssertions);
 
     // Update record values
@@ -71,14 +70,14 @@ describe('upsert and update', () => {
       metadata: newMetadata,
     });
 
-    const postUpdateAssertions = [
-      (response) => expect(response.records['0'].values).toEqual(newValues),
-      (response) =>
-        expect(response.records['0'].metadata).toEqual({
-          ...oldMetadata,
-          ...newMetadata,
-        }),
-    ];
+    const postUpdateAssertions = (response) => {
+      expect(response.records['0'].values).toEqual(newValues);
+      expect(response.records['0'].metadata).toEqual({
+        ...oldMetadata,
+        ...newMetadata,
+      });
+    };
+
     await assertWithRetries(() => ns.fetch(['0']), postUpdateAssertions);
   });
 });

--- a/src/integration/test-helpers.ts
+++ b/src/integration/test-helpers.ts
@@ -124,11 +124,11 @@ export const waitUntilRecordsReady = async (
   return indexStats;
 };
 
-type Assertion = (result: any) => void;
+type Assertions = (result: any) => void;
 
 export const assertWithRetries = async (
   asyncFn: () => Promise<any>,
-  assertions: Assertion[],
+  assertionsFn: Assertions,
   maxRetries: number = 5,
   delay: number = 3000
 ) => {
@@ -137,7 +137,7 @@ export const assertWithRetries = async (
   while (attempts < maxRetries) {
     try {
       const result = await asyncFn();
-      assertions.forEach((assertion) => assertion(result));
+      assertionsFn(result);
       return;
     } catch (error) {
       attempts++;

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -14,12 +14,11 @@ var pinecone = require('../dist');
 (async () => {
   const p = new pinecone.Pinecone();
 
-  // TODO: Uncomment when collections are supported
-  // const collections = await p.listCollections();
-  // for (const collection of collections) {
-  //   console.log(`Deleting collection ${collection.name}`);
-  //   await p.deleteCollection(collection.name);
-  // }
+  const collectionList = await p.listCollections();
+  for (const collection of collectionList.collections) {
+    console.log(`Deleting collection ${collection.name}`);
+    await p.deleteCollection(collection.name);
+  }
 
   const response = await p.listIndexes();
   for (const index of response.indexes) {


### PR DESCRIPTION
## Problem
There's some TODO comments left in the code. There's also a few things that would be nice to clean up.

## Solution
- Clean up TODOs
- Tweak some naming in unit tests
- Clean up `assertWithRetries`

## Type of Change
- [X] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)

## Test Plan
Passing CI
