### PR TITLE
Re-enable `IndexHostSingleton` unit tests

### DIFF
--- a/src/data/__tests__/indexHostSingleton.test.ts
+++ b/src/data/__tests__/indexHostSingleton.test.ts
@@ -143,7 +143,7 @@ describe('IndexHostSingleton', () => {
     expect(mockDescribeIndex).toHaveBeenCalledTimes(1);
   });
 
-  test.only('calling getHostUrl with different apiKey configurations should instantiate new ManageIndexesApi classes', async () => {
+  test('calling getHostUrl with different apiKey configurations should instantiate new ManageIndexesApi classes', async () => {
     const pineconeConfig1 = { apiKey: 'test-key-1' };
     const pineconeConfig2 = { apiKey: 'test-key-2' };
 


### PR DESCRIPTION
## Problem
Last PR I left a `test.only()` call in the `indexHostSingleton.test.ts` file. 🤦‍♂️ 

## Solution
Remove so we're running all the tests again.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Let tests run
