### PR TITLE
Add workflow and action files for RC code

### DIFF
--- a/.github/actions/npm-rc-release/action.yml
+++ b/.github/actions/npm-rc-release/action.yml
@@ -1,4 +1,4 @@
-name: 'npm rc release'
+name: 'Npm RC release'
 description: 'Publish code changes to npmjs.org'
 inputs:
   git_email:
@@ -8,12 +8,8 @@ inputs:
     description: 'Commit author name'
     required: true
   npm_token:
-    description: 'npm token for publishing. Login to npmjs.org to generate this.'
+    description: 'Npm token for publishing. Login to npmjs.org to generate this.'
     required: true
-outputs:
-  release_tag:
-    description: 'The name of the created git tag'
-    value: ${{ steps.release-tag-step.outputs.release-tag }}
 runs:
   using: 'composite'
   steps:
@@ -25,20 +21,15 @@ runs:
     - name: 'Bump version'
       shell: bash
       run: npm version prerelease --preid=rc --no-git-tag-version
-    - name: 'Commit and tag version changes'
+    - name: 'Commit changes'
       shell: bash
       run: |
         git add .
         newVersion=$(jq -r '.version' package.json)
-        git commit -m "[skip ci] Publish release v$newVersion"
-        git tag "v$newVersion"
-    - name: 'Output release tag'
-      shell: bash
-      id: release-tag-step
-      run: echo "release-tag=$(git describe --tags)" >> $GITHUB_OUTPUT
+        git commit -m "[skip ci] Publish RC release v$newVersion"
     - name: 'Push changes'
       shell: bash
-      run: git push --follow-tags
+      run: git push
     - name: 'Publish to npm'
       run: npm publish
       shell: bash

--- a/.github/actions/npm-rc-release/action.yml
+++ b/.github/actions/npm-rc-release/action.yml
@@ -21,15 +21,6 @@ runs:
     - name: 'Bump version'
       shell: bash
       run: npm version prerelease --preid=rc --no-git-tag-version
-    - name: 'Commit changes'
-      shell: bash
-      run: |
-        git add .
-        newVersion=$(jq -r '.version' package.json)
-        git commit -m "[skip ci] Publish RC release v$newVersion"
-    - name: 'Push changes'
-      shell: bash
-      run: git push
     - name: 'Publish to npm'
       run: npm publish
       shell: bash

--- a/.github/actions/npm-rc-release/action.yml
+++ b/.github/actions/npm-rc-release/action.yml
@@ -10,6 +10,9 @@ inputs:
   npm_token:
     description: 'Npm token for publishing. Login to npmjs.org to generate this.'
     required: true
+  rc_name:
+    description: 'Which RC your code changes are for.'
+    required: true
 runs:
   using: 'composite'
   steps:
@@ -20,7 +23,7 @@ runs:
         git config --global user.name "${{ inputs.git_username }}"
     - name: 'Bump version'
       shell: bash
-      run: npm version prerelease --preid=rc --no-git-tag-version
+      run: npm version prerelease --preid=rc."${{ inputs.nameRc }}" --no-git-tag-version
     - name: 'Publish to npm'
       run: npm publish
       shell: bash

--- a/.github/actions/npm-rc-release/action.yml
+++ b/.github/actions/npm-rc-release/action.yml
@@ -1,0 +1,46 @@
+name: 'npm rc release'
+description: 'Publish code changes to npmjs.org'
+inputs:
+  git_email:
+    description: 'Email of git commit containing version bump'
+    required: true
+  git_username:
+    description: 'Commit author name'
+    required: true
+  npm_token:
+    description: 'npm token for publishing. Login to npmjs.org to generate this.'
+    required: true
+outputs:
+  release_tag:
+    description: 'The name of the created git tag'
+    value: ${{ steps.release-tag-step.outputs.release-tag }}
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Configure git CLI'
+      shell: bash
+      run: |
+        git config --global user.email "${{ inputs.git_email }}"
+        git config --global user.name "${{ inputs.git_username }}"
+    - name: 'Bump version'
+      shell: bash
+      run: npm version prerelease --preid=rc --no-git-tag-version
+    - name: 'Commit and tag version changes'
+      shell: bash
+      run: |
+        git add .
+        newVersion=$(jq -r '.version' package.json)
+        git commit -m "[skip ci] Publish release v$newVersion"
+        git tag "v$newVersion"
+    - name: 'Output release tag'
+      shell: bash
+      id: release-tag-step
+      run: echo "release-tag=$(git describe --tags)" >> $GITHUB_OUTPUT
+    - name: 'Push changes'
+      shell: bash
+      run: git push --follow-tags
+    - name: 'Publish to npm'
+      run: npm publish
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,29 @@
+name: 'Release RC build'
+
+on:
+  workflow_dispatch: {}
+
+# prevent concurrent releases
+concurrency:
+  group: npm-rc-release
+  cancel-in-progress: true
+
+jobs:
+  version-and-release:
+    name: Release RC build to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Version and publish to npm
+        id: npm-rc-release
+        uses: ./.github/actions/npm-rc-release
+        with:
+          git_email: clients@pinecone.io
+          git_username: ${{ github.actor }}
+          npm_token: ${{ secrets.NPM_TOKEN }}
+      - run: echo "${{ steps.npm-rc-release.outputs.release_tag }} was published"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -26,4 +26,3 @@ jobs:
           git_email: clients@pinecone.io
           git_username: ${{ github.actor }}
           npm_token: ${{ secrets.NPM_TOKEN }}
-      - run: echo "${{ steps.npm-rc-release.outputs.release_tag }} was published"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,7 +1,13 @@
 name: 'Release RC build'
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      nameRc:
+        description: 'Input which RC your code changes are for'
+        required: true
+        type: string
+        default: '2024-07'
 
 # prevent concurrent releases
 concurrency:
@@ -26,3 +32,4 @@ jobs:
           git_email: clients@pinecone.io
           git_username: ${{ github.actor }}
           npm_token: ${{ secrets.NPM_TOKEN }}
+          nameRc: ${{ inputs.nameRc }}


### PR DESCRIPTION
## Problem

We would like to publish RC (release candidate) code to `npm`. In order to do that, we need new github workflow and action files. This PR adds those files, so that we can use the RC branch (`2024-07-rc`) to push to `npm` for users.
"
Since versioning RCs is a bit of an antipattern, these workflows do _not_ contain versioning commands. The "version" is controlled by this command, which just appends `.rc`: `run: npm version prerelease --preid=rc --no-git-tag-version`.

TBD on whether we need Github tags, either. Would love reviewers' input on that (I'm thinking we don't).


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

