### PR TITLE
Add `sparseVector` to `QueryByVectorValues` type

### DIFF
--- a/src/data/__tests__/indexHostSingleton.test.ts
+++ b/src/data/__tests__/indexHostSingleton.test.ts
@@ -173,11 +173,6 @@ describe('IndexHostSingleton', () => {
     expect(mockDescribeIndex).toHaveBeenNthCalledWith(1, 'index-1');
     expect(mockDescribeIndex).toHaveBeenNthCalledWith(2, 'index-2');
 
-    console.log(
-      'mockIndexOperationsBuilder',
-      JSON.stringify(mockIndexOperationsBuilder.mock)
-    );
-
     expect(mockIndexOperationsBuilder).toHaveBeenCalledTimes(2);
     expect(mockIndexOperationsBuilder).toHaveBeenNthCalledWith(
       1,

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -4,6 +4,7 @@ import {
   RecordIdSchema,
   RecordSparseValuesSchema,
   RecordValues,
+  RecordSparseValues,
   RecordValuesSchema,
 } from './types';
 import type { PineconeRecord, RecordMetadata } from './types';
@@ -94,6 +95,11 @@ export type QueryByVectorValues = QueryShared & {
    * Vector values output from an embedding model.
    */
   vector: RecordValues;
+
+  /**
+   * The sparse values of the query vector, if applicable.
+   */
+  sparseVector?: RecordSparseValues;
 };
 /**
  * The options that may be passed to {@link Index.query }

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -41,6 +41,7 @@ describe('query', () => {
     const recordsToUpsert = generateRecords({
       dimension: 5,
       quantity: numberOfRecords,
+      withSparseValues: true,
     });
     expect(recordsToUpsert).toHaveLength(3);
     expect(recordsToUpsert[0].id).toEqual('0');
@@ -96,7 +97,7 @@ describe('query', () => {
     );
   });
 
-  test('query with vector values', async () => {
+  test('query with vector and sparseVector values', async () => {
     const topK = 1;
     const assertions = (results) => {
       expect(results.matches).toBeDefined();
@@ -108,6 +109,10 @@ describe('query', () => {
       () =>
         ns.query({
           vector: [0.11, 0.22, 0.33, 0.44, 0.55],
+          sparseVector: {
+            indices: [32, 5, 3, 2, 1],
+            values: [0.11, 0.22, 0.33, 0.44, 0.55],
+          },
           topK,
         }),
       assertions
@@ -116,6 +121,10 @@ describe('query', () => {
 
   test('query with includeValues: true', async () => {
     const queryVec = Array.from({ length: 5 }, () => Math.random());
+    const sparseVec = {
+      indices: [0, 1, 2, 3, 4],
+      values: Array.from({ length: 5 }, () => Math.random()),
+    };
 
     const assertions = (results) => {
       expect(results.matches).toBeDefined();
@@ -127,6 +136,7 @@ describe('query', () => {
       () =>
         ns.query({
           vector: queryVec,
+          sparseVector: sparseVec,
           topK: 2,
           includeValues: true,
           includeMetadata: true,

--- a/src/utils/__tests__/user-agent.test.ts
+++ b/src/utils/__tests__/user-agent.test.ts
@@ -42,6 +42,10 @@ describe('user-agent', () => {
       config.sourceTag = '  MY SOURCE TAG     1234     ##### !!!!!!';
       userAgent = buildUserAgent(config);
       expect(userAgent).toContain('source_tag=my_source_tag_1234');
+
+      config.sourceTag = ' MY SOURCE TAG :1234-ABCD';
+      userAgent = buildUserAgent(config);
+      expect(userAgent).toContain('source_tag=my_source_tag_:1234abcd');
     });
   });
 });

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -35,13 +35,13 @@ const normalizeSourceTag = (sourceTag: string) => {
   /**
    * normalize sourceTag
    * 1. Lowercase
-   * 2. Limit charset to [a-z0-9_ ]
+   * 2. Limit charset to [a-z0-9_ :]
    * 3. Trim left/right spaces
    * 4. Condense multiple spaces to one, and replace with underscore
    */
   return sourceTag
     .toLowerCase()
-    .replace(/[^a-z0-9_ ]/g, '')
+    .replace(/[^a-z0-9_ :]/g, '')
     .trim()
     .replace(/[ ]+/g, '_');
 };


### PR DESCRIPTION
## Problem
`sparseVector?: RecordSparseValues` was left out of the `QueryByVectorValues` type. While the API supports sending `sparseVector` with query requests, if you attempt to compile the client with TypeScript you'll get a build error.

Issue: https://github.com/pinecone-io/pinecone-ts-client/issues/218

## Solution

- Update the `QueryByVectorValues` type to include `sparseVector?: RecordSparseValues`. This should allow users to pass a `sparseVector` along with their `query` operation if needed.
- Update `query` docstring + integration tests.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Verify CI integration tests pass. I added `sparseVector` to several of our happy-path `query` tests.

Testing this via the repl wasn't sufficient as you could pass the value directly, and you don't get TS build errors.

To properly test you'll need a TypeScript project that uses the Pinecone SDK, and queries with a `sparseVector` in the request object. `tsc` will fail if using the previous client.
