### PR TITLE
Update `sourceTag` normalization to include `:` as an allowed character

### DIFF
--- a/src/utils/__tests__/user-agent.test.ts
+++ b/src/utils/__tests__/user-agent.test.ts
@@ -42,6 +42,10 @@ describe('user-agent', () => {
       config.sourceTag = '  MY SOURCE TAG     1234     ##### !!!!!!';
       userAgent = buildUserAgent(config);
       expect(userAgent).toContain('source_tag=my_source_tag_1234');
+
+      config.sourceTag = ' MY SOURCE TAG :1234-ABCD';
+      userAgent = buildUserAgent(config);
+      expect(userAgent).toContain('source_tag=my_source_tag_:1234abcd');
     });
   });
 });

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -35,13 +35,13 @@ const normalizeSourceTag = (sourceTag: string) => {
   /**
    * normalize sourceTag
    * 1. Lowercase
-   * 2. Limit charset to [a-z0-9_ ]
+   * 2. Limit charset to [a-z0-9_ :]
    * 3. Trim left/right spaces
    * 4. Condense multiple spaces to one, and replace with underscore
    */
   return sourceTag
     .toLowerCase()
-    .replace(/[^a-z0-9_ ]/g, '')
+    .replace(/[^a-z0-9_ :]/g, '')
     .trim()
     .replace(/[ ]+/g, '_');
 };


### PR DESCRIPTION
## Problem
We want to allow `:` in `sourceTags` that are applied to user-agent headers on network requests.

## Solution

- Update `normalizeSourceTag` function to allow `:` as an accepted character.
- Add new unit test permutation to validate functionality.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Test locally using the TyepScript repl with `PINECONE_DEBUG` and `PINECONE_DEBUG_CURL` to monitor network traffic:
![Screenshot 2024-06-26 at 7 17 05 PM](https://github.com/pinecone-io/pinecone-ts-client/assets/119623786/e8014ff2-c623-4522-8361-7ea602b27e4b)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207476368919278