### PR TITLE
Update client to use ESModules syntax

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,6 +4,9 @@ inputs:
   pinecone_api_key:
     description: 'API key'
     required: true
+  node_version:
+    description: 'Node.js version to setup'
+    required: true
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -140,6 +140,7 @@ jobs:
           cd ts-compilation-test
           npm install typescript@${{ matrix.tsVersion }} --no-cache
           npm install @pinecone-database/pinecone --no-cache
+          npm install @types/node --save-dev
           cat package.json
           cat package-lock.json
           npm run tsc-version

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -139,8 +139,17 @@ jobs:
           cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
           cd ts-compilation-test
           npm install typescript@${{ matrix.tsVersion }} --no-cache
+          
+          # Determine appropriate @types/node version
+          NODE_TYPES_VERSION="latest"
+          if [[ "${{ matrix.tsVersion }}" =~ ^~4\.[0-9]+\.[0-9]+$ ]]; then
+          NODE_TYPES_VERSION="^14.14.0"
+          elif [[ "${{ matrix.tsVersion }}" =~ ^~5\.[0-9]+\.[0-9]+$ ]]; then
+          NODE_TYPES_VERSION="18"  # Compatible with Node.js 18.x and TypeScript 5.x.x
+          fi
+          
           npm install @pinecone-database/pinecone --no-cache
-          npm install @types/node --save-dev
+          npm install @types/node@$NODE_TYPES_VERSION --save-dev
           cat package.json
           cat package-lock.json
           npm run tsc-version

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -139,8 +139,7 @@ jobs:
           cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
           cd ts-compilation-test
           npm install typescript@${{ matrix.tsVersion }} --no-cache
-#          npm install '../pinecone-ts-client' --no-cache
-         npm install @pinecone-database/pinecone --no-cache
+          npm install @pinecone-database/pinecone --no-cache
           cat package.json
           cat package-lock.json
           npm run tsc-version

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -139,7 +139,8 @@ jobs:
           cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
           cd ts-compilation-test
           npm install typescript@${{ matrix.tsVersion }} --no-cache
-          npm install '../pinecone-ts-client' --no-cache
+#          npm install '../pinecone-ts-client' --no-cache
+         npm install @pinecone-database/pinecone --no-cache
           cat package.json
           cat package-lock.json
           npm run tsc-version

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -139,7 +139,7 @@ jobs:
           cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
           cd ts-compilation-test
           npm install typescript@${{ matrix.tsVersion }} --no-cache
-          
+
           # Determine appropriate @types/node version
           NODE_TYPES_VERSION="latest"
           if [[ "${{ matrix.tsVersion }}" =~ ^~4\.[0-9]+\.[0-9]+$ ]]; then
@@ -147,7 +147,7 @@ jobs:
           elif [[ "${{ matrix.tsVersion }}" =~ ^~5\.[0-9]+\.[0-9]+$ ]]; then
           NODE_TYPES_VERSION="18"  # Compatible with Node.js 18.x and TypeScript 5.x.x
           fi
-          
+
           npm install @pinecone-database/pinecone --no-cache
           npm install @types/node@$NODE_TYPES_VERSION --save-dev
           cat package.json

--- a/jest.config.integration-edge.js
+++ b/jest.config.integration-edge.js
@@ -5,7 +5,7 @@
 //   testEnvironment: '@edge-runtime/jest-environment',
 // };
 
-import config from './jest.config.integration-node';
+import config from './jest.config.integration-node.js';
 
 export default {
   ...config,

--- a/jest.config.integration-edge.js
+++ b/jest.config.integration-edge.js
@@ -1,6 +1,13 @@
-const config = require('./jest.config.integration-node');
+// const config = require('./jest.config.integration-node');
+//
+// module.exports = {
+//   ...config,
+//   testEnvironment: '@edge-runtime/jest-environment',
+// };
 
-module.exports = {
+import config from './jest.config.integration-node';
+
+export default {
   ...config,
   testEnvironment: '@edge-runtime/jest-environment',
 };

--- a/jest.config.integration-edge.js
+++ b/jest.config.integration-edge.js
@@ -1,10 +1,3 @@
-// const config = require('./jest.config.integration-node');
-//
-// module.exports = {
-//   ...config,
-//   testEnvironment: '@edge-runtime/jest-environment',
-// };
-
 import config from './jest.config.integration-node.js';
 
 export default {

--- a/jest.config.integration-node.js
+++ b/jest.config.integration-node.js
@@ -8,7 +8,7 @@
 //   testEnvironment: 'node',
 // };
 
-import config from './jest.config';
+import config from './jest.config.js';
 
 export default {
   ...config,

--- a/jest.config.integration-node.js
+++ b/jest.config.integration-node.js
@@ -1,6 +1,16 @@
-const config = require('./jest.config');
+// const config = require('./jest.config');
+//
+// module.exports = {
+//   ...config,
+//   reporters: [['github-actions', { silent: false }], 'default'],
+//   setupFilesAfterEnv: ['./utils/globalIntegrationTestSetup.ts'],
+//   testPathIgnorePatterns: [],
+//   testEnvironment: 'node',
+// };
 
-module.exports = {
+import config from './jest.config';
+
+export default {
   ...config,
   reporters: [['github-actions', { silent: false }], 'default'],
   setupFilesAfterEnv: ['./utils/globalIntegrationTestSetup.ts'],

--- a/jest.config.integration-node.js
+++ b/jest.config.integration-node.js
@@ -1,13 +1,3 @@
-// const config = require('./jest.config');
-//
-// module.exports = {
-//   ...config,
-//   reporters: [['github-actions', { silent: false }], 'default'],
-//   setupFilesAfterEnv: ['./utils/globalIntegrationTestSetup.ts'],
-//   testPathIgnorePatterns: [],
-//   testEnvironment: 'node',
-// };
-
 import config from './jest.config.js';
 
 export default {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   reporters: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "jest-skipped-reporter": "^0.0.5",
         "prettier": "^2.8.8",
         "ts-jest": "^29.0.5",
+        "ts-node": "^10.9.2",
         "typedoc": "^0.24.8",
         "typescript": "^4.9.4"
       },
@@ -577,8 +578,6 @@
       "version": "0.8.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1206,30 +1205,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -1664,8 +1655,6 @@
       "version": "8.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1727,9 +1716,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -2359,9 +2346,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -2468,8 +2453,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -7159,11 +7142,10 @@
       "license": "ISC"
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7498,9 +7480,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -7695,8 +7675,6 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@pinecone-database/pinecone",
   "version": "3.0.1",
   "main": "dist/index.js",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/pinecone-io/pinecone-ts-client"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "repl": "npm run build && node utils/replInit.ts",
     "test:integration:node": "TEST_ENV=node jest src/integration/ -c jest.config.integration-node.js --runInBand --bail",
     "test:integration:edge": "TEST_ENV=edge jest src/integration/ -c jest.config.integration-edge.js --runInBand --bail",
-    "test:integration:cleanup": "npm run build && node utils/cleanupResources.ts",
+    "test:integration:cleanup": "npm run build && npx utils/cleanupResources.ts",
     "test:unit": "jest src/"
   },
   "engines": {
@@ -45,6 +45,7 @@
     "jest-skipped-reporter": "^0.0.5",
     "prettier": "^2.8.8",
     "ts-jest": "^29.0.5",
+    "ts-node": "^10.9.2",
     "typedoc": "^0.24.8",
     "typescript": "^4.9.4"
   },

--- a/ts-compilation-test/package.json
+++ b/ts-compilation-test/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build": "tsc",
     "tsc-version": "tsc -v",
-    "start": "node lib/index.js",
-    "type": "module"
-  }
+    "start": "node lib/index.js"
+  },
+  "type": "module"
 }

--- a/ts-compilation-test/package.json
+++ b/ts-compilation-test/package.json
@@ -10,5 +10,8 @@
   },
   "dependencies": {
     "@pinecone-database/pinecone": "^3.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.0"
   }
 }

--- a/ts-compilation-test/package.json
+++ b/ts-compilation-test/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "build": "tsc",
     "tsc-version": "tsc -v",
-    "start": "node lib/index.js"
+    "start": "node lib/index.js",
+    "type": "module"
   }
 }

--- a/ts-compilation-test/package.json
+++ b/ts-compilation-test/package.json
@@ -4,5 +4,11 @@
     "tsc-version": "tsc -v",
     "start": "node lib/index.js"
   },
-  "type": "module"
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@pinecone-database/pinecone": "^3.0.1"
+  }
 }

--- a/ts-compilation-test/tsconfig.json
+++ b/ts-compilation-test/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "types": ["node"]
   },
   "compileOnSave": true,
   "include": ["src"]

--- a/ts-compilation-test/tsconfig.json
+++ b/ts-compilation-test/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "target": "es2015",
+    "module": "ESNext",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "moduleResolution": "Node"
   },
   "compileOnSave": true,
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
+    "target": "es2015",
+    "module": "ESNext",
     "lib": ["es2015", "dom"],
     "declaration": true,
     "sourceMap": true,
@@ -12,7 +12,8 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "jest", "@edge-runtime/types"],
     "noImplicitAny": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import pinecone from '../dist/index.js'; // Explicitly include the '.js' extension
+import pinecone from '../dist/index.js';
 
 dotenv.config();
 

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -1,4 +1,6 @@
-var dotenv = require('dotenv');
+import dotenv from 'dotenv';
+import pinecone from '../dist/index.js'; // Explicitly include the '.js' extension
+
 dotenv.config();
 
 for (const envVar of ['PINECONE_API_KEY']) {
@@ -9,21 +11,27 @@ for (const envVar of ['PINECONE_API_KEY']) {
   }
 }
 
-var pinecone = require('../dist');
-
 (async () => {
   const p = new pinecone.Pinecone();
 
   const collectionList = await p.listCollections();
-  for (const collection of collectionList.collections) {
-    console.log(`Deleting collection ${collection.name}`);
-    await p.deleteCollection(collection.name);
+  if (collectionList.collections) {
+    for (const collection of collectionList.collections) {
+      console.log(`Deleting collection ${collection.name}`);
+      await p.deleteCollection(collection.name);
+    }
+  } else {
+    console.log('No collections found to delete');
   }
 
   const response = await p.listIndexes();
-  for (const index of response.indexes) {
-    console.log(`Deleting index ${index.name}`);
-    await p.deleteIndex(index.name);
+  if (response.indexes) {
+    for (const index of response.indexes) {
+      console.log(`Deleting index ${index.name}`);
+      await p.deleteIndex(index.name);
+    }
+  } else {
+    console.log('No indexes found to delete');
   }
 
   process.exit();


### PR DESCRIPTION
## Problem

We recently [shipped a fix](https://github.com/pinecone-io/pinecone-ts-client/pull/249) to compatibility issues users were facing with our SDK when running in Edge runtimes.

While this seems to have fixed some problems for users running in Edge runtimes, another issue came to light while helping a community-forum poster: the way in which our Typescript files are transpiled (dictated by our `tsconfig` file) is in accordance with older Node versions, not more modern, popular Javascript syntax.

## More info
Our `tsconfig.json` file dictated that our Typescript files get transpiled into `es5` Javascript using the `CommonJS` module syntax. This is [usually reserved for ensuring users can run packages using old versions of Node](https://blog.logrocket.com/commonjs-vs-es-modules-node-js/) (e.g. <9). 

Since we made the decision to no longer support versions of Node <18, having our `tsconfig` file transpile our Typescript in this older syntax doesn't make a whole lot of sense.

To bring our transpilation process up to date with newer versions of Node, it follows that we should update our `"target"` to `"es2015"` and our `"module"` to `"ESNext"`. 

There are many key differences between the two (explained in the article linked above), but the most important difference is that they use different syntax for loading and exporting Javascript modules.

## How did this come to light?
There is a current, open issue on [our community forum](https://community.pinecone.io/t/error-using-node-js-sdk-on-edge/6337/11?u=audreylorb.pinecone) about using our SDK in an Edge runtime. While troubleshooting the Edge portion of this issue, it came to light that another problem this user was facing was related to how our Typescript files were being transpiled into Javascript.

When I looked into this user's stacktrace of the error, the highlighted lines were all lines that used the older, CommonJS module import syntax (`require`) instead of the newer ESModules import syntax (`import`). 

Updating our `tsconfig` file to use ESModules instead of CommonJS will ensure our transpiles files use the more modern Javascript syntax, which should, in turn, allow users to embed our client within their modern Javascript apps (running in Edge or Node runtimes). 

## Solution

Update all compilation-related files to transpile Typescript files using ESModules syntax. I've ensured all unit and integration tests pass locally.

## Notes
- As part of the general upgrade from using CommonJS to ESModules syntax, we also had to upgrade the ways in which some tests run + upgrade the syntax used by our jest config files. Changes include:
    - ESModules `import` and `export default` syntax replacing old `require` and `export.modules` syntax in our `jest.config....ts` files for Node and Edge
    - Add `"type": "module"` to our `package.json` files in both our root dir and our compilation dir we use for CI testing (mandatory for running ESModules)
    - Add conditional stmts to our `testing.yml` file, in the compilation section, so that Node `@types` are specific to the different TS versions we test in the matrix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208096908844885