### PR TITLE
Update GH workflow files to use Node 20.x

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,6 +4,9 @@ inputs:
   pinecone_api_key:
     description: 'API key'
     required: true
+  node_version:
+    description: 'Node.js version to setup'
+    required: true
 runs:
   using: 'composite'
   steps:
@@ -13,7 +16,7 @@ runs:
         node-version: ${{ inputs.node_version }}
         registry-url: 'https://registry.npmjs.org'
     - name: Cache NPM dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.npm
         key: npm-${{ hashFiles('package-lock.json') }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "cross-fetch": "^3.1.5",
         "encoding": "^0.1.13"
       },
       "devDependencies": {
@@ -2362,13 +2361,6 @@
       "license": "MIT",
       "optional": true,
       "peer": true
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5682,24 +5674,6 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "dev": true,
@@ -7082,10 +7056,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
     "node_modules/ts-jest": {
       "version": "29.0.5",
       "dev": true,
@@ -7547,18 +7517,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "/dist"
   ],
   "dependencies": {
-    "cross-fetch": "^3.1.5",
     "encoding": "^0.1.13"
   }
 }


### PR DESCRIPTION
## Problem

We were getting warnings about using a deprecated version of a Github workflow (`cache@3`).

We were also getting warnings about using an input called `node_version` that was invalid. 

## Solution

Update the workflow we use from `@3` to `@4`. Additionally, add `node_version` into `inputs` section.

Additional housekeeping change: remove `crossFetch` from `package.json`, it was just there as a holdover from when we used `crossFetch`, but [we have removed it](https://github.com/pinecone-io/pinecone-ts-client/pull/250).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208096908844879