### PR TITLE
Update CI to test newer versions of Node and test fewer versions of Bun

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: ${{ inputs.node_version }}
         registry-url: 'https://registry.npmjs.org'
     - name: Cache NPM dependencies
       uses: actions/cache@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,19 +102,19 @@ jobs:
       fail-fast: false
       matrix:
         tsVersion: [
-           '~4.1.0',
-           '~4.2.0',
-           '~4.3.0',
-           '~4.4.0',
-           '~4.5.0',
-           '~4.6.0',
-           '~4.7.0',
-           '~4.8.0',
-           '~4.9.0',
-           '~5.0.0',
-           '~5.1.0',
-           '~5.2.0',
-           # 'latest', - typebox breaks with latest TypeScript, re-enable later
+            '~4.1.0',
+            '~4.2.0',
+            '~4.3.0',
+            '~4.4.0',
+            '~4.5.0',
+            '~4.6.0',
+            '~4.7.0',
+            '~4.8.0',
+            '~4.9.0',
+            '~5.0.0',
+            '~5.1.0',
+            '~5.2.0',
+            # 'latest', - typebox breaks with latest TypeScript, re-enable later
         ]
     steps:
       - name: Checkout

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,10 +35,8 @@ jobs:
             { runner: 'npm', jest_env: 'node' },
             { runner: 'npm', jest_env: 'edge' },
             { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.5' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.10' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.15' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.20' },
+            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
+            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
           ]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,19 +102,19 @@ jobs:
       fail-fast: false
       matrix:
         tsVersion: [
-          '~4.1.0',
-          '~4.2.0',
-          '~4.3.0',
-          '~4.4.0',
-          '~4.5.0',
-          '~4.6.0',
-          '~4.7.0',
-          '~4.8.0',
-          '~4.9.0',
-          '~5.0.0',
-          '~5.1.0',
-          '~5.2.0',
-          # 'latest', - typebox breaks with latest TypeScript, re-enable later
+           '~4.1.0',
+           '~4.2.0',
+           '~4.3.0',
+           '~4.4.0',
+           '~4.5.0',
+           '~4.6.0',
+           '~4.7.0',
+           '~4.8.0',
+           '~4.9.0',
+           '~5.0.0',
+           '~5.1.0',
+           '~5.2.0',
+           # 'latest', - typebox breaks with latest TypeScript, re-enable later
         ]
     steps:
       - name: Checkout

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -115,7 +115,7 @@ jobs:
             '~5.1.0',
             '~5.2.0',
             # 'latest', - typebox breaks with latest TypeScript, re-enable later
-        ]
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          pinecone_api_key: ${{ secrets.PINECONE_API_KEY }}
           node_version: ${{ matrix.node_version }}
 
       - name: Setup bun

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,6 +29,7 @@ jobs:
         pinecone_env:
           - prod
           # - staging
+        node_version: [16.x, 18.x, 20.x]
         config:
           [
             { runner: 'npm', jest_env: 'node' },
@@ -46,6 +47,9 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          pinecone_api_key: ${{ secrets.PINECONE_API_KEY }}
+          node_version: ${{ matrix.node_version }}
 
       - name: Setup bun
         if: matrix.config.bun_version
@@ -98,20 +102,20 @@ jobs:
       fail-fast: false
       matrix:
         tsVersion: [
-            '~4.1.0',
-            '~4.2.0',
-            '~4.3.0',
-            '~4.4.0',
-            '~4.5.0',
-            '~4.6.0',
-            '~4.7.0',
-            '~4.8.0',
-            '~4.9.0',
-            '~5.0.0',
-            '~5.1.0',
-            '~5.2.0',
-            # 'latest', - typebox breaks with latest TypeScript, re-enable later
-          ]
+          '~4.1.0',
+          '~4.2.0',
+          '~4.3.0',
+          '~4.4.0',
+          '~4.5.0',
+          '~4.6.0',
+          '~4.7.0',
+          '~4.8.0',
+          '~4.9.0',
+          '~5.0.0',
+          '~5.1.0',
+          '~5.2.0',
+          # 'latest', - typebox breaks with latest TypeScript, re-enable later
+        ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

We currently only test Node version `16.x`, but there are much newer versions with upgraded capabilities. To ensure full coverage, we want to add in `18.x` and `20.x`. This PR does that.

Note: this will increase the time it takes for our CI pipeline to complete, but we have discussed, and the increased latency is worth it to cover more modern versions of Node.

We have also **decreased** the number of `bun` versions tested since they have released a major new version `1.1.x`. We originally had many versions out of an abundance of caution leading up to releasing Pinecone serverless. Now that there have been major releases of `bun` cut more recently, it's my opinion that we only really need to test the following: 
- `1.0.0`, which is basically when they GAed `bun` (and we've always tested this initial major release)
- `1.0.36`, the last minor release before `1.1.0`.
- `1.1.11`, the most recent version of `bun`, which works with Windows and fixes some bugs found in the initial `1.1.0` release.

Our CI pipeline still takes a while, but ultimately I think this is better test coverage, and we can do a quick follow-up PR with some hacks to decrease the overall time at some point in the near future.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207545518662996