### PR TITLE
Add `sourceTag` to `PineconeConfiguration` and `additionalHeaders` to data plane calls

### DIFF
--- a/src/control/__tests__/indexOperationsBuilder.test.ts
+++ b/src/control/__tests__/indexOperationsBuilder.test.ts
@@ -1,0 +1,40 @@
+import { indexOperationsBuilder } from '../indexOperationsBuilder';
+import { Configuration } from '../../pinecone-generated-ts-fetch';
+
+jest.mock('../../pinecone-generated-ts-fetch', () => ({
+  ...jest.requireActual('../../pinecone-generated-ts-fetch'),
+  Configuration: jest.fn(),
+}));
+
+describe('indexOperationsBuilder', () => {
+  test('API Configuration basePath is set to api.pinecone.io by default', () => {
+    const config = { apiKey: 'test-api-key' };
+    indexOperationsBuilder(config);
+    expect(Configuration).toHaveBeenCalledWith(
+      expect.objectContaining({ basePath: 'https://api.pinecone.io' })
+    );
+  });
+
+  test('controllerHostUrl overwrites the basePath in API Configuration', () => {
+    const controllerHostUrl = 'https://test-controller-host-url.io';
+    const config = {
+      apiKey: 'test-api-key',
+      controllerHostUrl,
+    };
+    indexOperationsBuilder(config);
+    expect(Configuration).toHaveBeenCalledWith(
+      expect.objectContaining({ basePath: controllerHostUrl })
+    );
+  });
+
+  test('additionalHeaders are passed to the API Configuration', () => {
+    const additionalHeaders = { 'x-test-header': 'test-value' };
+    const config = { apiKey: 'test-api-key', additionalHeaders };
+    indexOperationsBuilder(config);
+    expect(Configuration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining(additionalHeaders),
+      })
+    );
+  });
+});

--- a/src/control/indexOperationsBuilder.ts
+++ b/src/control/indexOperationsBuilder.ts
@@ -24,7 +24,7 @@ export const indexOperationsBuilder = (
     apiKey,
     queryParamsStringify,
     headers: {
-      'User-Agent': buildUserAgent(),
+      'User-Agent': buildUserAgent(config),
       ...headers,
     },
     fetchApi: getFetch(config),

--- a/src/data/__tests__/index.test.ts
+++ b/src/data/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { FetchCommand } from '../fetch';
 import { QueryCommand } from '../query';
 import { UpdateCommand } from '../update';
 import { UpsertCommand } from '../upsert';
-import { VectorOperationsProvider } from '../vectorOperationsProvider';
+import { DataOperationsProvider } from '../dataOperationsProvider';
 import { Index } from '../index';
 import type { ScoredPineconeRecord } from '../query';
 
@@ -10,7 +10,7 @@ jest.mock('../fetch');
 jest.mock('../query');
 jest.mock('../update');
 jest.mock('../upsert');
-jest.mock('../vectorOperationsProvider');
+jest.mock('../dataOperationsProvider');
 
 describe('Index', () => {
   let config;
@@ -27,7 +27,7 @@ describe('Index', () => {
   });
 
   describe('index initialization', () => {
-    test('passes config, indexName, indexHostUrl, and additionalHeaders to VectorOperationsProvider', () => {
+    test('passes config, indexName, indexHostUrl, and additionalHeaders to DataOperationsProvider', () => {
       const indexHostUrl = 'https://test-api-pinecone.io';
       const additionalHeaders = { 'x-custom-header': 'custom-value' };
       new Index(
@@ -37,8 +37,8 @@ describe('Index', () => {
         indexHostUrl,
         additionalHeaders
       );
-      expect(VectorOperationsProvider).toHaveBeenCalledTimes(1);
-      expect(VectorOperationsProvider).toHaveBeenCalledWith(
+      expect(DataOperationsProvider).toHaveBeenCalledTimes(1);
+      expect(DataOperationsProvider).toHaveBeenCalledWith(
         config,
         'index-name',
         indexHostUrl,

--- a/src/data/__tests__/index.test.ts
+++ b/src/data/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { FetchCommand } from '../fetch';
 import { QueryCommand } from '../query';
 import { UpdateCommand } from '../update';
 import { UpsertCommand } from '../upsert';
+import { VectorOperationsProvider } from '../vectorOperationsProvider';
 import { Index } from '../index';
 import type { ScoredPineconeRecord } from '../query';
 
@@ -9,6 +10,7 @@ jest.mock('../fetch');
 jest.mock('../query');
 jest.mock('../update');
 jest.mock('../upsert');
+jest.mock('../vectorOperationsProvider');
 
 describe('Index', () => {
   let config;
@@ -24,165 +26,188 @@ describe('Index', () => {
     };
   });
 
-  test('can write functions that take types with generic params', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const fn1 = (record: ScoredPineconeRecord) => {
-      // no type errors on this because typescript doesn't know anything about what keys are defined
-      // ScoredPineconeRecord without specifying the generic type param
-      console.log(record.metadata && record.metadata.yolo);
-    };
-    type MyMeta = {
-      name: string;
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const fn2 = (record: ScoredPineconeRecord<MyMeta>) => {
-      console.log(record.metadata && record.metadata.name);
-
-      // @ts-expect-error because bogus not in MyMeta
-      console.log(record.metadata && record.metadata.bogus);
-    };
+  describe('index initialization', () => {
+    test('passes config, indexName, indexHostUrl, and additionalHeaders to VectorOperationsProvider', () => {
+      const indexHostUrl = 'https://test-api-pinecone.io';
+      const additionalHeaders = { 'x-custom-header': 'custom-value' };
+      new Index(
+        'index-name',
+        config,
+        undefined,
+        indexHostUrl,
+        additionalHeaders
+      );
+      expect(VectorOperationsProvider).toHaveBeenCalledTimes(1);
+      expect(VectorOperationsProvider).toHaveBeenCalledWith(
+        config,
+        'index-name',
+        indexHostUrl,
+        additionalHeaders
+      );
+    });
   });
 
-  test('can be used without generic types param', async () => {
-    const index = new Index('index-name', config, 'namespace');
+  describe('metadata', () => {
+    test('can write functions that take types with generic params', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const fn1 = (record: ScoredPineconeRecord) => {
+        // no type errors on this because typescript doesn't know anything about what keys are defined
+        // ScoredPineconeRecord without specifying the generic type param
+        console.log(record.metadata && record.metadata.yolo);
+      };
+      type MyMeta = {
+        name: string;
+      };
 
-    // You can use the index class without passing the generic type for metadata,
-    // but you lose type safety in that case.
-    await index.update({ id: '1', metadata: { foo: 'bar' } });
-    await index.update({ id: '1', metadata: { baz: 'quux' } });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const fn2 = (record: ScoredPineconeRecord<MyMeta>) => {
+        console.log(record.metadata && record.metadata.name);
 
-    // Same thing with upsert. You can upsert anything in metadata field without type.
-    await index.upsert([
-      { id: '2', values: [0.1, 0.2], metadata: { hello: 'world' } },
-    ]);
+        // @ts-expect-error because bogus not in MyMeta
+        console.log(record.metadata && record.metadata.bogus);
+      };
+    });
 
-    // @ts-expect-error even when you haven't passed a generic type, it enforces the expected shape of RecordMetadata
-    await index.upsert([{ id: '2', values: [0.1, 0.2], metadata: 2 }]);
-  });
+    test('can be used without generic types param', async () => {
+      const index = new Index('index-name', config, 'namespace');
 
-  test('preserves metadata typing through chained namespace calls', async () => {
-    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
-    const ns1 = index.namespace('ns1');
+      // You can use the index class without passing the generic type for metadata,
+      // but you lose type safety in that case.
+      await index.update({ id: '1', metadata: { foo: 'bar' } });
+      await index.update({ id: '1', metadata: { baz: 'quux' } });
 
-    // @ts-expect-error because MovieMetadata metadata still expected after chained namespace call
-    await ns1.update({ id: '1', metadata: { title: 'Vertigo', rating: 5 } });
-  });
+      // Same thing with upsert. You can upsert anything in metadata field without type.
+      await index.upsert([
+        { id: '2', values: [0.1, 0.2], metadata: { hello: 'world' } },
+      ]);
 
-  test('upsert: has type errors when passing malformed metadata', async () => {
-    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
-    expect(UpsertCommand).toHaveBeenCalledTimes(1);
+      // @ts-expect-error even when you haven't passed a generic type, it enforces the expected shape of RecordMetadata
+      await index.upsert([{ id: '2', values: [0.1, 0.2], metadata: 2 }]);
+    });
 
-    // No ts errors when upserting with proper MovieMetadata
-    await index.upsert([
-      {
-        id: '1',
-        values: [0.1, 0.1, 0.1],
-        metadata: {
-          genre: 'romance',
-          runtime: 120,
+    test('preserves metadata typing through chained namespace calls', async () => {
+      const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+      const ns1 = index.namespace('ns1');
+
+      // @ts-expect-error because MovieMetadata metadata still expected after chained namespace call
+      await ns1.update({ id: '1', metadata: { title: 'Vertigo', rating: 5 } });
+    });
+
+    test('upsert: has type errors when passing malformed metadata', async () => {
+      const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+      expect(UpsertCommand).toHaveBeenCalledTimes(1);
+
+      // No ts errors when upserting with proper MovieMetadata
+      await index.upsert([
+        {
+          id: '1',
+          values: [0.1, 0.1, 0.1],
+          metadata: {
+            genre: 'romance',
+            runtime: 120,
+          },
         },
-      },
-    ]);
+      ]);
 
-    // No ts errors when upserting with no metadata
-    await index.upsert([
-      {
-        id: '2',
-        values: [0.1, 0.1, 0.1],
-      },
-    ]);
-
-    // ts error expected when passing metadata that doesn't match MovieMetadata
-    await index.upsert([
-      {
-        id: '3',
-        values: [0.1, 0.1, 0.1],
-        metadata: {
-          // @ts-expect-error
-          somethingElse: 'foo',
+      // No ts errors when upserting with no metadata
+      await index.upsert([
+        {
+          id: '2',
+          values: [0.1, 0.1, 0.1],
         },
-      },
-    ]);
-  });
+      ]);
 
-  test('fetch: response is typed with generic metadata type', async () => {
-    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
-    expect(FetchCommand).toHaveBeenCalledTimes(1);
+      // ts error expected when passing metadata that doesn't match MovieMetadata
+      await index.upsert([
+        {
+          id: '3',
+          values: [0.1, 0.1, 0.1],
+          metadata: {
+            // @ts-expect-error
+            somethingElse: 'foo',
+          },
+        },
+      ]);
+    });
 
-    const response = await index.fetch(['1']);
-    if (response && response.records) {
-      // eslint-disable-next-line
-      Object.entries(response.records).forEach(([key, value]) => {
-        // No errors on these because they are properties from MovieMetadata
-        console.log(value.metadata?.genre);
-        console.log(value.metadata?.runtime);
+    test('fetch: response is typed with generic metadata type', async () => {
+      const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+      expect(FetchCommand).toHaveBeenCalledTimes(1);
 
-        // @ts-expect-error because result is expecting metadata to be MovieMetadata
-        console.log(value.metadata?.bogus);
-      });
-    }
-  });
+      const response = await index.fetch(['1']);
+      if (response && response.records) {
+        // eslint-disable-next-line
+        Object.entries(response.records).forEach(([key, value]) => {
+          // No errors on these because they are properties from MovieMetadata
+          console.log(value.metadata?.genre);
+          console.log(value.metadata?.runtime);
 
-  test('query: returns typed results', async () => {
-    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
-    expect(QueryCommand).toHaveBeenCalledTimes(1);
-
-    const results = await index.query({ id: '1', topK: 5 });
-    if (results && results.matches) {
-      if (results.matches.length > 0) {
-        const firstResult = results.matches[0];
-
-        // no ts error because score is part of ScoredPineconeRecord
-        console.log(firstResult.score);
-
-        // no ts error because genre and runtime part of MovieMetadata
-        console.log(firstResult.metadata?.genre);
-        console.log(firstResult.metadata?.runtime);
-
-        // @ts-expect-error because bogus not part of MovieMetadata
-        console.log(firstResult.metadata?.bogus);
+          // @ts-expect-error because result is expecting metadata to be MovieMetadata
+          console.log(value.metadata?.bogus);
+        });
       }
-    }
-  });
-
-  test('update: has typed arguments', async () => {
-    const index = new Index<MovieMetadata>('index-name', config, 'namespace');
-    expect(UpdateCommand).toHaveBeenCalledTimes(1);
-
-    // Can update metadata only without ts errors
-    await index.update({
-      id: '1',
-      metadata: { genre: 'romance', runtime: 90 },
     });
 
-    // Can update values only without ts errors
-    await index.update({ id: '2', values: [0.1, 0.2, 0.3] });
+    test('query: returns typed results', async () => {
+      const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+      expect(QueryCommand).toHaveBeenCalledTimes(1);
 
-    // Can update sparseValues only without ts errors
-    await index.update({
-      id: '3',
-      sparseValues: { indices: [0, 3], values: [0.2, 0.5] },
+      const results = await index.query({ id: '1', topK: 5 });
+      if (results && results.matches) {
+        if (results.matches.length > 0) {
+          const firstResult = results.matches[0];
+
+          // no ts error because score is part of ScoredPineconeRecord
+          console.log(firstResult.score);
+
+          // no ts error because genre and runtime part of MovieMetadata
+          console.log(firstResult.metadata?.genre);
+          console.log(firstResult.metadata?.runtime);
+
+          // @ts-expect-error because bogus not part of MovieMetadata
+          console.log(firstResult.metadata?.bogus);
+        }
+      }
     });
 
-    // Can update all fields without ts errors
-    await index.update({
-      id: '4',
-      values: [0.1, 0.2, 0.3],
-      sparseValues: { indices: [0], values: [0.789] },
-      metadata: { genre: 'horror', runtime: 10 },
-    });
+    test('update: has typed arguments', async () => {
+      const index = new Index<MovieMetadata>('index-name', config, 'namespace');
+      expect(UpdateCommand).toHaveBeenCalledTimes(1);
 
-    // @ts-expect-error when id is missing
-    await index.update({ metadata: { genre: 'drama', runtime: 97 } });
+      // Can update metadata only without ts errors
+      await index.update({
+        id: '1',
+        metadata: { genre: 'romance', runtime: 90 },
+      });
 
-    // @ts-expect-error when metadata has unexpected fields
-    await index.update({ id: '5', metadata: { title: 'Vertigo' } });
+      // Can update values only without ts errors
+      await index.update({ id: '2', values: [0.1, 0.2, 0.3] });
 
-    await index.update({
-      id: '6',
-      // @ts-expect-error when metadata has extra properties
-      metadata: { genre: 'comedy', runtime: 80, title: 'Miss Congeniality' },
+      // Can update sparseValues only without ts errors
+      await index.update({
+        id: '3',
+        sparseValues: { indices: [0, 3], values: [0.2, 0.5] },
+      });
+
+      // Can update all fields without ts errors
+      await index.update({
+        id: '4',
+        values: [0.1, 0.2, 0.3],
+        sparseValues: { indices: [0], values: [0.789] },
+        metadata: { genre: 'horror', runtime: 10 },
+      });
+
+      // @ts-expect-error when id is missing
+      await index.update({ metadata: { genre: 'drama', runtime: 97 } });
+
+      // @ts-expect-error when metadata has unexpected fields
+      await index.update({ id: '5', metadata: { title: 'Vertigo' } });
+
+      await index.update({
+        id: '6',
+        // @ts-expect-error when metadata has extra properties
+        metadata: { genre: 'comedy', runtime: 80, title: 'Miss Congeniality' },
+      });
     });
   });
 });

--- a/src/data/dataOperationsProvider.ts
+++ b/src/data/dataOperationsProvider.ts
@@ -3,6 +3,7 @@ import {
   Configuration,
   ConfigurationParameters,
   DataPlaneApi,
+  type HTTPHeaders,
 } from '../pinecone-generated-ts-fetch';
 import {
   queryParamsStringify,
@@ -18,15 +19,18 @@ export class DataOperationsProvider {
   private indexName: string;
   private indexHostUrl?: string;
   private dataOperations?: DataPlaneApi;
+  private additionalHeaders?: HTTPHeaders;
 
   constructor(
     config: PineconeConfiguration,
     indexName: string,
-    indexHostUrl?: string
+    indexHostUrl?: string,
+    additionalHeaders?: HTTPHeaders
   ) {
     this.config = config;
     this.indexName = indexName;
     this.indexHostUrl = normalizeUrl(indexHostUrl);
+    this.additionalHeaders = additionalHeaders;
   }
 
   async provide() {
@@ -51,12 +55,15 @@ export class DataOperationsProvider {
   }
 
   buildDataOperationsConfig() {
+    const headers = this.additionalHeaders || null;
+
     const indexConfigurationParameters: ConfigurationParameters = {
       basePath: this.indexHostUrl,
       apiKey: this.config.apiKey,
       queryParamsStringify,
       headers: {
-        'User-Agent': buildUserAgent(),
+        'User-Agent': buildUserAgent(this.config),
+        ...headers,
       },
       fetchApi: getFetch(this.config),
       middleware,

--- a/src/data/dataOperationsProvider.ts
+++ b/src/data/dataOperationsProvider.ts
@@ -3,8 +3,8 @@ import {
   Configuration,
   ConfigurationParameters,
   DataPlaneApi,
-  type HTTPHeaders,
 } from '../pinecone-generated-ts-fetch';
+import type { HTTPHeaders } from '../pinecone-generated-ts-fetch';
 import {
   queryParamsStringify,
   buildUserAgent,

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -14,6 +14,7 @@ import { describeIndexStats } from './describeIndexStats';
 import { DataOperationsProvider } from './dataOperationsProvider';
 import { listPaginated } from './list';
 import type { ListOptions } from './list';
+import type { HTTPHeaders } from '../pinecone-generated-ts-fetch';
 import type {
   PineconeConfiguration,
   RecordMetadata,
@@ -333,12 +334,14 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @param config - The configuration from the Pinecone client.
    * @param namespace - The namespace for the index.
    * @param indexHostUrl - An optional override for the host address used for data operations.
+   * @param additionalHeaders - An optional object of additional header to send with each request.
    */
   constructor(
     indexName: string,
     config: PineconeConfiguration,
     namespace = '',
-    indexHostUrl?: string
+    indexHostUrl?: string,
+    additionalHeaders?: HTTPHeaders
   ) {
     this.config = config;
     this.target = {
@@ -350,7 +353,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
     const apiProvider = new DataOperationsProvider(
       config,
       indexName,
-      indexHostUrl
+      indexHostUrl,
+      additionalHeaders
     );
 
     this._deleteAll = deleteAll(apiProvider, namespace);

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -43,9 +43,9 @@ export type PineconeConfiguration = {
   additionalHeaders?: HTTPHeaders;
 
   /**
-   * Optional integration id that is applied to the User-Agent header with all requests.
+   * Optional sourceTag that is applied to the User-Agent header with all requests.
    */
-  integrationId?: string;
+  sourceTag?: string;
 };
 
 export const RecordIdSchema = Type.String({ minLength: 1 });

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -41,6 +41,11 @@ export type PineconeConfiguration = {
    * Optional headers to be included in all requests.
    */
   additionalHeaders?: HTTPHeaders;
+
+  /**
+   * Optional integration id that is applied to the User-Agent header with all requests.
+   */
+  integrationId?: string;
 };
 
 export const RecordIdSchema = Type.String({ minLength: 1 });

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -16,6 +16,7 @@ import {
 import {
   ConfigureIndexRequestSpecPod,
   CreateCollectionRequest,
+  type HTTPHeaders,
 } from './pinecone-generated-ts-fetch';
 import { IndexHostSingleton } from './data/indexHostSingleton';
 import {
@@ -619,14 +620,22 @@ export class Pinecone {
    * @typeParam T - The type of metadata associated with each record.
    * @param indexName - The name of the index to target.
    * @param indexHostUrl - An optional host url to use for operations against this index. If not provided, the host url will be resolved by calling {@link describeIndex}.
+   * @param additionalHeaders - An optional object containing additional headers to pass with each index request.
    * @typeParam T - The type of the metadata object associated with each record.
    * @returns An {@link Index} object that can be used to perform data operations.
    */
   index<T extends RecordMetadata = RecordMetadata>(
     indexName: string,
-    indexHostUrl?: string
+    indexHostUrl?: string,
+    additionalHeaders?: HTTPHeaders
   ) {
-    return new Index<T>(indexName, this.config, undefined, indexHostUrl);
+    return new Index<T>(
+      indexName,
+      this.config,
+      undefined,
+      indexHostUrl,
+      additionalHeaders
+    );
   }
 
   /**
@@ -635,8 +644,9 @@ export class Pinecone {
   // Alias method to match the Python SDK capitalization
   Index<T extends RecordMetadata = RecordMetadata>(
     indexName: string,
-    indexHostUrl?: string
+    indexHostUrl?: string,
+    additionalHeaders?: HTTPHeaders
   ) {
-    return this.index<T>(indexName, indexHostUrl);
+    return this.index<T>(indexName, indexHostUrl, additionalHeaders);
   }
 }

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -16,8 +16,8 @@ import {
 import {
   ConfigureIndexRequestSpecPod,
   CreateCollectionRequest,
-  type HTTPHeaders,
 } from './pinecone-generated-ts-fetch';
+import type { HTTPHeaders } from './pinecone-generated-ts-fetch';
 import { IndexHostSingleton } from './data/indexHostSingleton';
 import {
   PineconeConfigurationError,

--- a/src/utils/__tests__/user-agent.test.ts
+++ b/src/utils/__tests__/user-agent.test.ts
@@ -1,22 +1,47 @@
 import { buildUserAgent } from '../user-agent';
 import * as EnvironmentModule from '../environment';
 
-describe('buildUserAgent', () => {
-  test('applies Edge Runtime when running in an edge environment', () => {
-    jest.spyOn(EnvironmentModule, 'isEdge').mockReturnValue(true);
-    const config = { apiKey: 'test-api-key' };
-    const userAgent = buildUserAgent(config);
+describe('user-agent', () => {
+  describe('buildUserAgent', () => {
+    test('applies Edge Runtime when running in an edge environment', () => {
+      jest.spyOn(EnvironmentModule, 'isEdge').mockReturnValue(true);
+      const config = { apiKey: 'test-api-key' };
+      const userAgent = buildUserAgent(config);
 
-    expect(userAgent).toContain('Edge Runtime');
+      expect(userAgent).toContain('Edge Runtime');
+    });
+
+    test('applies source_tag when provided via PineconeConfiguration', () => {
+      const config = {
+        apiKey: 'test-api-key',
+        sourceTag: 'test source tag',
+      };
+
+      const userAgent = buildUserAgent(config);
+      expect(userAgent).toContain('source_tag=test_source_tag');
+    });
   });
 
-  test('applies integrationId when provided via PineconeConfiguration', () => {
-    const config = {
-      apiKey: 'test-api-key',
-      integrationId: 'test-integration-id',
-    };
+  describe('normalizeSourceTag', () => {
+    test('normalizes variations of sourceTag', () => {
+      const config = {
+        apiKey: 'test-api-key',
+        sourceTag: 'my source tag!!!',
+      };
+      let userAgent = buildUserAgent(config);
+      expect(userAgent).toContain('source_tag=my_source_tag');
 
-    const userAgent = buildUserAgent(config);
-    expect(userAgent).toContain('integrationId=test-integration-id');
+      config.sourceTag = 'My Source Tag';
+      userAgent = buildUserAgent(config);
+      expect(userAgent).toContain('source_tag=my_source_tag');
+
+      config.sourceTag = '   My   Source    Tag       123    ';
+      userAgent = buildUserAgent(config);
+      expect(userAgent).toContain('source_tag=my_source_tag_123');
+
+      config.sourceTag = '  MY SOURCE TAG     1234     ##### !!!!!!';
+      userAgent = buildUserAgent(config);
+      expect(userAgent).toContain('source_tag=my_source_tag_1234');
+    });
   });
 });

--- a/src/utils/__tests__/user-agent.test.ts
+++ b/src/utils/__tests__/user-agent.test.ts
@@ -1,0 +1,22 @@
+import { buildUserAgent } from '../user-agent';
+import * as EnvironmentModule from '../environment';
+
+describe('buildUserAgent', () => {
+  test('applies Edge Runtime when running in an edge environment', () => {
+    jest.spyOn(EnvironmentModule, 'isEdge').mockReturnValue(true);
+    const config = { apiKey: 'test-api-key' };
+    const userAgent = buildUserAgent(config);
+
+    expect(userAgent).toContain('Edge Runtime');
+  });
+
+  test('applies integrationId when provided via PineconeConfiguration', () => {
+    const config = {
+      apiKey: 'test-api-key',
+      integrationId: 'test-integration-id',
+    };
+
+    const userAgent = buildUserAgent(config);
+    expect(userAgent).toContain('integrationId=test-integration-id');
+  });
+});

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -20,9 +20,28 @@ export const buildUserAgent = (config: PineconeConfiguration) => {
     userAgentParts.push(`node ${process.version}`);
   }
 
-  if (config.integrationId) {
-    userAgentParts.push(`integrationId=${config.integrationId}`);
+  if (config.sourceTag) {
+    userAgentParts.push(`source_tag=${normalizeSourceTag(config.sourceTag)}`);
   }
 
   return userAgentParts.join('; ');
+};
+
+const normalizeSourceTag = (sourceTag: string) => {
+  if (!sourceTag) {
+    return;
+  }
+
+  /**
+   * normalize sourceTag
+   * 1. Lowercase
+   * 2. Limit charset to [a-z0-9_ ]
+   * 3. Trim left/right spaces
+   * 4. Condense multiple spaces to one, and replace with underscore
+   */
+  return sourceTag
+    .toLowerCase()
+    .replace(/[^a-z0-9_ ]/g, '')
+    .trim()
+    .replace(/[ ]+/g, '_');
 };

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,7 +1,8 @@
 import { isEdge } from './environment';
+import type { PineconeConfiguration } from '../data/types';
 import * as packageInfo from '../version.json';
 
-export const buildUserAgent = () => {
+export const buildUserAgent = (config: PineconeConfiguration) => {
   // We always want to include the package name and version
   // along with the langauge name to help distinguish these
   // requests from those emitted by other clients
@@ -17,6 +18,10 @@ export const buildUserAgent = () => {
   // If available, capture information about the Node.js version
   if (typeof process !== 'undefined' && process && process.version) {
     userAgentParts.push(`node ${process.version}`);
+  }
+
+  if (config.integrationId) {
+    userAgentParts.push(`integrationId=${config.integrationId}`);
   }
 
   return userAgentParts.join('; ');


### PR DESCRIPTION
## Problem
We want to provide the ability for consumers to include a `source_tag` to identify the source of requests while using the client. Additionally, there are debugging and development scenarios where being able to pass additional headers with network requests would be convenient.

## Solution
- Add `sourceTag` to `PineconeConfiguration`. Update `buildUserAgent()` to take in `PineconeConfiguration`, which should be available at all the points we call to build the agent. If `sourceTag` is provided it will be normalized, and inserted into the `User-Agent` header for all network requests with this format: `source_tag=<normalizeSourceTag>`. 
  - Normalization rules:
  - Lowercase
  - Limit to charset `[a-z0-9_ ]`
  - Trim left/right space
  - Condense all spaces to one space and replace with `_`
- Add `additionalHeaders` to the `Index` constructor. Custom headers can now be provided when targeting a specific index. `Index` now passes these headers to `VectorOperationsProvider` when setting up the API.
- Update `VectorOperationsProvider` to apply `additionalHeaders` to the API `Configuration` when provided.

## Type of Change
New feature, but specific to developer / support usage.
- [X] New feature (non-breaking change which adds functionality)

## Test Plan
New unit test files:
- `indexOperationsBuilder.test.ts`
- `user-agent.test.ts`

New unit test for validating `additionalHeaders` is passed as expected, a bit of refactoring in `index.test.ts` which appears messier than it is.

Running locally with `PINECONE_DEBUG=true` to make sure the custom headers / `sourceTag` are passed on requests when provided.

### Passing `integrationId`
```typescript
import { Pinecone } from '@pinecone-database/pinecone'

const pc = new Pinecone({ apiKey: 'your-api-key', sourceTag: 'test source tag' });
const index = pc.Index('my-index');

// Test control + data plane operations
await pc.listIndexes();
await index.upsert(...);
```

### Passing `additionalHeaders` to `Index`
```typescript
import { Pinecone } from '@pinecone-database/pinecone'

const pc = new Pinecone({ apiKey: 'your-api-key', sourceTag: 'test source tag' });
const index = pc.Index('my-index', undefined, { 'x-custom-header': 'header-value' });

// Make requests
await index.upsert(...);
```
