### PR TITLE
Remove support for Node `<18.0.0`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Prettier

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,13 +24,15 @@ jobs:
         run: npm run format
       - name: Check for prettier changes
         run: |
-          git diff --exit-code >/dev/null 2>&1
           git diff
-          EXIT_CODE=$?
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
-            exit 1
-          fi
+        # run: |
+        #   git diff --exit-code >/dev/null 2>&1
+        #   git diff
+        #   EXIT_CODE=$?
+        #   if [ $EXIT_CODE -ne 0 ]; then
+        #     echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
+        #     exit 1
+        #   fi
         shell: bash
       - name: ESLint
         run: npm run lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node_version: 20.x
+          node_version: '18.17.1'
       - name: Prettier
         run: npm run format
       - name: Check for prettier changes
@@ -30,8 +30,11 @@ jobs:
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
+            echo "Summary of changes:"
+            git diff
             exit 1
           fi
+        shell: bash
       - name: ESLint
         run: npm run lint
       - name: TypeDoc

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,18 +20,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          node_version: '18.17.1'
       - name: Prettier
         run: npm run format
       - name: Check for prettier changes
         run: |
           git diff --exit-code >/dev/null 2>&1
+          git diff
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
-            echo "Summary of changes:"
-            git diff
             exit 1
           fi
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm run format
       - name: Check for prettier changes
         run: |
-          git diff --exit-code >/dev/null 2>&1
+          git diff --exit-code >/dev/null
           git diff
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Prettier
         run: npm run format
       - name: Check for prettier changes
+        shell: bash
         run: |
-          git diff --exit-code >/dev/null 2>&1 || true
+          git diff --exit-code >/dev/null 2>&1
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Prettier changes detected. Please run 'npm run format' and commit the changes."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,7 @@ jobs:
           git diff --exit-code > /dev/null 2>&1 || EXIT_CODE=$?; echo "Exit code: $EXIT_CODE"
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
+            echo "Summary of changes: "
             git diff
             exit 1
           fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,16 +24,13 @@ jobs:
         run: npm run format
       - name: Check for prettier changes
         run: |
+          git diff --exit-code >/dev/null 2>&1
           git diff
-        # run: |
-        #   git diff --exit-code >/dev/null 2>&1
-        #   git diff
-        #   EXIT_CODE=$?
-        #   if [ $EXIT_CODE -ne 0 ]; then
-        #     echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
-        #     exit 1
-        #   fi
-        shell: bash
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
+            exit 1
+          fi
       - name: ESLint
         run: npm run lint
       - name: TypeDoc

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Check for prettier changes
         shell: bash
         run: |
-          git diff --exit-code >/dev/null 2>&1
-          EXIT_CODE=$?
+          git diff --exit-code > /dev/null 2>&1 || EXIT_CODE=$?; echo "Exit code: $EXIT_CODE"
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
             git diff

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Prettier

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          node_version: 20.x
       - name: Prettier
         run: npm run format
       - name: Check for prettier changes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,11 +24,11 @@ jobs:
         run: npm run format
       - name: Check for prettier changes
         run: |
-          git diff --exit-code >/dev/null
-          git diff
+          git diff --exit-code >/dev/null 2>&1 || true
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Prettier changes detected. Please run 'npm run format' and commit the changes."
+            git diff
             exit 1
           fi
       - name: ESLint

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
         pinecone_env:
           - prod
           # - staging
-        node_version: [16.x, 18.x, 20.x]
+        node_version: [18.x, 20.x]
         config:
           [
             { runner: 'npm', jest_env: 'node' },

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 codegen
+src/pinecone-generated-ts-fetch

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^4.9.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:unit": "jest src/"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:unit": "jest src/"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=14.0.0"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "^2.3.3",

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -2,7 +2,6 @@ import {
   CreateIndexRequest,
   IndexModel,
   ManageIndexesApi,
-  CreateIndexRequestMetricEnum,
   ServerlessSpecCloudEnum,
   PodSpecMetadataConfig,
 } from '../pinecone-generated-ts-fetch/control';


### PR DESCRIPTION
## Problem
When implementing inference @aulorbe ran into issues related to large response payloads causing timeouts in integration tests. She tracked this down to being related to the specific version of Node being used to run the integration tests. Specifically, this was a problem with versions `<=16.0.0`.

We currently support Node `>14.0.0`, however `v20.0.0` is the current LTS version. `v14.0.0` was EOL April 30, 2023, and `v16.0.0` in September 11th, 2023. Details in this Slack thread: https://pinecone-io.slack.com/archives/C05MYEX7T2L/p1718202858574909?thread_ts=1718135375.511479&cid=C05MYEX7T2L

## Solution
Given the issues we've run into testing on older versions of Node, and these versions being fully EOL'd, we should bump our engine support to `v18.0.0` for now. Details in Slack: https://pinecone-io.slack.com/archives/C05MYEX7T2L/p1718202858574909?thread_ts=1718135375.511479&cid=C05MYEX7T2L

- Update `package.json` to support Node `>=18.0.0`.
- Remove `v16.0.0` from integration testing matrix.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
`npm run build`
`npm run test:integration`

Validate we've got green across the board for inference integration tests in CI.
