### PR TITLE
Export `ListResponse` type from generated core, add docstring for `ListOptions`

### DIFF
--- a/src/data/list.ts
+++ b/src/data/list.ts
@@ -3,9 +3,15 @@ import { Type } from '@sinclair/typebox';
 import { DataOperationsProvider } from './dataOperationsProvider';
 import type { ListRequest, ListResponse } from '../pinecone-generated-ts-fetch';
 
+/**
+ * See [List record IDs](https://docs.pinecone.io/guides/data/list-record-ids)
+ */
 export type ListOptions = {
+  /** The id prefix to match. If unspecified, an empty string prefix will be used with the effect of listing all ids in a namespace. */
   prefix?: string;
+  /** The maximum number of ids to return. If unspecified, the server will use a default value. */
   limit?: number;
+  /** A token needed to fetch the next page of results. This token is returned in the response if additional results are available. */
   paginationToken?: string;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export type {
   FetchAPI,
   IndexList,
   IndexModel,
+  ListResponse,
   ServerlessSpec,
   ServerlessSpecCloudEnum,
   PodSpec,


### PR DESCRIPTION
## Problem
We're not exporting the generated `ListResponse` type from the OpenAPI core. This is limiting for consumers when working with the client: https://github.com/pinecone-io/pinecone-ts-client/issues/209

## Solution
- Export `ListResponse` from `pinecone-generated-ts-fetch`.
- Add docstring for `ListOptions` type.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)
- [X] Non-code change (docs, etc)

## Test Plan
CI unit + integration tests
