### PR TITLE
Remove custom node:util in order to run in Edge

### DIFF
--- a/src/models/embeddingsList.ts
+++ b/src/models/embeddingsList.ts
@@ -3,7 +3,6 @@ import {
   EmbeddingsList as OpenAPIEmbeddingsList,
   EmbeddingsListUsage,
 } from '../pinecone-generated-ts-fetch/control';
-import * as util from 'node:util';
 
 /* This class wraps the OpenAPI-generated EmbeddingsList interface so that an EmbeddingsList object acts like an Array.
 This class also customizes the output of an EmbeddingsList to improve UX.
@@ -83,11 +82,6 @@ export class EmbeddingsList
       `  "usage": ${usageObject}\n` +
       `  })`
     );
-  }
-
-  // Customize console output
-  [util.inspect.custom](): string {
-    return this.toString();
   }
 
   public toJSON(): any {


### PR DESCRIPTION
## Problem

In the process of troubleshooting this community user's issue https://community.pinecone.io/t/error-using-node-js-sdk-on-edge/6337/13, it became apparent that the custom Node utility function we were invoking in `EmbeddingList.ts` was causing issues for people running in `Edge`. 

Specifically, the stacktrace included this snippet:

> ⨯ Error [TypeError]: Cannot read properties of undefined (reading 'custom')
    at <unknown> (webpack-internal:///(rsc)/./node_modules/.pnpm/@pinecone-database+pinecone@3.0.1/node_modules/@pinecone-database/pinecone/dist/models/embeddingsList.js:114)
    at eval (webpack-internal:///(rsc)/./node_modules/.pnpm/@pinecone-database+pinecone@3.0.1/node_modules/@pinecone-database/pinecone/dist/models/embeddingsList.js:114:43)
    at eval (webpack-internal:///(rsc)/./node_modules/.pnpm/@pinecone-database+pinecone@3.0.1/node_modules/@pinecone-database/pinecone/dist/models/embeddingsList.js:162:2)
    at (rsc)/./node_modules/.pnpm/@pinecone-database+pinecone@3.0.1/node_modules/@pinecone-database/pinecone/dist/models/embeddingsList.js (file:///Users/roie.s.c/dev/pinecone-rag-demo/.next/server/app/api/crawl/route.js:491:1)
    at __webpack_require__ (file:///Users/roie.s.c/dev/pinecone-rag-demo/.next/server/edge-runtime-webpack.js:37:33)
    at fn (file:///Users/roie.s.c/dev/pinecone-rag-demo/.next/server/edge-runtime-webpack.js:293:21)
    at eval (webpack-internal:///(rsc)/./node_modules/.pnpm/@pinecone-database+pinecone@3.0.1/node_modules/@pinecone-database/pinecone/dist/models/index.js:4:24)
    at (rsc)/./node_modules/.pnpm/@pinecone-database+pinecone@3.0.1/node_modules/@pinecone-database/pinecone/dist/models/index.js (file:///Users/roie.s.c/dev/pinecone-rag-demo/.next/server/app/api/crawl/route.js:502:1)
    at __webpack_require__ (file:///Users/roie.s.c/dev/pinecone-rag-demo/.next/server/edge-runtime-webpack.js:37:33)
    at fn (file:///Users/roie.s.c/dev/pinecone-rag-demo/.next/server/edge-runtime-webpack.js:293:21)
    at eval (webpack-internal:///(rsc)/./node_modules/.pnpm/@pinecone-database+pinecone@3.0.1/node_modules/@pinecone-database/pinecone/dist/inference/inference.js:40:16)

## Solution

The simple removing of this function solves the problem and does not affect the intended output of `console.log` behavior on `EmbeddingList` objects.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

I was able to launch a Vercel app (running in `Edge`, specifically) into Production using this PR's changed code. Without the code change in this PR, I was running into the same issue first brought up by the community forum user.
