### PR TITLE
Add missing spec exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,4 +51,8 @@ export type {
   FetchAPI,
   IndexList,
   IndexModel,
+  ServerlessSpec,
+  ServerlessSpecCloudEnum,
+  PodSpec,
+  PodSpecMetadataConfig,
 } from './pinecone-generated-ts-fetch';


### PR DESCRIPTION
## Problem
While updating sample apps I noticed there's a few generated types missing, specifically in relation to `spec` and the values for the different configurations. This will be important for users of the package to have access to.

## Solution
Export generated types:
-   `ServerlessSpec`
-   `ServerlessSpecCloudEnum`
-   `PodSpec`
-   `PodSpecMetadataConfig`

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Test Plan
CI - will be re-building dev version and re-testing with new exports in sample apps
