### PR TITLE
Add console warning when using SDK in browser context

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@ generateQueryEmbeddings().then((embeddingsResponse) => {
 
 ## Productionizing
 
-**Warning:** The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context in a production setting could lead to exposing your API key to third parties. If you have deployed the SDK to production in a browser, please rotate your API keys.
+**Note:** The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context can expose your API key(s). If you have deployed the SDK to production in a browser, please rotate your API keys.
 
 If you are ready to take a JavaScript application to production where raw performance is the overriding concern, you can set the environment variable `PINECONE_DISABLE_RUNTIME_VALIDATIONS="true"` to disable runtime argument validation in the Pinecone client. Runtime validations are used to provide feedback when incorrect method options are provided, for example if you attempt to create an index without specifying a required dimension property.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ await pc.createIndex({
   metric: 'dotproduct',
   spec: {
     pod: {
+      environment: 'us-east4-gcp',
       pods: 2,
       podType: 'p1.x2',
       metadataConfig: {

--- a/README.md
+++ b/README.md
@@ -927,6 +927,8 @@ generateQueryEmbeddings().then((embeddingsResponse) => {
 
 ## Productionizing
 
+**Warning:** The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context in a production setting could lead to exposing your API key to third parties. If you have deployed the SDK to production in a browser, please rotate your API keys.
+
 If you are ready to take a JavaScript application to production where raw performance is the overriding concern, you can set the environment variable `PINECONE_DISABLE_RUNTIME_VALIDATIONS="true"` to disable runtime argument validation in the Pinecone client. Runtime validations are used to provide feedback when incorrect method options are provided, for example if you attempt to create an index without specifying a required dimension property.
 
 These runtime validations are most helpful for users who are not developing with Typescript or who are experimenting in a REPL or notebook-type setting. But once you've tested an application and have gained confidence things are working as expected, you can disable these checks to gain a small improvement in performance. This will have the most impact if your workload is upserting very large amounts of data.

--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -154,7 +154,7 @@ describe('Pinecone', () => {
       new Pinecone({ apiKey: 'test-api-key' });
 
       expect(warnSpy).toHaveBeenCalledWith(
-        'Warning: The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context in a production setting could lead to exposing your API key to third parties. If you have deployed the SDK to production in a browser, please rotate your API keys.'
+        'The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context can expose your API key(s). If you have deployed the SDK to production in a browser, please rotate your API keys.'
       );
 
       // Clean up: remove the mock window object

--- a/src/__tests__/pinecone.test.ts
+++ b/src/__tests__/pinecone.test.ts
@@ -2,7 +2,6 @@ import { Pinecone } from '../pinecone';
 import { IndexHostSingleton } from '../data/indexHostSingleton';
 import type { PineconeConfiguration } from '../data';
 import * as utils from '../utils';
-import { warn } from 'console';
 
 const fakeFetch = jest.fn();
 const fakeHost = '123-456.pinecone.io';
@@ -65,12 +64,6 @@ jest.mock('../control', () => {
 });
 
 describe('Pinecone', () => {
-  let originalWindow: typeof globalThis.window;
-
-  beforeEach(() => {
-    originalWindow = global.window;
-  });
-
   describe('constructor', () => {
     describe('required properties', () => {
       test('should throw an error if apiKey is not provided', () => {
@@ -150,12 +143,9 @@ describe('Pinecone', () => {
     });
 
     test('should log a warning if the SDK is used in a browser context', () => {
-      // Mock the window object since our unit tests are not running in a browser context
-      (global as any).window = Object.create(window);
-      Object.defineProperty(window, 'document', {
-        value: {},
-        writable: true,
-      });
+      // Mock window simulate browser context
+      const mockWindow = {} as any;
+      global.window = mockWindow;
 
       const warnSpy = jest
         .spyOn(console, 'warn')
@@ -167,8 +157,9 @@ describe('Pinecone', () => {
         'Warning: The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context in a production setting could lead to exposing your API key to third parties. If you have deployed the SDK to production in a browser, please rotate your API keys.'
       );
 
-      // Rstore the original window
-      delete (global as any).window;
+      // Clean up: remove the mock window object
+      // @ts-ignore
+      delete global.window;
     });
   });
 

--- a/src/inference/inference.ts
+++ b/src/inference/inference.ts
@@ -34,36 +34,17 @@ export class Inference {
     inputs: Array<string>,
     params: Record<string, string>
   ): Promise<EmbeddingsList> {
-    try {
-      const typedAndFormattedInputs: Array<EmbedRequestInputsInner> =
-        this._formatInputs(inputs);
-      const typedParams: EmbedRequestParameters = this._formatParams(params);
-      const typedRequest: EmbedOperationRequest = {
-        embedRequest: {
-          model: model,
-          inputs: typedAndFormattedInputs,
-          parameters: typedParams,
-        },
-      };
-      const response = await this._inferenceApi.embed(typedRequest);
-      if (response.model && response.data && response.usage) {
-        return new EmbeddingsList(
-          response.model,
-          response.data,
-          response.usage
-        );
-      } else {
-        console.log(
-          'Response from Inference API is missing required fields; response:',
-          response
-        );
-        throw new Error(
-          'Response from Inference API is missing required fields'
-        );
-      }
-    } catch (error) {
-      console.log('Error occurred while generating embeddings:', error);
-      throw error;
-    }
+    const typedAndFormattedInputs: Array<EmbedRequestInputsInner> =
+      this._formatInputs(inputs);
+    const typedParams: EmbedRequestParameters = this._formatParams(params);
+    const typedRequest: EmbedOperationRequest = {
+      embedRequest: {
+        model: model,
+        inputs: typedAndFormattedInputs,
+        parameters: typedParams,
+      },
+    };
+    const response = await this._inferenceApi.embed(typedRequest);
+    return new EmbeddingsList(response.model, response.data, response.usage);
   }
 }

--- a/src/inference/inferenceOperationsBuilder.ts
+++ b/src/inference/inferenceOperationsBuilder.ts
@@ -26,7 +26,7 @@ export const inferenceOperationsBuilder = (
     queryParamsStringify,
     headers: {
       'User-Agent': buildUserAgent(config),
-      'X-Pinecone-Api-Version': X_PINECONE_API_VERSION,
+      'X-Pinecone-API-Version': X_PINECONE_API_VERSION,
       ...headers,
     },
     fetchApi: getFetch(config),

--- a/src/inference/inferenceOperationsBuilder.ts
+++ b/src/inference/inferenceOperationsBuilder.ts
@@ -26,7 +26,7 @@ export const inferenceOperationsBuilder = (
     queryParamsStringify,
     headers: {
       'User-Agent': buildUserAgent(config),
-      'X-Pinecone-API-Version': X_PINECONE_API_VERSION,
+      'X-Pinecone-Api-Version': X_PINECONE_API_VERSION,
       ...headers,
     },
     fetchApi: getFetch(config),

--- a/src/inference/inferenceOperationsBuilder.ts
+++ b/src/inference/inferenceOperationsBuilder.ts
@@ -3,6 +3,7 @@ import {
   Configuration,
   type ConfigurationParameters as IndexOperationsApiConfigurationParameters,
   InferenceApi,
+  X_PINECONE_API_VERSION,
 } from '../pinecone-generated-ts-fetch/control';
 import {
   buildUserAgent,
@@ -25,7 +26,7 @@ export const inferenceOperationsBuilder = (
     queryParamsStringify,
     headers: {
       'User-Agent': buildUserAgent(config),
-      'X-Pinecone-API-Version': '2024-07',
+      'X-Pinecone-Api-Version': X_PINECONE_API_VERSION,
       ...headers,
     },
     fetchApi: getFetch(config),

--- a/src/integration/inference/embed.test.ts
+++ b/src/integration/inference/embed.test.ts
@@ -15,10 +15,7 @@ describe('Integration Test: Pinecone Inference API embeddings endpoint', () => {
     };
     model = 'multilingual-e5-large';
     const apiKey = process.env.PINECONE_API_KEY || '';
-    pinecone = new Pinecone({
-      apiKey,
-      additionalHeaders: { 'X-Pinecone-API-Version': '2024-07' },
-    });
+    pinecone = new Pinecone({ apiKey });
   });
 
   it('Confirm output types', async () => {

--- a/src/models/__tests__/embeddingsList.test.ts
+++ b/src/models/__tests__/embeddingsList.test.ts
@@ -22,7 +22,7 @@ describe('EmbeddingsList', () => {
     expect(embeddingsList.model).toEqual(mockModel);
     expect(embeddingsList.data).toEqual(mockEmbeddings);
     expect(embeddingsList.usage).toEqual(mockUsage);
-    expect(embeddingsList.data.values).toEqual(mockEmbeddings.values);
+    expect(embeddingsList.data?.values).toEqual(mockEmbeddings.values);
   });
 
   it('Should return correct Embedding by index and by element', () => {

--- a/src/models/embeddingsList.ts
+++ b/src/models/embeddingsList.ts
@@ -25,9 +25,9 @@ export class EmbeddingsList
   extends Array<Embedding>
   implements OpenAPIEmbeddingsList
 {
-  model: string;
-  data: Array<Embedding>;
-  usage: EmbeddingsListUsage;
+  model?: string;
+  data?: Array<Embedding>;
+  usage?: EmbeddingsListUsage;
 
   constructor(
     model: string,

--- a/src/models/embeddingsList.ts
+++ b/src/models/embeddingsList.ts
@@ -26,13 +26,13 @@ export class EmbeddingsList
   implements OpenAPIEmbeddingsList
 {
   model?: string;
-  data?: Array<Embedding>;
+  data: Array<Embedding>;
   usage?: EmbeddingsListUsage;
 
   constructor(
-    model: string,
-    data: Array<Embedding>,
-    usage: EmbeddingsListUsage
+    model?: string,
+    data: Array<Embedding> = [],
+    usage?: EmbeddingsListUsage
   ) {
     super(...data);
     // Set the prototype explicitly to ensure the instance is of type EmbeddingsList

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -561,7 +561,7 @@ export class Pinecone {
   _checkForBrowser() {
     if (isBrowser()) {
       console.warn(
-        'Warning: The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context in a production setting could lead to exposing your API key to third parties. If you have deployed the SDK to production in a browser, please rotate your API keys.'
+        'The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context can expose your API key(s). If you have deployed the SDK to production in a browser, please rotate your API keys.'
       );
     }
   }

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -13,12 +13,9 @@ import {
   indexOperationsBuilder,
   CollectionName,
 } from './control';
-import {
-  ConfigureIndexRequestSpecPod,
-  CreateCollectionRequest,
-} from './pinecone-generated-ts-fetch/control';
 import type {
   ConfigureIndexRequest,
+  CreateCollectionRequest,
   HTTPHeaders,
 } from './pinecone-generated-ts-fetch/control';
 import { IndexHostSingleton } from './data/indexHostSingleton';
@@ -31,6 +28,7 @@ import { buildValidator } from './validator';
 import type { PineconeConfiguration, RecordMetadata } from './data';
 import { Inference } from './inference';
 import { inferenceOperationsBuilder } from './inference/inferenceOperationsBuilder';
+import { isBrowser } from './utils/environment';
 
 /**
  * The `Pinecone` class is the main entrypoint to this sdk. You will use
@@ -115,8 +113,9 @@ export class Pinecone {
     }
 
     this._validateConfig(options);
-
     this.config = options;
+
+    this._checkForBrowser();
 
     const api = indexOperationsBuilder(this.config);
     const infApi = inferenceOperationsBuilder(this.config);
@@ -556,6 +555,15 @@ export class Pinecone {
       'The client configuration',
       PineconeConfigurationSchema
     )(options);
+  }
+
+  /** @internal */
+  _checkForBrowser() {
+    if (isBrowser()) {
+      console.warn(
+        'Warning: The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context in a production setting could lead to exposing your API key to third parties. If you have deployed the SDK to production in a browser, please rotate your API keys.'
+      );
+    }
   }
 
   /**

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -4,3 +4,7 @@ export const isEdge = () => {
   // to Vercel docs.
   return typeof EdgeRuntime === 'string';
 };
+
+export const isBrowser = () => {
+  return typeof window !== 'undefined';
+};


### PR DESCRIPTION
## Problem
We recently had an issue logged around problems using the Pinecone SDK from a browser context because we're applying a user-agent to outgoing HTTP requests, and certain browsers don't play nicely with that.

Ultimately, people should not be using the SDK from a browser as it's a large security risk, and exposes their API key if deployed to production. We'd like to add a warning when we detect the SDK is being used from the browser.

## Solution
- Add `isBrowser` function to `utils/environment.ts`.
- Add private helper `_checkForBrowser()` to `Pinecone` which calls `isBrowser` and calls `console.warn` if true. This is run once when constructing the `Pinecone` class.
- Add a unit test to validate the behavior when `window` is present in the global object.
- Use the generated API version default `X_PINECONE_API_VERSION` in the `inferenceOperationsBuilder`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
You'll need to run the SDK from within a browser, which would take some setup. The unit test should be good enough to cover the behavior here.
