### PR TITLE
Implement Deletion Protection

### DIFF
--- a/src/control/__tests__/configureIndex.test.ts
+++ b/src/control/__tests__/configureIndex.test.ts
@@ -32,8 +32,7 @@ describe('configureIndex', () => {
     const IOA = { configureIndex: fakeConfigure } as ManageIndexesApi;
 
     const returned = await configureIndex(IOA)('index-name', {
-      replicas: 4,
-      podType: 'p2.x2',
+      spec: { pod: { replicas: 4, podType: 'p2.x2' } },
     });
 
     expect(returned).toBe(indexModel);

--- a/src/control/__tests__/configureIndex.validation.test.ts
+++ b/src/control/__tests__/configureIndex.validation.test.ts
@@ -29,7 +29,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if index name is not a string', async () => {
       const toThrow = async () =>
-        await configureIndex(MIA)(1, { replicas: 10 });
+        await configureIndex(MIA)(1, { spec: { pod: { replicas: 10 } } });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -39,7 +39,7 @@ describe('configureIndex argument validations', () => {
 
     test('should throw if index name is empty string', async () => {
       const toThrow = async () =>
-        await configureIndex(MIA)('', { replicas: 2 });
+        await configureIndex(MIA)('', { spec: { pod: { replicas: 2 } } });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
@@ -47,43 +47,59 @@ describe('configureIndex argument validations', () => {
       );
     });
 
-    test('should throw if spec and pod are not provided', async () => {
+    test('should throw if spec or deletionProtection are not provided', async () => {
       const toThrowSpec = async () =>
         await configureIndex(MIA)('index-name', {});
 
       expect(toThrowSpec).rejects.toThrowError(PineconeArgumentError);
       expect(toThrowSpec).rejects.toThrowError(
-        'The second argument to configureIndex should not be empty object. Please specify at least one property (replicas, podType) to update.'
+        'The second argument to configureIndex should not be empty object. Please specify at least one property (spec, deletionProtection) to update.'
       );
     });
 
     test('should throw if replicas is not a number', async () => {
       const toThrow = async () =>
-        await configureIndex(MIA)('index-name', { replicas: '10' });
+        await configureIndex(MIA)('index-name', {
+          spec: { pod: { replicas: '10' } },
+        });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex had type errors: property 'replicas' must be integer."
+        "The second argument to configureIndex had type errors: property 'spec/properties/pod/properties/replicas' must be integer."
       );
     });
 
     test('should throw if podType is not a string', async () => {
       const toThrow = async () =>
-        await configureIndex(MIA)('index-name', { podType: 10.5 });
+        await configureIndex(MIA)('index-name', {
+          spec: { pod: { podType: 10.5 } },
+        });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex had type errors: property 'podType' must be string."
+        "The second argument to configureIndex had type errors: property 'spec/properties/pod/properties/podType' must be string."
       );
     });
 
     test('should throw if replicas is not a positive integer', async () => {
       const toThrow = async () =>
-        await configureIndex(MIA)('index-name', { replicas: 0 });
+        await configureIndex(MIA)('index-name', {
+          spec: { pod: { replicas: 0 } },
+        });
 
       expect(toThrow).rejects.toThrowError(PineconeArgumentError);
       expect(toThrow).rejects.toThrowError(
-        "The second argument to configureIndex had validation errors: property 'replicas' must be >= 1."
+        "The second argument to configureIndex had validation errors: property 'spec/properties/pod/properties/replicas' must be >= 1."
+      );
+    });
+
+    test('should throw if deletionProtection is an empty string', async () => {
+      const toThrow = async () =>
+        await configureIndex(MIA)('index-name', { deletionProtection: '' });
+
+      expect(toThrow).rejects.toThrowError(PineconeArgumentError);
+      expect(toThrow).rejects.toThrowError(
+        "The second argument to configureIndex had validation errors: property 'deletionProtection' must not be blank."
       );
     });
   });

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -103,7 +103,7 @@ const CreateIndexOptionsSchema = Type.Object(
     name: IndexNameSchema,
     dimension: DimensionSchema,
     metric: MetricSchema,
-
+    deletionProtection: Type.Optional(Type.String()),
     spec: Type.Object({
       serverless: Type.Optional(
         Type.Object({

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -10,6 +10,7 @@ const positiveInteger = Type.Integer({ minimum: 1 });
 // string. To avoid this confusing case, we require lenth > 1.
 export const IndexNameSchema = nonemptyString;
 
+export const DeletionProtectionSchema = nonemptyString;
 export const PodTypeSchema = nonemptyString;
 export const ReplicasSchema = positiveInteger;
 export const PodsSchema = positiveInteger;

--- a/src/errors/http.ts
+++ b/src/errors/http.ts
@@ -150,6 +150,8 @@ export const mapHttpStatusError = (failedRequestInfo: FailedRequestInfo) => {
       return new PineconeBadRequestError(failedRequestInfo);
     case 401:
       return new PineconeAuthorizationError(failedRequestInfo);
+    case 403:
+      return new PineconeBadRequestError(failedRequestInfo);
     case 404:
       return new PineconeNotFoundError(failedRequestInfo);
     case 409:

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export type {
   CreateCollectionRequest,
   CreateIndexRequest,
   CreateIndexRequestMetricEnum,
+  DeletionProtection,
   DescribeCollectionRequest,
   DescribeIndexRequest,
   Embedding,

--- a/src/integration/control/configureIndex.test.ts
+++ b/src/integration/control/configureIndex.test.ts
@@ -1,40 +1,109 @@
-import { BasePineconeError } from '../../errors';
+import { BasePineconeError, PineconeBadRequestError } from '../../errors';
 import { Pinecone } from '../../index';
 import { randomIndexName, waitUntilReady } from '../test-helpers';
 
-// TODO: Re-enable
-describe.skip('configure index', () => {
-  let indexName;
+describe('configure index', () => {
+  let podIndexName, serverlessIndexName;
   let pinecone: Pinecone;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     pinecone = new Pinecone();
-    indexName = randomIndexName('configureIndex');
+    podIndexName = randomIndexName('configureIndex');
+    serverlessIndexName = randomIndexName('configureIndex');
 
+    // create pod index
     await pinecone.createIndex({
-      name: indexName,
+      name: podIndexName,
       dimension: 5,
       metric: 'cosine',
       spec: {
         pod: {
           environment: 'us-east1-gcp',
           podType: 'p1.x1',
-          pods: 2,
+          pods: 1,
+        },
+      },
+      waitUntilReady: true,
+    });
+
+    // create serverless index
+    await pinecone.createIndex({
+      name: serverlessIndexName,
+      dimension: 5,
+      metric: 'cosine',
+      spec: {
+        serverless: {
+          cloud: 'aws',
+          region: 'us-east-1',
         },
       },
       waitUntilReady: true,
     });
   });
 
-  afterEach(async () => {
-    await pinecone.deleteIndex(indexName);
+  afterAll(async () => {
+    // wait until indexes are done upgrading before deleting
+    await waitUntilReady(podIndexName);
+    await waitUntilReady(serverlessIndexName);
+
+    await pinecone.deleteIndex(podIndexName);
+    await pinecone.deleteIndex(serverlessIndexName);
   });
 
-  describe.skip('error handling', () => {
-    test('configure index with invalid index name', async () => {
+  describe('pod index', () => {
+    test('scale replicas up', async () => {
+      const description = await pinecone.describeIndex(podIndexName);
+      expect(description.spec.pod?.replicas).toEqual(1);
+
+      await pinecone.configureIndex(podIndexName, {
+        spec: { pod: { replicas: 2 } },
+      });
+      const description2 = await pinecone.describeIndex(podIndexName);
+      expect(description2.spec.pod?.replicas).toEqual(2);
+    });
+
+    test('scale podType up', async () => {
+      // Verify the starting state
+      const description = await pinecone.describeIndex(podIndexName);
+      expect(description.spec.pod?.podType).toEqual('p1.x1');
+
+      await pinecone.configureIndex(podIndexName, {
+        spec: { pod: { podType: 'p1.x2' } },
+      });
+      const description2 = await pinecone.describeIndex(podIndexName);
+      expect(description2.spec.pod?.podType).toEqual('p1.x2');
+    });
+  });
+
+  describe('serverless index', () => {
+    test('enable and disable deletionProtection', async () => {
+      await pinecone.configureIndex(serverlessIndexName, {
+        deletionProtection: 'enabled',
+      });
+
+      await waitUntilReady(serverlessIndexName);
+
+      // verify we cannot delete the index
+      await pinecone.deleteIndex(serverlessIndexName).catch((e) => {
+        const err = e as PineconeBadRequestError;
+        expect(err.name).toEqual('PineconeBadRequestError');
+        expect(err.message).toContain(
+          'Deletion protection is enabled for this index'
+        );
+      });
+
+      // disable so we can clean the index up
+      await pinecone.configureIndex(serverlessIndexName, {
+        deletionProtection: 'disabled',
+      });
+    });
+  });
+
+  describe('error cases', () => {
+    test('cannot configure index with invalid index name', async () => {
       try {
         await pinecone.configureIndex('non-existent-index', {
-          replicas: 2,
+          spec: { pod: { replicas: 2 } },
         });
       } catch (e) {
         const err = e as BasePineconeError;
@@ -42,113 +111,62 @@ describe.skip('configure index', () => {
       }
     });
 
-    test('configure index when exceeding quota', async () => {
+    test('cannot configure index when exceeding quota', async () => {
       try {
-        await pinecone.configureIndex(indexName, {
-          replicas: 20,
+        await pinecone.configureIndex(podIndexName, {
+          spec: { pod: { replicas: 20 } },
         });
       } catch (e) {
         const err = e as BasePineconeError;
         expect(err.name).toEqual('PineconeBadRequestError');
-        expect(err.message).toContain('The index exceeds the project quota');
         expect(err.message).toContain(
-          'Upgrade your account or change the project settings to increase the quota.'
+          `You've reached the max pods allowed in project`
+        );
+        expect(err.message).toContain(
+          'To increase this limit, adjust your project settings in the console'
         );
       }
     });
-  });
 
-  describe.skip('scaling replicas', () => {
-    test('scaling up', async () => {
-      const description = await pinecone.describeIndex(indexName);
-      expect(description.spec.pod?.replicas).toEqual(2);
-
-      await pinecone.configureIndex(indexName, {
-        replicas: 3,
-      });
-      const description2 = await pinecone.describeIndex(indexName);
-      expect(description2.spec.pod?.replicas).toEqual(3);
-    });
-
-    test('scaling down', async () => {
-      const description = await pinecone.describeIndex(indexName);
-      expect(description.spec.pod?.replicas).toEqual(2);
-
-      await pinecone.configureIndex(indexName, {
-        replicas: 1,
-      });
-      const description3 = await pinecone.describeIndex(indexName);
-      expect(description3.spec.pod?.replicas).toEqual(1);
-    });
-  });
-
-  describe.skip('scaling pod type', () => {
-    test('scaling podType: changing base pod type', async () => {
-      // Verify the starting state
-      const description = await pinecone.describeIndex(indexName);
-      expect(description.spec.pod?.podType).toEqual('p1.x1');
-
+    test('cannot change base pod type', async () => {
       try {
         // Try to change the base pod type
-        await pinecone.configureIndex(indexName, {
-          podType: 'p2.x1',
+        await pinecone.configureIndex(podIndexName, {
+          spec: { pod: { podType: 'p2.x1' } },
+        });
+      } catch (e) {
+        const err = e as BasePineconeError;
+        expect(err.name).toEqual('PineconeBadRequestError');
+        expect(err.message).toContain('Bad request: Cannot change pod type');
+      }
+    });
+
+    test('cannot set deletionProtection value other than enabled / disabled', async () => {
+      try {
+        await pinecone.configureIndex(serverlessIndexName, {
+          // @ts-expect-error
+          deletionProtection: 'bogus',
         });
       } catch (e) {
         const err = e as BasePineconeError;
         expect(err.name).toEqual('PineconeBadRequestError');
         expect(err.message).toContain(
-          'updating base pod type is not supported'
+          'Invalid deletion_protection, value should be either enabled or disabled'
         );
       }
     });
 
-    test('scaling podType: size increase', async () => {
-      // Verify the starting state
-      const description = await pinecone.describeIndex(indexName);
-      expect(description.spec.pod?.podType).toEqual('p1.x1');
-
-      await pinecone.configureIndex(indexName, {
-        podType: 'p1.x2',
-      });
-      const description2 = await pinecone.describeIndex(indexName);
-      expect(description2.spec.pod?.podType).toEqual('p1.x2');
-    });
-
-    test('scaling podType: size down', async () => {
-      // Verify the starting state
-      const description = await pinecone.describeIndex(indexName);
-      expect(description.spec.pod?.podType).toEqual('p1.x1');
-
-      // Size up
-      await pinecone.configureIndex(indexName, {
-        podType: 'p1.x2',
-      });
-      const description2 = await pinecone.describeIndex(indexName);
-      expect(description2.spec.pod?.podType).toEqual('p1.x2');
-
-      await waitUntilReady(indexName);
-
+    test('cannot configure pod spec for serverless', async () => {
       try {
-        // try to size down
-        await pinecone.configureIndex(indexName, {
-          podType: 'p1.x1',
+        await pinecone.configureIndex(serverlessIndexName, {
+          spec: { pod: { replicas: 2 } },
         });
-        const description3 = await pinecone.describeIndex(indexName);
-        expect(description3.spec.pod?.podType).toEqual('p1.x1');
       } catch (e) {
         const err = e as BasePineconeError;
-
-        if (err.name === 'PineconeBadRequestError') {
-          expect(err.message).toContain(
-            'scaling down pod type is not supported'
-          );
-        } else if (err.name === 'PineconeInternalServerError') {
-          // noop. Seems like the API is sometimes returns 500 when scaling up
-          // and down in quick succession. But it's not a client issue so I
-          // don't want to fail the test in that case.
-        } else {
-          throw err;
-        }
+        expect(err.name).toEqual('PineconeBadRequestError');
+        expect(err.message).toContain(
+          'Configuring replicas and pod type is not supported for serverless'
+        );
       }
     });
   });

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -438,14 +438,18 @@ export class Pinecone {
   /**
    * Configure an index
    *
-   * Use this method to update configuration on an existing index. You can update the number of replicas, and pod type.
+   * Use this method to update configuration on an existing index. For both pod-based and serverless indexes you can update
+   * the deletionProtection status of an index. For pod-based index you can also configure the number of replicas and pod type.
    *
    * @example
    * ```js
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const pc = new Pinecone();
    *
-   * await pc.configureIndex('my-index', { replicas: 2, podType: 'p1.x2' })
+   * await pc.configureIndex('my-index', {
+   *   deletionProtection: 'enabled',
+   *   spec:{ pod:{ replicas: 2, podType: 'p1.x2' }},
+   * });
    * ```
    *
    * @param indexName - The name of the index to configure.

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -17,7 +17,10 @@ import {
   ConfigureIndexRequestSpecPod,
   CreateCollectionRequest,
 } from './pinecone-generated-ts-fetch/control';
-import type { HTTPHeaders } from './pinecone-generated-ts-fetch/control';
+import type {
+  ConfigureIndexRequest,
+  HTTPHeaders,
+} from './pinecone-generated-ts-fetch/control';
 import { IndexHostSingleton } from './data/indexHostSingleton';
 import {
   PineconeConfigurationError,
@@ -451,7 +454,7 @@ export class Pinecone {
    * @throws {@link Errors.PineconeConnectionError} when network problems or an outage of Pinecone's APIs prevent the request from being completed.
    * @returns A promise that resolves to {@link IndexModel} when the request to configure the index is completed.
    */
-  configureIndex(indexName: IndexName, options: ConfigureIndexRequestSpecPod) {
+  configureIndex(indexName: IndexName, options: ConfigureIndexRequest) {
     return this._configureIndex(indexName, options);
   }
 


### PR DESCRIPTION
## Problem
`deletionProtection` is part of the control plane spec, but we have not implemented it in the TypeScript SDK.

## Solution
- Update `configureIndex` schema and `options` type to `ConfigureIndexRequest` to properly support the new object structure for making requests to configure an index. We needed `deletionProtection` at the top level, and the new nesting for `spec: { pod : { ... }}`.
- Update `createIndex` schema to validate optional `deletionProtection`.
- Refactor `configureIndex` unit / validation tests.
- Refactor / enable `configureIndex` integration tests - these had been disabled during the serverless launch era and I never re-wrote them. Better late than never.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

- Test that creating and index without passing `deletionProtection` defaults to `disabled`.
- Confirm that you can configure both pod and serverless index `deletionProtection` options.
- Confirm that trying to delete an index with `deletionProtection: 'enabled'` throws an error.
- Validate we're seeing the `deletionProtection` field in operations such as `listIndexes` and `describeIndex`.
