### PR TITLE
Change "client" to "SDK"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Pinecone Node.js Client &middot; ![License](https://img.shields.io/github/license/pinecone-io/pinecone-ts-client?color=orange) ![npm](https://img.shields.io/npm/v/%40pinecone-database%2Fpinecone?link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40pinecone-database%2Fpinecone) ![npm](https://img.shields.io/npm/dw/%40pinecone-database/pinecone?style=flat&color=blue&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40pinecone-database%2Fpinecone) ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/pinecone-io/pinecone-ts-client/merge.yml?label=CI&link=https%3A%2F%2Fgithub.com%2Fpinecone-io%2Fpinecone-ts-client%2Factions%2Fworkflows%2Fmerge.yml)
+# Pinecone Node.js SDK &middot; ![License](https://img.shields.io/github/license/pinecone-io/pinecone-ts-client?color=orange) ![npm](https://img.shields.io/npm/v/%40pinecone-database%2Fpinecone?link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40pinecone-database%2Fpinecone) ![npm](https://img.shields.io/npm/dw/%40pinecone-database/pinecone?style=flat&color=blue&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40pinecone-database%2Fpinecone) ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/pinecone-io/pinecone-ts-client/merge.yml?label=CI&link=https%3A%2F%2Fgithub.com%2Fpinecone-io%2Fpinecone-ts-client%2Factions%2Fworkflows%2Fmerge.yml)
 
-This is the official Node.js client for [Pinecone](https://www.pinecone.io), written in TypeScript.
+This is the official Node.js SDK for [Pinecone](https://www.pinecone.io), written in TypeScript.
 
 ## Documentation
 
 - [**Reference Documentation**](https://sdk.pinecone.io/typescript/classes/Pinecone.html)
-- If you are upgrading from a `v0.x` beta client, check out the [**v1 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v1-migration.md).
-- If you are upgrading from a `v1.x` client, check out the [**v2 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v2-migration.md).
+- If you are upgrading from `v0.x`, check out the [**v1 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v1-migration.md).
+- If you are upgrading from `v1.x`, check out the [**v2 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v2-migration.md).
 
 ### Example code
 
@@ -16,7 +16,7 @@ The snippets shown in this README are intended to be concise. For more realistic
 - [Article recommender](https://github.com/pinecone-io/recommender-example-typescript)
 - [Image search](https://github.com/pinecone-io/image-search-example)
 
-## Upgrading your client
+## Upgrading the SDK
 
 #### Upgrading from `2.x` to `3.x`
 
@@ -26,11 +26,11 @@ when configuring an index has changed to include `deletionProtection`. The `podT
 #### Upgrading from older versions
 
 - **Upgrading to `2.x`** : There were many changes made in this release to support Pinecone's new Serverless index offering. The changes are covered in detail in the [**v2 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v2-migration.md). Serverless indexes are only available in `2.x` release versions or greater.
-- **Upgrading to `1.x`** : This release officially moved the SDK out of beta, and there are a number of breaking changes that need to be addressed when upgrading from a `0.x` client. See the [**v1 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v1-migration.md) for details.
+- **Upgrading to `1.x`** : This release officially moved the SDK out of beta, and there are a number of breaking changes that need to be addressed when upgrading from a `0.x` version. See the [**v1 Migration Guide**](https://github.com/pinecone-io/pinecone-ts-client/blob/main/v1-migration.md) for details.
 
 ## Prerequisites
 
-The Pinecone TypeScript client is compatible with TypeScript 4.1 and greater.
+The Pinecone TypeScript SDK is compatible with TypeScript 4.1 and greater.
 
 ## Installation
 


### PR DESCRIPTION
## Problem

We are inconsistent in how we refer to our client libraries.

## Solution

As we mostly refer to our "SDKs" rather than our "clients", we've updated our docs to prefer "SDK". This PR makes equivalent updates to the Python README.

Addresses: https://app.asana.com/0/1206419570114940/1207978475519546/f

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
