### PR TITLE
Remove serverless public preview warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const pc = new Pinecone({
 
 At a minimum, to create a serverless index you must specify a `name`, `dimension`, and `spec`. The `dimension` indicates the size of the records you intend to store in the index. For example, if your intention was to store and query embeddings generated with OpenAI's [textembedding-ada-002](https://platform.openai.com/docs/guides/embeddings/second-generation-models) model, you would need to create an index with dimension `1536` to match the output of that model.
 
-The `spec` configures how the index should be deployed. For serverless indexes, you define only the cloud and region where the index should be hosted. For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics.
+The `spec` configures how the index should be deployed. For serverless indexes, you define only the cloud and region where the index should be hosted. For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics. For more information on serverless and regional availability, see [Understanding indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes).
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';

--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ const pc = new Pinecone({
 
 #### Create a serverless index with minimal configuration
 
-> ⚠️ **Warning**
->
-> Serverless indexes are in **public preview** and are available only on AWS in the `us-west-2` region. Check the [current limitations](https://docs.pinecone.io/docs/limits#serverless-index-limitations) and test thoroughly before using it in production.
-
 At a minimum, to create a serverless index you must specify a `name`, `dimension`, and `spec`. The `dimension` indicates the size of the records you intend to store in the index. For example, if your intention was to store and query embeddings generated with OpenAI's [textembedding-ada-002](https://platform.openai.com/docs/guides/embeddings/second-generation-models) model, you would need to create an index with dimension `1536` to match the output of that model.
 
 The `spec` configures how the index should be deployed. For serverless indexes, you define only the cloud and region where the index should be hosted. For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics.

--- a/src/pinecone-generated-ts-fetch/models/CreateIndexRequestSpec.ts
+++ b/src/pinecone-generated-ts-fetch/models/CreateIndexRequestSpec.ts
@@ -27,11 +27,10 @@ import {
 } from './ServerlessSpec';
 
 /**
- * The spec object defines how the index should be deployed.
+ * The spec object defines how the index should be deployed. For serverless indexes, you define only the cloud and region 
+ * where the index should be hosted. For pod-based indexes, you define the environment where the index should be hosted, 
+ * the pod type and size to use, and other index characteristics.
  * 
- * For serverless indexes, you define only the cloud and region where the index should be hosted. For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics.
- * 
- * Serverless indexes are in public preview and are available only on AWS in the us-west-2 region. Test thoroughly before using serverless indexes in production.
  * @export
  * @interface CreateIndexRequestSpec
  */

--- a/src/pinecone-generated-ts-fetch/models/CreateIndexRequestSpec.ts
+++ b/src/pinecone-generated-ts-fetch/models/CreateIndexRequestSpec.ts
@@ -29,7 +29,8 @@ import {
 /**
  * The spec object defines how the index should be deployed. For serverless indexes, you define only the cloud and region 
  * where the index should be hosted. For pod-based indexes, you define the environment where the index should be hosted, 
- * the pod type and size to use, and other index characteristics.
+ * the pod type and size to use, and other index characteristics. For more information on creating indexes, 
+ * see [Understanding indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes).
  * 
  * @export
  * @interface CreateIndexRequestSpec

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -304,11 +304,6 @@ export class Pinecone {
    * ```
    *
    * @example
-   *
-   * > ⚠️ **Warning**
-   * >
-   * > Serverless indexes are in **public preview** and are available only on AWS in the `us-west-2` region. Check the [current limitations](https://docs.pinecone.io/docs/limits#serverless-index-limitations) and test thoroughly before using it in production.
-   *
    * The `spec` object defines how the index should be deployed. For serverless indexes, you define only the cloud and region where the index should be hosted.
    * For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics.
    * In a different example, you can create a pod-based index by specifying the `pod` spec object with the `environment`, `pods`, `podType`, and `metric` properties.

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -307,6 +307,7 @@ export class Pinecone {
    * The `spec` object defines how the index should be deployed. For serverless indexes, you define only the cloud and region where the index should be hosted.
    * For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics.
    * In a different example, you can create a pod-based index by specifying the `pod` spec object with the `environment`, `pods`, `podType`, and `metric` properties.
+   * For more information on creating indexes, see [Understanding indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes).
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const pc = new Pinecone();

--- a/v2-migration.md
+++ b/v2-migration.md
@@ -87,7 +87,7 @@ In the new `v2.0.0` client, there is a lot more flexibility in how indexes are c
 
 ### Creating a serverless index
 
-Serverless indexes are newly available with the `v2.0.0` client, and you must be on this version or greater to work with them. Creating a serverless index requires defining the `cloud` and `region` where the server should be hosted via the `spec` object with the key `serverless`.
+Serverless indexes are newly available with the `v2.0.0` client, and you must be on this version or greater to work with them. Creating a serverless index requires defining the `cloud` and `region` where the server should be hosted via the `spec` object with the key `serverless`. For more information on serverless and regional availability, see [Understanding indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes).
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';

--- a/v2-migration.md
+++ b/v2-migration.md
@@ -87,10 +87,6 @@ In the new `v2.0.0` client, there is a lot more flexibility in how indexes are c
 
 ### Creating a serverless index
 
-> ⚠️ **Warning**
->
-> Serverless indexes are in **public preview** and are available only on AWS in the `us-west-2` region. Check the [current limitations](https://docs.pinecone.io/docs/limits#serverless-index-limitations) and test thoroughly before using it in production.
-
 Serverless indexes are newly available with the `v2.0.0` client, and you must be on this version or greater to work with them. Creating a serverless index requires defining the `cloud` and `region` where the server should be hosted via the `spec` object with the key `serverless`.
 
 ```typescript


### PR DESCRIPTION
## Problem
The serverless public preview warnings from January are still in docstrings and documentation. Since we've expanded the number of regions available, we should pull these out.

## Solution
Remove "public preview" warnings calling out the `us-west-2` environment from README, docstrings, and the migration guide.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI, run the client reference action after merged to main to update reference docs.
