### PR TITLE
Include `sourceTag` in `PineconeConfigurationSchema`

### DIFF
--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -100,12 +100,13 @@ describe('Pinecone', () => {
     });
 
     describe('optional properties', () => {
-      test('should not throw when optional properties provided: fetchAPI, controllerHostUrl', () => {
+      test('should not throw when optional properties provided: fetchAPI, controllerHostUrl, sourceTag', () => {
         expect(() => {
           new Pinecone({
             apiKey: 'test-key',
             fetchApi: utils.getFetch({} as PineconeConfiguration),
             controllerHostUrl: 'https://foo-bar.io',
+            sourceTag: 'integration-test-123',
           } as PineconeConfiguration);
         }).not.toThrow();
       });

--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -106,7 +106,7 @@ describe('Pinecone', () => {
             apiKey: 'test-key',
             fetchApi: utils.getFetch({} as PineconeConfiguration),
             controllerHostUrl: 'https://foo-bar.io',
-            sourceTag: 'integration-test-123',
+            sourceTag: 'test-tag-123',
           } as PineconeConfiguration);
         }).not.toThrow();
       });

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -14,6 +14,7 @@ export const PineconeConfigurationSchema = Type.Object(
     fetchApi: Type.Optional(Type.Any()),
 
     additionalHeaders: Type.Optional(Type.Any()),
+    sourceTag: Type.Optional(Type.String({ minLength: 1 })),
   },
   { additionalProperties: false }
 );


### PR DESCRIPTION
## Problem
When `sourceTag` was added to `PineconeConfiguration` as an argument it was not included in the `PineconeConfigurationSchema` object. This object is used by `typebox` at runtime to validate the arguments passed to the constructor. Since `sourceTag` is not included, and `PineconeConfigurationSchema` has `additionalProperties: false` configured, users will see an error when trying to pass `sourceTag`:

`PineconeArgumentError: The client configuration had validation errors: argument must NOT have additional properties.`

This can be disabled with the `PINECONE_DISABLE_RUNTIME_VALIDATIONS` environment variable, but that should not be required.

## Solution
Add `sourceTag` to `PineconeConfigurationSchema`. Update the unit test that validates passing the additional parameters to the Pinecone constructor.

We probably need some better integration / unit test coverage for some of the headers and config values that we're expecting to be sent on request. I can follow up with that. For now I tested locally with `PINECONE_DEBUG` and `PINECONE_DEBUG_CURL` to verify the request:

![Screenshot 2024-05-10 at 3 14 22 PM](https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/7899c427-62a6-48f8-8287-3b704f4406ad)


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
You can pull this branch down and run the repl locally. Basically, just confirm you can pass `sourceTag` as an argument to `Pinecone` and then make some network calls to check it shows up as you'd expect (see example screenshot above):

```
$ export PINECONE_DEBUG=true
$ export PINECONE_DEBUG_CURL=true
$ npm run repl
$ await init()

const newClient = new Pinecone({ apiKey: "my-key", sourceTag: "my-tag" })
await newClient.listIndexes()

// Validate the request has the expected user-agent shape
```
