### PR TITLE
Clean up docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ PINECONE_API_KEY="your_api_key"
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
 
-const client = new Pinecone();
+const pc = new Pinecone();
 ```
 
 #### Using a configuration object
@@ -55,7 +55,7 @@ If you prefer to pass configuration in code, the constructor accepts a config ob
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
 
-const client = new Pinecone({
+const pc = new Pinecone({
   apiKey: 'your_api_key',
 });
 ```
@@ -76,9 +76,9 @@ The `spec` configures how the index should be deployed. For serverless indexes, 
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.createIndex({
+await pc.createIndex({
   name: 'sample-index',
   dimension: 1536,
   spec: {
@@ -96,9 +96,9 @@ To create a pod-based index, you define `pod` in the `spec` object which contain
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.createIndex({
+await pc.createIndex({
   name: 'sample-index-2',
   dimension: 1536,
   metric: 'dotproduct',
@@ -129,9 +129,9 @@ not immediately ready for upserting, querying, or performing other data operatio
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.describeIndex('serverless-index');
+await pc.describeIndex('serverless-index');
 // {
 //    name: 'serverless-index',
 //    dimension: 1536,
@@ -149,7 +149,7 @@ await client.describeIndex('serverless-index');
 //    }
 // }
 
-await client.describeIndex('serverless-index');
+await pc.describeIndex('serverless-index');
 // {
 //    name: 'serverless-index',
 //    dimension: 1536,
@@ -174,9 +174,9 @@ If you pass the `waitUntilReady` option, the client will handle polling for stat
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.createIndex({
+await pc.createIndex({
   name: 'serverless-index',
   dimension: 1536,
   spec: {
@@ -201,9 +201,9 @@ Given that you have an existing collection:
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.describeCollection('product-description-embeddings');
+await pc.describeCollection('product-description-embeddings');
 // {
 //   name: 'product-description-embeddings',
 //   size: 543427063,
@@ -218,9 +218,9 @@ You can specify a sourceCollection along with other configuration in your `creat
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.createIndex({
+await pc.createIndex({
   name: 'product-description-p1x1',
   dimension: 256,
   metric: 'cosine'
@@ -239,9 +239,9 @@ When the new index is ready, it should contain all the data that was in the coll
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.index('product-description-p2x2').describeIndexStats();
+await pc.index('product-description-p2x2').describeIndexStats();
 // {
 //   namespaces: { '': { recordCount: 78000 } },
 //   dimension: 256,
@@ -256,9 +256,9 @@ You can fetch the description of any index by name using `describeIndex`.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.describeIndex('serverless-index');
+await pc.describeIndex('serverless-index');
 // {
 //    name: 'serverless-index',
 //    dimension: 1536,
@@ -287,10 +287,10 @@ You can adjust the number of replicas or scale to a larger pod size (specified w
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.configureIndex('pod-index', { replicas: 3 });
-const config = await client.describeIndex('pod-index');
+await pc.configureIndex('pod-index', { replicas: 3 });
+const config = await pc.describeIndex('pod-index');
 // {
 //    name: 'pod-index',
 //    dimension: 1536,
@@ -318,9 +318,9 @@ Indexes are deleted by name.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.deleteIndex('sample-index');
+await pc.deleteIndex('sample-index');
 ```
 
 ### List Indexes
@@ -329,9 +329,9 @@ The `listIndexes` command returns an object with an array of index models under 
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.listIndexes();
+await pc.listIndexes();
 // {
 //   indexes: [
 //     {
@@ -385,9 +385,9 @@ A collection is a static copy of a pod-based index that may be used to create ba
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.createCollection({
+await pc.createCollection({
   name: 'collection-name',
   source: 'index-name',
 });
@@ -399,9 +399,9 @@ This API call should return quickly, but the creation of a collection can take f
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.deleteCollection('collection-name');
+await pc.deleteCollection('collection-name');
 ```
 
 You can use `listCollections` to confirm the deletion.
@@ -410,9 +410,9 @@ You can use `listCollections` to confirm the deletion.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-const describeCollection = await client.describeCollection('collection3');
+const describeCollection = await pc.describeCollection('collection3');
 // {
 //   name: 'collection3',
 //   size: 3126700,
@@ -428,9 +428,9 @@ The `listCollections` command returns an object with an array of collection mode
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-const list = await client.listCollections();
+const list = await pc.listCollections();
 // {
 //   collections: [
 //     {
@@ -463,8 +463,8 @@ To perform data operations on an index, you target it using the `index` method.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('test-index');
+const pc = new Pinecone();
+const index = pc.index('test-index');
 
 // Now perform index operations
 await index.fetch(['1']);
@@ -474,8 +474,8 @@ The first argument is the name of the index you are targeting. There's an option
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('test-index', 'my-index-host-1532-svc.io');
+const pc = new Pinecone();
+const index = pc.index('test-index', 'my-index-host-1532-svc.io');
 
 // Now perform index operations against: https://my-index-host-1532-svc.io
 await index.fetch(['1']);
@@ -487,7 +487,7 @@ If you are storing metadata alongside your vector values, you can pass a type pa
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
 type MovieMetadata = {
   title: string,
@@ -496,7 +496,7 @@ type MovieMetadata = {
 }
 
 // Specify a custom metadata type while targeting the index
-const index = client.index<MovieMetadata>('test-index');
+const index = pc.index<MovieMetadata>('test-index');
 
 // Now you get type errors if upserting malformed metadata
 await index.upsert([{
@@ -539,8 +539,8 @@ By default, all data operations take place inside the default namespace of `''`.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('test-index').namespace('ns1');
+const pc = new Pinecone();
+const index = pc.index('test-index').namespace('ns1');
 
 // Now perform index operations in the targeted index and namespace
 await index.fetch(['1']);
@@ -550,8 +550,8 @@ If needed, you can check the currently targeted index and namespace by inspectin
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('test-index').namespace('ns1');
+const pc = new Pinecone();
+const index = pc.index('test-index').namespace('ns1');
 
 console.log(index.target); // { index: 'test-index', namespace: 'ns1', indexHostUrl: undefined }
 ```
@@ -575,10 +575,10 @@ To upsert some records, you can use the client like so:
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
 // Target an index
-const index = client.index('sample-index');
+const index = pc.index('sample-index');
 
 // Prepare your data. The length of each array
 // of vector values must match the dimension of
@@ -605,8 +605,8 @@ target the index and use the `describeIndexStats()` command.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('example-index');
+const pc = new Pinecone();
+const index = pc.index('example-index');
 
 await index.describeIndexStats();
 // {
@@ -645,8 +645,8 @@ For example, to query by vector values you would pass the `vector` param in the 
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('my-index');
+const pc = new Pinecone();
+const index = pc.index('my-index');
 
 await index.query({ topK: 3, vector: [0.22, 0.66] });
 // {
@@ -686,10 +686,10 @@ Remember that data operations take place within the context of a namespace, so i
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
 // Target the index and namespace
-const index = client.index('my-index').namespace('my-namespace');
+const index = pc.index('my-index').namespace('my-namespace');
 
 const results = await index.query({ topK: 3, vector: [0.22, 0.66] });
 ```
@@ -700,8 +700,8 @@ You can query using the vector values of an existing record in the index by pass
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('my-index');
+const pc = new Pinecone();
+const index = pc.index('my-index');
 
 const results = await index.query({ topK: 10, id: '1' });
 ```
@@ -712,9 +712,9 @@ If you are working with [sparse-dense vectors](https://docs.pinecone.io/v2/docs/
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
+const pc = new Pinecone();
 
-await client.createIndex({
+await pc.createIndex({
   name: 'hyrbid-image-search',
   metric: 'dotproduct',
   dimension: 512,
@@ -755,8 +755,8 @@ You may want to update vector `values`, `sparseValues`, or `metadata`. Specify t
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('imdb-movies');
+const pc = new Pinecone();
+const index = pc.index('imdb-movies');
 
 await index.update({
   id: '18593',
@@ -768,8 +768,8 @@ await index.update({
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('my-index');
+const pc = new Pinecone();
+const index = pc.index('my-index');
 
 const fetchResult = await index.fetch(['id-1', 'id-2']);
 ```
@@ -782,8 +782,8 @@ For convenience there are several delete-related methods. You can verify the res
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('my-index');
+const pc = new Pinecone();
+const index = pc.index('my-index');
 
 await index.deleteOne('id-to-delete');
 ```
@@ -792,8 +792,8 @@ await index.deleteOne('id-to-delete');
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('my-index');
+const pc = new Pinecone();
+const index = pc.index('my-index');
 
 await index.deleteMany(['id-1', 'id-2', 'id-3']);
 ```
@@ -802,8 +802,8 @@ await index.deleteMany(['id-1', 'id-2', 'id-3']);
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('albums-database');
+const pc = new Pinecone();
+const index = pc.index('albums-database');
 
 await index.deleteMany({ genre: 'rock' });
 ```
@@ -818,8 +818,8 @@ To nuke everything in the targeted namespace, use the `deleteAll` method.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const client = new Pinecone();
-const index = client.index('my-index');
+const pc = new Pinecone();
+const index = pc.index('my-index');
 
 await index.namespace('foo-namespace').deleteAll();
 ```

--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ await pc.createIndex({
   },
   waitUntilReady: true
 });
-const index = client.index('hybrid-image-search');
+const index = pc.index('hybrid-image-search');
 
 // Create some vector embeddings using your model of choice.
 const records = [...]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ PINECONE_API_KEY="your_api_key"
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
 
-const pc = new Pinecone();
+const client = new Pinecone();
 ```
 
 #### Using a configuration object
@@ -55,7 +55,7 @@ If you prefer to pass configuration in code, the constructor accepts a config ob
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
 
-const pc = new Pinecone({
+const client = new Pinecone({
   apiKey: 'your_api_key',
 });
 ```
@@ -76,9 +76,9 @@ The `spec` configures how the index should be deployed. For serverless indexes, 
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.createIndex({
+await client.createIndex({
   name: 'sample-index',
   dimension: 1536,
   spec: {
@@ -96,9 +96,9 @@ To create a pod-based index, you define `pod` in the `spec` object which contain
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.createIndex({
+await client.createIndex({
   name: 'sample-index-2',
   dimension: 1536,
   metric: 'dotproduct',
@@ -129,9 +129,9 @@ not immediately ready for upserting, querying, or performing other data operatio
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.describeIndex('serverless-index');
+await client.describeIndex('serverless-index');
 // {
 //    name: 'serverless-index',
 //    dimension: 1536,
@@ -149,7 +149,7 @@ await pc.describeIndex('serverless-index');
 //    }
 // }
 
-await pc.describeIndex('serverless-index');
+await client.describeIndex('serverless-index');
 // {
 //    name: 'serverless-index',
 //    dimension: 1536,
@@ -174,9 +174,9 @@ If you pass the `waitUntilReady` option, the client will handle polling for stat
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.createIndex({
+await client.createIndex({
   name: 'serverless-index',
   dimension: 1536,
   spec: {
@@ -201,9 +201,9 @@ Given that you have an existing collection:
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.describeCollection('product-description-embeddings');
+await client.describeCollection('product-description-embeddings');
 // {
 //   name: 'product-description-embeddings',
 //   size: 543427063,
@@ -218,9 +218,9 @@ You can specify a sourceCollection along with other configuration in your `creat
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.createIndex({
+await client.createIndex({
   name: 'product-description-p1x1',
   dimension: 256,
   metric: 'cosine'
@@ -239,9 +239,9 @@ When the new index is ready, it should contain all the data that was in the coll
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.index('product-description-p2x2').describeIndexStats();
+await client.index('product-description-p2x2').describeIndexStats();
 // {
 //   namespaces: { '': { recordCount: 78000 } },
 //   dimension: 256,
@@ -256,9 +256,9 @@ You can fetch the description of any index by name using `describeIndex`.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.describeIndex('serverless-index');
+await client.describeIndex('serverless-index');
 // {
 //    name: 'serverless-index',
 //    dimension: 1536,
@@ -287,10 +287,10 @@ You can adjust the number of replicas or scale to a larger pod size (specified w
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.configureIndex('pod-index', { replicas: 3 });
-const config = await pc.describeIndex('pod-index');
+await client.configureIndex('pod-index', { replicas: 3 });
+const config = await client.describeIndex('pod-index');
 // {
 //    name: 'pod-index',
 //    dimension: 1536,
@@ -318,9 +318,9 @@ Indexes are deleted by name.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.deleteIndex('sample-index');
+await client.deleteIndex('sample-index');
 ```
 
 ### List Indexes
@@ -329,9 +329,9 @@ The `listIndexes` command returns an object with an array of index models under 
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.listIndexes();
+await client.listIndexes();
 // {
 //   indexes: [
 //     {
@@ -385,9 +385,9 @@ A collection is a static copy of a pod-based index that may be used to create ba
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.createCollection({
+await client.createCollection({
   name: 'collection-name',
   source: 'index-name',
 });
@@ -399,9 +399,9 @@ This API call should return quickly, but the creation of a collection can take f
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.deleteCollection('collection-name');
+await client.deleteCollection('collection-name');
 ```
 
 You can use `listCollections` to confirm the deletion.
@@ -410,9 +410,9 @@ You can use `listCollections` to confirm the deletion.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-const describeCollection = await pc.describeCollection('collection3');
+const describeCollection = await client.describeCollection('collection3');
 // {
 //   name: 'collection3',
 //   size: 3126700,
@@ -428,9 +428,9 @@ The `listCollections` command returns an object with an array of collection mode
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-const list = await pc.listCollections();
+const list = await client.listCollections();
 // {
 //   collections: [
 //     {
@@ -463,9 +463,9 @@ To perform data operations on an index, you target it using the `index` method.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('test-index');
 
-const index = pc.index('test-index');
 // Now perform index operations
 await index.fetch(['1']);
 ```
@@ -474,9 +474,9 @@ The first argument is the name of the index you are targeting. There's an option
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('test-index', 'my-index-host-1532-svc.io');
 
-const index = pc.index('test-index', 'my-index-host-1532-svc.io');
 // Now perform index operations against: https://my-index-host-1532-svc.io
 await index.fetch(['1']);
 ```
@@ -487,7 +487,7 @@ If you are storing metadata alongside your vector values, you can pass a type pa
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
 type MovieMetadata = {
   title: string,
@@ -496,7 +496,7 @@ type MovieMetadata = {
 }
 
 // Specify a custom metadata type while targeting the index
-const index = pc.index<MovieMetadata>('test-index');
+const index = client.index<MovieMetadata>('test-index');
 
 // Now you get type errors if upserting malformed metadata
 await index.upsert([{
@@ -539,9 +539,9 @@ By default, all data operations take place inside the default namespace of `''`.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('test-index').namespace('ns1');
 
-const index = pc.index('test-index').namespace('ns1');
 // Now perform index operations in the targeted index and namespace
 await index.fetch(['1']);
 ```
@@ -550,9 +550,9 @@ If needed, you can check the currently targeted index and namespace by inspectin
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('test-index').namespace('ns1');
 
-const index = pc.index('test-index').namespace('ns1');
 console.log(index.target); // { index: 'test-index', namespace: 'ns1', indexHostUrl: undefined }
 ```
 
@@ -575,10 +575,10 @@ To upsert some records, you can use the client like so:
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
 // Target an index
-const index = pc.index('sample-index');
+const index = client.index('sample-index');
 
 // Prepare your data. The length of each array
 // of vector values must match the dimension of
@@ -605,9 +605,10 @@ target the index and use the `describeIndexStats()` command.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('example-index');
 
-await pc.index('example-index').describeIndexStats();
+await index.describeIndexStats();
 // {
 //   namespaces: {
 //     '': { recordCount: 10 }
@@ -644,9 +645,10 @@ For example, to query by vector values you would pass the `vector` param in the 
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('my-index');
 
-await pc.index('my-index').query({ topK: 3, vector: [0.22, 0.66] });
+await index.query({ topK: 3, vector: [0.22, 0.66] });
 // {
 //   matches: [
 //     {
@@ -684,12 +686,12 @@ Remember that data operations take place within the context of a namespace, so i
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-const results = await pc
-  .index('my-index')
-  .namespace('my-namespace')
-  .query({ topK: 3, vector: [0.22, 0.66] });
+// Target the index and namespace
+const index = client.index('my-index').namespace('my-namespace');
+
+const results = await index.query({ topK: 3, vector: [0.22, 0.66] });
 ```
 
 #### Querying by record id
@@ -698,9 +700,10 @@ You can query using the vector values of an existing record in the index by pass
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('my-index');
 
-const results = await pc.index('my-index').query({ topK: 10, id: '1' });
+const results = await index.query({ topK: 10, id: '1' });
 ```
 
 #### Hybrid search with sparseVector
@@ -709,9 +712,9 @@ If you are working with [sparse-dense vectors](https://docs.pinecone.io/v2/docs/
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
 
-await pc.createIndex({
+await client.createIndex({
   name: 'hyrbid-image-search',
   metric: 'dotproduct',
   dimension: 512,
@@ -724,7 +727,7 @@ await pc.createIndex({
   },
   waitUntilReady: true
 });
-const index = pc.index('hybrid-image-search');
+const index = client.index('hybrid-image-search');
 
 // Create some vector embeddings using your model of choice.
 const records = [...]
@@ -752,9 +755,10 @@ You may want to update vector `values`, `sparseValues`, or `metadata`. Specify t
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('imdb-movies');
 
-await pc.index('imdb-movies').update({
+await index.update({
   id: '18593',
   metadata: { genre: 'romance' },
 });
@@ -764,7 +768,8 @@ await pc.index('imdb-movies').update({
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('my-index');
 
 const fetchResult = await index.fetch(['id-1', 'id-2']);
 ```
@@ -777,9 +782,9 @@ For convenience there are several delete-related methods. You can verify the res
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('my-index');
 
-const index = pc.index('my-index');
 await index.deleteOne('id-to-delete');
 ```
 
@@ -787,9 +792,9 @@ await index.deleteOne('id-to-delete');
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('my-index');
 
-const index = pc.index('my-index');
 await index.deleteMany(['id-1', 'id-2', 'id-3']);
 ```
 
@@ -797,9 +802,10 @@ await index.deleteMany(['id-1', 'id-2', 'id-3']);
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('albums-database');
 
-await pc.index('albums-database').deleteMany({ genre: 'rock' });
+await index.deleteMany({ genre: 'rock' });
 ```
 
 #### Delete all records in a namespace
@@ -812,9 +818,9 @@ To nuke everything in the targeted namespace, use the `deleteAll` method.
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';
-const pc = new Pinecone();
+const client = new Pinecone();
+const index = client.index('my-index');
 
-const index = pc.index('my-index');
 await index.namespace('foo-namespace').deleteAll();
 ```
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -56,9 +56,9 @@ export type {
  *
  * ```typescript
  * import { Pinecone } from '@pinecone-database/pinecone';
+ * const client = new Pinecone()
  *
- * const pinecone = new Pinecone()
- * const index = pinecone.index('index-name')
+ * const index = client.index('index-name')
  * ```
  *
  * ### Targeting an index, with user-defined Metadata types
@@ -66,7 +66,8 @@ export type {
  * If you are storing metadata alongside your vector values inside your Pinecone records, you can pass a type parameter to `index()` in order to get proper TypeScript typechecking when upserting and querying data.
  *
  * ```typescript
- * const pinecone = new Pinecone();
+ * import { Pinecone } from '@pinecone-database/pinecone';
+ * const client = new Pinecone();
  *
  * type MovieMetadata = {
  *   title: string,
@@ -75,7 +76,7 @@ export type {
  * }
  *
  * // Specify a custom metadata type while targeting the index
- * const index = pinecone.index<MovieMetadata>('test-index');
+ * const index = client.index<MovieMetadata>('test-index');
  *
  * // Now you get type errors if upserting malformed metadata
  * await index.upsert([{
@@ -134,8 +135,10 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * await pinecone.index('my-index').describeIndexStats();
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('my-index').describeIndexStats();
    * // {
    * //  namespaces: {
    * //    '': { recordCount: 10 },
@@ -146,9 +149,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * //   totalRecordCount: 11
    * // }
    *
-   * await pinecone.index('my-index').deleteAll();
+   * await client.index('my-index').deleteAll();
    *
-   * // Records in default namespace '' are now gone, but records in namespace 'foo' are not modified.
+   * // Records from namespace 'foo' are now deleted. Records in other namespaces are not modified.
    * await client.index('my-index').describeIndexStats();
    * // {
    * //  namespaces: {
@@ -159,7 +162,11 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * //   totalRecordCount: 1
    * // }
    *
+   * await client.index('my-index').deleteAll();
+   * // Since no namespace was specified, records in default namespace '' are now deleted.
+   *
    * ```
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves when the delete is completed.
    */
   deleteAll() {
@@ -175,15 +182,18 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * await pinecone.index('my-index').deleteMany(['record-1', 'record-2']);
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('my-index').deleteMany(['record-1', 'record-2']);
    *
    * // or
-   * await pinecone.index('my-index').deleteMany({ genre: 'classical' });
+   * await client.index('my-index').deleteMany({ genre: 'classical' });
    * ```
    * @param options - An array of record id values or a filter object.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves when the delete is completed.
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   deleteMany(options) {
     return this._deleteMany(options);
@@ -196,12 +206,15 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * await pinecone.index('my-index').deleteOne('record-1');
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('my-index').deleteOne('record-1');
    * ```
    * @param id - The id of the record to delete.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves when the delete is completed.
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   deleteOne(id) {
     return this._deleteOne(id);
@@ -214,8 +227,10 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * await pinecone.index('my-index').describeIndexStats();
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('my-index').describeIndexStats();
    *
    * // {
    * //  namespaces: {
@@ -228,6 +243,7 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * //   totalRecordCount: 4010
    * // }
    * ```
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves with the {@link IndexStatsDescription} value when the operation is completed.
    */
   describeIndexStats() {
@@ -250,8 +266,10 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * const index = pinecone.index('my-index');
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * const index = client.index('my-index');
    * ```
    *
    * @constructor
@@ -295,11 +313,12 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
    *
    * // Create an Index client instance scoped to operate on a
    * // single namespace
-   * const ns = pinecone.index('my-index').namespace('my-namespace');
+   * const ns = client.index('my-index').namespace('my-namespace');
    *
    * // Now operations against this intance only affect records in
    * // the targeted namespace
@@ -313,8 +332,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```
    *
    * @param namespace - The namespace to target within the index. All operations performed with the returned client instance will be scoped only to the targeted namespace.
-   *
-   * This `namespace()` method will inherit custom metadata types if you are chaining the call off an { @link Index } client instance that is typed with a user-specified metadata type. See { @link Pinecone.index } for more info.
+   * This `namespace()` method will inherit custom metadata types if you are chaining the call off an {@link Index} client instance that is typed with a user-specified metadata type. See {@link Pinecone.index} for more info.
+   * @returns An {@link Index} object that can be used to perform data operations scoped to the specified namespace.
    */
   namespace(namespace: string): Index<T> {
     return new Index<T>(
@@ -330,8 +349,10 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * await pinecone.index('my-index').upsert([{
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('my-index').upsert([{
    *  id: 'record-1',
    *  values: [0.176, 0.345, 0.263],
    * },{
@@ -341,9 +362,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```
    *
    * @param data - An array of {@link PineconeRecord} objects to upsert.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves when the upsert is completed.
-   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   async upsert(data: Array<PineconeRecord<T>>) {
     return await this._upsertCommand.run(data);
@@ -354,13 +375,15 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * await pinecone.index('my-index').fetch(['record-1', 'record-2']);
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('my-index').fetch(['record-1', 'record-2']);
    * ```
    * @param options - The {@link FetchOptions} for the operation.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves with the {@link FetchResponse} when the fetch is completed.
-   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   async fetch(options: FetchOptions) {
     return await this._fetchCommand.run(options);
@@ -373,17 +396,19 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @example
    * ```js
-   * const pinecone = new Pinecone();
-   * await pinecone.index('my-index').query({ topK: 3, id: 'record-1'});
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('my-index').query({ topK: 3, id: 'record-1'});
    *
    * // or
-   * await pinecone.index('my-index').query({ topK: 3, vector: [0.176, 0.345, 0.263] });
+   * await client.index('my-index').query({ topK: 3, vector: [0.176, 0.345, 0.263] });
    * ```
    *
    * @param options - The {@link QueryOptions} for the operation.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves with the {@link QueryResponse} when the query is completed.
-   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   async query(options: QueryOptions) {
     return await this._queryCommand.run(options);
@@ -392,10 +417,21 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
   /**
    * Update a record in the index by id.
    *
+   * @example
+   * ```js
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
+   * await client.index('imdb-movies').update({
+   *   id: '18593',
+   *   metadata: { genre: 'romance' },
+   * });
+   * ```
+   *
    * @param options - The {@link UpdateOptions} for the operation.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves when the update is completed.
-   * @throws {@link Errors.PineconeConnectionError} when invalid environment, project id, or index name is configured.
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are passed.
    */
   async update(options: UpdateOptions<T>) {
     return await this._updateCommand.run(options);

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -333,9 +333,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *   // ... query records in namespace 'my-namespace'
    * })
    * ```
+   * This `namespace()` method will inherit custom metadata types if you are chaining the call off an {@link Index} client instance that is typed with a user-specified metadata type. See {@link Pinecone.index} for more info.
    *
    * @param namespace - The namespace to target within the index. All operations performed with the returned client instance will be scoped only to the targeted namespace.
-   * This `namespace()` method will inherit custom metadata types if you are chaining the call off an {@link Index} client instance that is typed with a user-specified metadata type. See {@link Pinecone.index} for more info.
    * @returns An {@link Index} object that can be used to perform data operations scoped to the specified namespace.
    */
   namespace(namespace: string): Index<T> {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -137,8 +137,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('my-index');
    *
-   * await client.index('my-index').describeIndexStats();
+   * await index.describeIndexStats();
    * // {
    * //  namespaces: {
    * //    '': { recordCount: 10 },
@@ -149,10 +150,10 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * //   totalRecordCount: 11
    * // }
    *
-   * await client.index('my-index').deleteAll();
+   * await index.deleteAll();
    *
    * // Records from namespace 'foo' are now deleted. Records in other namespaces are not modified.
-   * await client.index('my-index').describeIndexStats();
+   * await index.describeIndexStats();
    * // {
    * //  namespaces: {
    * //   foo: { recordCount: 1 }
@@ -162,7 +163,7 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * //   totalRecordCount: 1
    * // }
    *
-   * await client.index('my-index').deleteAll();
+   * await index.deleteAll();
    * // Since no namespace was specified, records in default namespace '' are now deleted.
    *
    * ```
@@ -184,11 +185,12 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('my-index');
    *
-   * await client.index('my-index').deleteMany(['record-1', 'record-2']);
+   * await index.deleteMany(['record-1', 'record-2']);
    *
    * // or
-   * await client.index('my-index').deleteMany({ genre: 'classical' });
+   * await index.deleteMany({ genre: 'classical' });
    * ```
    * @param options - An array of record id values or a filter object.
    * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
@@ -208,8 +210,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('my-index');
    *
-   * await client.index('my-index').deleteOne('record-1');
+   * await index.deleteOne('record-1');
    * ```
    * @param id - The id of the record to delete.
    * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
@@ -229,9 +232,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('my-index');
    *
-   * await client.index('my-index').describeIndexStats();
-   *
+   * await index.describeIndexStats();
    * // {
    * //  namespaces: {
    * //    '': { recordCount: 10 }
@@ -351,8 +354,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('my-index');
    *
-   * await client.index('my-index').upsert([{
+   * await index.upsert([{
    *  id: 'record-1',
    *  values: [0.176, 0.345, 0.263],
    * },{
@@ -377,8 +381,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('my-index');
    *
-   * await client.index('my-index').fetch(['record-1', 'record-2']);
+   * await index.fetch(['record-1', 'record-2']);
    * ```
    * @param options - The {@link FetchOptions} for the operation.
    * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
@@ -398,11 +403,12 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('my-index');
    *
-   * await client.index('my-index').query({ topK: 3, id: 'record-1'});
+   * await index.query({ topK: 3, id: 'record-1'});
    *
    * // or
-   * await client.index('my-index').query({ topK: 3, vector: [0.176, 0.345, 0.263] });
+   * await index.query({ topK: 3, vector: [0.176, 0.345, 0.263] });
    * ```
    *
    * @param options - The {@link QueryOptions} for the operation.
@@ -421,8 +427,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const client = new Pinecone();
+   * const index = client.index('imdb-movies');
    *
-   * await client.index('imdb-movies').update({
+   * await index.update({
    *   id: '18593',
    *   metadata: { genre: 'romance' },
    * });

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -56,9 +56,9 @@ export type {
  *
  * ```typescript
  * import { Pinecone } from '@pinecone-database/pinecone';
- * const client = new Pinecone()
+ * const pc = new Pinecone()
  *
- * const index = client.index('index-name')
+ * const index = pc.index('index-name')
  * ```
  *
  * ### Targeting an index, with user-defined Metadata types
@@ -67,7 +67,7 @@ export type {
  *
  * ```typescript
  * import { Pinecone } from '@pinecone-database/pinecone';
- * const client = new Pinecone();
+ * const pc = new Pinecone();
  *
  * type MovieMetadata = {
  *   title: string,
@@ -76,7 +76,7 @@ export type {
  * }
  *
  * // Specify a custom metadata type while targeting the index
- * const index = client.index<MovieMetadata>('test-index');
+ * const index = pc.index<MovieMetadata>('test-index');
  *
  * // Now you get type errors if upserting malformed metadata
  * await index.upsert([{
@@ -136,8 +136,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('my-index');
+   * const pc = new Pinecone();
+   * const index = pc.index('my-index');
    *
    * await index.describeIndexStats();
    * // {
@@ -184,8 +184,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('my-index');
+   * const pc = new Pinecone();
+   * const index = pc.index('my-index');
    *
    * await index.deleteMany(['record-1', 'record-2']);
    *
@@ -209,8 +209,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('my-index');
+   * const pc = new Pinecone();
+   * const index = pc.index('my-index');
    *
    * await index.deleteOne('record-1');
    * ```
@@ -231,8 +231,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('my-index');
+   * const pc = new Pinecone();
+   * const index = pc.index('my-index');
    *
    * await index.describeIndexStats();
    * // {
@@ -270,9 +270,9 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * const index = client.index('my-index');
+   * const index = pc.index('my-index');
    * ```
    *
    * @constructor
@@ -317,11 +317,11 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
    * // Create an Index client instance scoped to operate on a
    * // single namespace
-   * const ns = client.index('my-index').namespace('my-namespace');
+   * const ns = pc.index('my-index').namespace('my-namespace');
    *
    * // Now operations against this intance only affect records in
    * // the targeted namespace
@@ -353,8 +353,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('my-index');
+   * const pc = new Pinecone();
+   * const index = pc.index('my-index');
    *
    * await index.upsert([{
    *  id: 'record-1',
@@ -380,8 +380,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('my-index');
+   * const pc = new Pinecone();
+   * const index = pc.index('my-index');
    *
    * await index.fetch(['record-1', 'record-2']);
    * ```
@@ -402,8 +402,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('my-index');
+   * const pc = new Pinecone();
+   * const index = pc.index('my-index');
    *
    * await index.query({ topK: 3, id: 'record-1'});
    *
@@ -426,8 +426,8 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
-   * const index = client.index('imdb-movies');
+   * const pc = new Pinecone();
+   * const index = pc.index('imdb-movies');
    *
    * await index.update({
    *   id: '18593',

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -6,7 +6,7 @@ import type { ErrorContext } from '../pinecone-generated-ts-fetch';
  * request and never receives any response.
  *
  * This could be due to:
- * - Incorrect configuration of the client. If the apiKey value is incorrect the request will not reach a Pinecone server.
+ * - Network problems which prevent the request from being completed.
  * - An outage of Pinecone's APIs. See [Pinecone's status page](https://status.pinecone.io/) to find out whether there is an ongoing incident.
  *
  * The `cause` property will contain a reference to the underlying error. Inspect its value to find out more about the root cause of the error.
@@ -35,7 +35,7 @@ export class PineconeConnectionError extends BasePineconeError {
     }
 
     super(
-      `Request failed to reach Pinecone${urlMessage}. This can occur for reasons such as incorrect configuration (environment, project id, index name), network problems that prevent the request from being completed, or a Pinecone API outage. Check your client configuration, check your network connection, and visit https://status.pinecone.io/ to see whether any outages are ongoing.`,
+      `Request failed to reach Pinecone${urlMessage}. This can occur for reasons such as network problems that prevent the request from being completed, or a Pinecone API outage. Check your network connection, and visit https://status.pinecone.io/ to see whether any outages are ongoing.`,
       e
     );
     this.name = 'PineconeConnectionError';

--- a/src/integration/errorHandling.test.ts
+++ b/src/integration/errorHandling.test.ts
@@ -56,7 +56,7 @@ describe('Error handling', () => {
           const err = e as PineconeConnectionError;
           expect(err.name).toEqual('PineconeConnectionError');
           expect(err.message).toEqual(
-            'Request failed to reach Pinecone. This can occur for reasons such as incorrect configuration (environment, project id, index name), network problems that prevent the request from being completed, or a Pinecone API outage. Check your client configuration, check your network connection, and visit https://status.pinecone.io/ to see whether any outages are ongoing.'
+            'Request failed to reach Pinecone. This can occur for reasons such as network problems that prevent the request from being completed, or a Pinecone API outage. Check your network connection, and visit https://status.pinecone.io/ to see whether any outages are ongoing.'
           );
           // @ts-ignore
           expect(err.cause.name).toEqual('Error');

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -49,7 +49,7 @@ import type { PineconeConfiguration, RecordMetadata } from './data';
  * ```typescript
  * import { Pinecone } from '@pinecone-database/pinecone';
  *
- * const pinecone = new Pinecone();
+ * const client = new Pinecone();
  * ```
  *
  * ### Using a configuration object
@@ -60,7 +60,7 @@ import type { PineconeConfiguration, RecordMetadata } from './data';
  * ```typescript
  * import { Pinecone } from '@pinecone-database/pinecone';
  *
- * const pinecone = new Pinecone({
+ * const client = new Pinecone({
  *   apiKey: 'your_api_key',
  * });
  *
@@ -93,7 +93,7 @@ export class Pinecone {
    * ```
    * import { Pinecone } from '@pinecone-database/pinecone';
    *
-   * const pinecone = new Pinecone({
+   * const client = new Pinecone({
    *  apiKey: 'my-api-key',
    * });
    * ```
@@ -181,7 +181,11 @@ export class Pinecone {
    *
    * @example
    * ```js
-   * const indexModel = await pinecone.describeIndex('my-index')
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * const indexModel = await client.describeIndex('my-index')
    * console.log(indexModel)
    * // {
    * //     name: 'sample-index-1',
@@ -203,7 +207,9 @@ export class Pinecone {
    * ```
    *
    * @param indexName - The name of the index to describe.
-   * @returns A promise that resolves to {@link IndexModel}
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
+   * @returns A promise that resolves to {@link IndexModel}.
    */
   async describeIndex(indexName: IndexName) {
     const indexModel = await this._describeIndex(indexName);
@@ -219,9 +225,14 @@ export class Pinecone {
 
   /**
    * List all Pinecone indexes
+   *
    * @example
    * ```js
-   * const indexList = await pinecone.listIndexes()
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * const indexList = await client.listIndexes()
    * console.log(indexList)
    * // {
    * //     indexes: [
@@ -261,6 +272,8 @@ export class Pinecone {
    * //   }
    * ```
    *
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves to {@link IndexList}.
    */
   async listIndexes() {
@@ -284,7 +297,11 @@ export class Pinecone {
    * @example
    * The minimum required configuration to create an index is the index `name`, `dimension`, and `spec`.
    * ```js
-   * await pinecone.createIndex({ name: 'my-index', dimension: 128, spec: { serverless: { cloud: 'aws', region: 'us-west-2' }}})
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.createIndex({ name: 'my-index', dimension: 128, spec: { serverless: { cloud: 'aws', region: 'us-west-2' }}})
    * ```
    *
    * @example
@@ -314,7 +331,11 @@ export class Pinecone {
    * @example
    * If you would like to create the index only if it does not already exist, you can use the `suppressConflicts` boolean option.
    * ```js
-   * await pinecone.createIndex({
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.createIndex({
    *   name: 'my-index',
    *   dimension: 1536,
    *   spec: {
@@ -330,7 +351,11 @@ export class Pinecone {
    * @example
    * If you plan to begin upserting immediately after index creation is complete, you should use the `waitUntilReady` option. Otherwise, the index may not be ready to receive data operations when you attempt to upsert.
    * ```js
-   * await pinecone.createIndex({
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.createIndex({
    *  name: 'my-index',
    *   spec: {
    *     serverless: {
@@ -344,13 +369,17 @@ export class Pinecone {
    * const records = [
    *   // PineconeRecord objects with your embedding values
    * ]
-   * await pinecone.index('my-index').upsert(records)
+   * await client.index('my-index').upsert(records)
    * ```
    *
    * @example
    * By default all metadata fields are indexed when records are upserted with metadata, but if you want to improve performance you can specify the specific fields you want to index. This example is showing a few hypothetical metadata fields, but the values you'd use depend on what metadata you plan to store with records in your Pinecone index.
    * ```js
-   * await pinecone.createIndex({
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.createIndex({
    *   name: 'my-index',
    *   dimension: 1536,
    *   spec: {
@@ -367,10 +396,10 @@ export class Pinecone {
    *
    * @see [Distance metrics](https://docs.pinecone.io/docs/indexes#distance-metrics)
    * @see [Pod types and sizes](https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes)
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are provided.
-   * @throws {@link Errors.PineconeConflictError} when attempting to create an index using a name that already exists in your project.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
    * @throws {@link Errors.PineconeBadRequestError} when index creation fails due to invalid parameters being specified or other problem such as project quotas limiting the creation of any additional indexes.
-   *
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
+   * @throws {@link Errors.PineconeConflictError} when attempting to create an index using a name that already exists in your project.
    * @returns A promise that resolves to {@link IndexModel} when the request to create the index is completed. Note that the index is not immediately ready to use. You can use the {@link describeIndex} function to check the status of the index.
    */
   createIndex(options: CreateIndexOptions) {
@@ -382,12 +411,17 @@ export class Pinecone {
    *
    * @example
    * ```js
-   * await pinecone.deleteIndex('my-index')
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.deleteIndex('my-index')
    * ```
    *
    * @param indexName - The name of the index to delete.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
    * @returns A promise that resolves when the request to delete the index is completed.
-   * @throws {@link Errors.PineconeArgumentError} when invalid arguments are provided
    */
   async deleteIndex(indexName: IndexName) {
     await this._deleteIndex(indexName);
@@ -405,12 +439,18 @@ export class Pinecone {
    *
    * @example
    * ```js
-   * await pinecone.configureIndex('my-index', { replicas: 2, podType: 'p1.x2' })
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.configureIndex('my-index', { replicas: 2, podType: 'p1.x2' })
    * ```
    *
    * @param indexName - The name of the index to configure.
-   * @returns A promise that resolves to {@link IndexModel} when the request to configure the index is completed.
    * @param options - The configuration properties you would like to update
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
+   * @returns A promise that resolves to {@link IndexModel} when the request to configure the index is completed.
    */
   configureIndex(indexName: IndexName, options: ConfigureIndexRequestSpecPod) {
     return this._configureIndex(indexName, options);
@@ -421,18 +461,23 @@ export class Pinecone {
    *
    * @example
    * ```js
-   * const indexList = await pinecone.listIndexes()
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * const indexList = await client.listIndexes()
    * const indexName = indexList.indexes[0].name;
-   * await pinecone.createCollection({
+   * await client.createCollection({
    *  name: 'my-collection',
    *  source: indexName
    * })
    * ```
    *
-   *
    * @param options - The collection configuration.
    * @param options.name - The name of the collection. Must be unique within the project and contain alphanumeric and hyphen characters. The name must start and end with alphanumeric characters.
    * @param options.source - The name of the index to use as the source for the collection.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns a promise that resolves to {@link CollectionModel} when the request to create the collection is completed.
    */
   createCollection(options: CreateCollectionRequest) {
@@ -444,9 +489,15 @@ export class Pinecone {
    *
    * @example
    * ```js
-   * await pinecone.listCollections()
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.listCollections()
    * ```
    *
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves to {@link CollectionList}.
    */
   listCollections() {
@@ -458,12 +509,18 @@ export class Pinecone {
    *
    * @example
    * ```
-   * const collectionList = await pinecone.listCollections()
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * const collectionList = await client.listCollections()
    * const collectionName = collectionList.collections[0].name;
-   * await pinecone.deleteCollection(collectionName)
+   * await client.deleteCollection(collectionName)
    * ```
    *
    * @param collectionName - The name of the collection to delete.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves when the request to delete the collection is completed.
    */
   deleteCollection(collectionName: CollectionName) {
@@ -475,10 +532,16 @@ export class Pinecone {
    *
    * @example
    * ```js
-   * await pinecone.describeCollection('my-collection')
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
+   *
+   * await client.describeCollection('my-collection')
    * ```
    *
    * @param collectionName - The name of the collection to describe.
+   * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
+   * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves to a {@link CollectionModel}.
    */
   describeCollection(collectionName: CollectionName) {
@@ -506,8 +569,9 @@ export class Pinecone {
    * ```typescript
    * import { Pinecone } from '@pinecone-database/pinecone';
    *
-   * const pinecone = new Pinecone()
-   * const index = pinecone.index('index-name')
+   * const client = new Pinecone()
+   *
+   * const index = client.index('index-name')
    * ```
    *
    * #### Targeting an index, with user-defined Metadata types
@@ -515,7 +579,9 @@ export class Pinecone {
    * If you are storing metadata alongside your vector values inside your Pinecone records, you can pass a type parameter to `index()` in order to get proper TypeScript typechecking when upserting and querying data.
    *
    * ```typescript
-   * const pinecone = new Pinecone();
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   *
+   * const client = new Pinecone();
    *
    * type MovieMetadata = {
    *   title: string,
@@ -524,7 +590,7 @@ export class Pinecone {
    * }
    *
    * // Specify a custom metadata type while targeting the index
-   * const index = pinecone.index<MovieMetadata>('test-index');
+   * const index = client.index<MovieMetadata>('test-index');
    *
    * // Now you get type errors if upserting malformed metadata
    * await index.upsert([{

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -182,7 +182,6 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * const indexModel = await client.describeIndex('my-index')
@@ -229,7 +228,6 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * const indexList = await client.listIndexes()
@@ -314,6 +312,9 @@ export class Pinecone {
    * For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics.
    * In a different example, you can create a pod-based index by specifying the `pod` spec object with the `environment`, `pods`, `podType`, and `metric` properties.
    * ```js
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const client = new Pinecone();
+   *
    * await pinecone.createIndex({
    *  name: 'my-index',
    *  dimension: 1536,
@@ -332,7 +333,6 @@ export class Pinecone {
    * If you would like to create the index only if it does not already exist, you can use the `suppressConflicts` boolean option.
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * await client.createIndex({
@@ -352,7 +352,6 @@ export class Pinecone {
    * If you plan to begin upserting immediately after index creation is complete, you should use the `waitUntilReady` option. Otherwise, the index may not be ready to receive data operations when you attempt to upsert.
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * await client.createIndex({
@@ -376,7 +375,6 @@ export class Pinecone {
    * By default all metadata fields are indexed when records are upserted with metadata, but if you want to improve performance you can specify the specific fields you want to index. This example is showing a few hypothetical metadata fields, but the values you'd use depend on what metadata you plan to store with records in your Pinecone index.
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * await client.createIndex({
@@ -412,7 +410,6 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * await client.deleteIndex('my-index')
@@ -440,7 +437,6 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * await client.configureIndex('my-index', { replicas: 2, podType: 'p1.x2' })
@@ -462,7 +458,6 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * const indexList = await client.listIndexes()
@@ -490,7 +485,6 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * await client.listCollections()
@@ -510,7 +504,6 @@ export class Pinecone {
    * @example
    * ```
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * const collectionList = await client.listCollections()
@@ -533,7 +526,6 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone();
    *
    * await client.describeCollection('my-collection')
@@ -568,7 +560,6 @@ export class Pinecone {
    *
    * ```typescript
    * import { Pinecone } from '@pinecone-database/pinecone';
-   *
    * const client = new Pinecone()
    *
    * const index = client.index('index-name')

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -49,7 +49,7 @@ import type { PineconeConfiguration, RecordMetadata } from './data';
  * ```typescript
  * import { Pinecone } from '@pinecone-database/pinecone';
  *
- * const client = new Pinecone();
+ * const pc = new Pinecone();
  * ```
  *
  * ### Using a configuration object
@@ -60,7 +60,7 @@ import type { PineconeConfiguration, RecordMetadata } from './data';
  * ```typescript
  * import { Pinecone } from '@pinecone-database/pinecone';
  *
- * const client = new Pinecone({
+ * const pc = new Pinecone({
  *   apiKey: 'your_api_key',
  * });
  *
@@ -93,7 +93,7 @@ export class Pinecone {
    * ```
    * import { Pinecone } from '@pinecone-database/pinecone';
    *
-   * const client = new Pinecone({
+   * const pc = new Pinecone({
    *  apiKey: 'my-api-key',
    * });
    * ```
@@ -182,9 +182,9 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * const indexModel = await client.describeIndex('my-index')
+   * const indexModel = await pc.describeIndex('my-index')
    * console.log(indexModel)
    * // {
    * //     name: 'sample-index-1',
@@ -228,9 +228,9 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * const indexList = await client.listIndexes()
+   * const indexList = await pc.listIndexes()
    * console.log(indexList)
    * // {
    * //     indexes: [
@@ -297,9 +297,9 @@ export class Pinecone {
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    *
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.createIndex({ name: 'my-index', dimension: 128, spec: { serverless: { cloud: 'aws', region: 'us-west-2' }}})
+   * await pc.createIndex({ name: 'my-index', dimension: 128, spec: { serverless: { cloud: 'aws', region: 'us-west-2' }}})
    * ```
    *
    * @example
@@ -313,9 +313,9 @@ export class Pinecone {
    * In a different example, you can create a pod-based index by specifying the `pod` spec object with the `environment`, `pods`, `podType`, and `metric` properties.
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await pinecone.createIndex({
+   * await pc.createIndex({
    *  name: 'my-index',
    *  dimension: 1536,
    *  metric: 'cosine',
@@ -333,9 +333,9 @@ export class Pinecone {
    * If you would like to create the index only if it does not already exist, you can use the `suppressConflicts` boolean option.
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.createIndex({
+   * await pc.createIndex({
    *   name: 'my-index',
    *   dimension: 1536,
    *   spec: {
@@ -352,9 +352,9 @@ export class Pinecone {
    * If you plan to begin upserting immediately after index creation is complete, you should use the `waitUntilReady` option. Otherwise, the index may not be ready to receive data operations when you attempt to upsert.
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.createIndex({
+   * await pc.createIndex({
    *  name: 'my-index',
    *   spec: {
    *     serverless: {
@@ -368,16 +368,16 @@ export class Pinecone {
    * const records = [
    *   // PineconeRecord objects with your embedding values
    * ]
-   * await client.index('my-index').upsert(records)
+   * await pc.index('my-index').upsert(records)
    * ```
    *
    * @example
    * By default all metadata fields are indexed when records are upserted with metadata, but if you want to improve performance you can specify the specific fields you want to index. This example is showing a few hypothetical metadata fields, but the values you'd use depend on what metadata you plan to store with records in your Pinecone index.
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.createIndex({
+   * await pc.createIndex({
    *   name: 'my-index',
    *   dimension: 1536,
    *   spec: {
@@ -410,9 +410,9 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.deleteIndex('my-index')
+   * await pc.deleteIndex('my-index')
    * ```
    *
    * @param indexName - The name of the index to delete.
@@ -437,9 +437,9 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.configureIndex('my-index', { replicas: 2, podType: 'p1.x2' })
+   * await pc.configureIndex('my-index', { replicas: 2, podType: 'p1.x2' })
    * ```
    *
    * @param indexName - The name of the index to configure.
@@ -458,11 +458,11 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * const indexList = await client.listIndexes()
+   * const indexList = await pc.listIndexes()
    * const indexName = indexList.indexes[0].name;
-   * await client.createCollection({
+   * await pc.createCollection({
    *  name: 'my-collection',
    *  source: indexName
    * })
@@ -485,9 +485,9 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.listCollections()
+   * await pc.listCollections()
    * ```
    *
    * @throws {@link Errors.PineconeArgumentError} when arguments passed to the method fail a runtime validation.
@@ -504,11 +504,11 @@ export class Pinecone {
    * @example
    * ```
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * const collectionList = await client.listCollections()
+   * const collectionList = await pc.listCollections()
    * const collectionName = collectionList.collections[0].name;
-   * await client.deleteCollection(collectionName)
+   * await pc.deleteCollection(collectionName)
    * ```
    *
    * @param collectionName - The name of the collection to delete.
@@ -526,9 +526,9 @@ export class Pinecone {
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
-   * await client.describeCollection('my-collection')
+   * await pc.describeCollection('my-collection')
    * ```
    *
    * @param collectionName - The name of the collection to describe.
@@ -560,9 +560,9 @@ export class Pinecone {
    *
    * ```typescript
    * import { Pinecone } from '@pinecone-database/pinecone';
-   * const client = new Pinecone()
+   * const pc = new Pinecone()
    *
-   * const index = client.index('index-name')
+   * const index = pc.index('index-name')
    * ```
    *
    * #### Targeting an index, with user-defined Metadata types
@@ -572,7 +572,7 @@ export class Pinecone {
    * ```typescript
    * import { Pinecone } from '@pinecone-database/pinecone';
    *
-   * const client = new Pinecone();
+   * const pc = new Pinecone();
    *
    * type MovieMetadata = {
    *   title: string,
@@ -581,7 +581,7 @@ export class Pinecone {
    * }
    *
    * // Specify a custom metadata type while targeting the index
-   * const index = client.index<MovieMetadata>('test-index');
+   * const index = pc.index<MovieMetadata>('test-index');
    *
    * // Now you get type errors if upserting malformed metadata
    * await index.upsert([{


### PR DESCRIPTION
## Problem
- Leading up to serverless public preview, there was an effort to update the variable values for the various clients in examples and docs from `const pinecone = new Pinecone()` to `const client = new Pinecone()` which didn't make it into the TypeScripts documentation.
- We received feedback from customer success that the current docstring for `deleteAll()` was possibly confusing to some users, and we wanted to be more explicit.
- Feedback in this PR: https://github.com/pinecone-io/pinecone-ts-client/pull/202 around the strings for `PineconeConnectionError` no longer being accurate since it references checking client configurations like environment and project ID which are no longer relevant >v2.0.

## Solution
- Update docstring and message for `PineconeConnectionError` to remove references to old configuration values. Update the description in all docstrings where we mark this as thrown.
- Update docstrings for `deleteAll()` to be more explicit around chaining calls to specific namespaces.
- Update docstrings for a lot of our functions in `pinecone.ts` and `/data/index.ts`. Most of this is stylistically aligning things, moving from using `pinecone` as a variable to `client`, and adding some missing `@returns` and `@throws` notation.
- Update `README.md` to clean up some of our code examples.

## Type of Change
- [X] Non-code change (docs, etc)

## Test Plan
Re-build docs locally and open the HTML to make sure things look as expected:

```
npm run docs:build
```

This will generate a `/docs` folder at the root of the repo, open the HTML file in here.
