### PR TITLE
types(update): wrap metadata param in `Partial`

### DIFF
--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -45,7 +45,7 @@ export type UpdateOptions<T extends RecordMetadata = RecordMetadata> = {
   /**
    * The metadata you would like to store with this record.
    */
-  metadata?: T;
+  metadata?: Partial<T>;
 };
 
 export class UpdateCommand<T extends RecordMetadata = RecordMetadata> {


### PR DESCRIPTION
## Problem

This PR makes it so that you don't need to supply all of the required fields in your custom metadata interface when updating a vector using the TS client.

For example, say I have a metadata interface defined as the following:

```
interface MyMetadata {
  title: string;
  source: string;
  isArchived?: boolean;
}
```
I want to update the value for `isArchived`, but I want to leave the values for `title` and `source` as is. I'd write the following code, but I get a type error because no value for `title` or `source` were provided

```
const ns = pinecone.index<MyMetadata>(indexName).namespace(namespace);
await ns.update({ id: "abc123", metadata: { isArchived: true });
```

```
Type '{ isArchived: boolean; }' is missing the following properties from type '{ title: string; source: string; isArchived?: boolean | undefined; }': title, source
```

## Solution

By wrapping the generic in `Partial`, we make it so that all of the fields in the interface are optional which is the intent of this method according to the [documentation](https://docs.pinecone.io/reference/update)

> If set_metadata is included, the values of the fields specified in it will be added or overwrite the previous value.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

N/A