### PR TITLE
Update README to no longer mention runtime checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,8 +966,5 @@ generateQueryEmbeddings().then((embeddingsResponse) => {
 
 ## Productionizing
 
-**Note:** The Pinecone SDK is intended for server-side use only. Using the SDK within a browser context can expose your API key(s). If you have deployed the SDK to production in a browser, please rotate your API keys.
-
-If you are ready to take a JavaScript application to production where raw performance is the overriding concern, you can set the environment variable `PINECONE_DISABLE_RUNTIME_VALIDATIONS="true"` to disable runtime argument validation in the Pinecone client. Runtime validations are used to provide feedback when incorrect method options are provided, for example if you attempt to create an index without specifying a required dimension property.
-
-These runtime validations are most helpful for users who are not developing with Typescript or who are experimenting in a REPL or notebook-type setting. But once you've tested an application and have gained confidence things are working as expected, you can disable these checks to gain a small improvement in performance. This will have the most impact if your workload is upserting very large amounts of data.
+The Pinecone Typescript SDK is intended for server-side use only. Using the SDK within a browser context can **expose 
+your API key(s)**. If you have deployed the SDK to production in a browser, **please rotate your API keys.**

--- a/README.md
+++ b/README.md
@@ -966,5 +966,5 @@ generateQueryEmbeddings().then((embeddingsResponse) => {
 
 ## Productionizing
 
-The Pinecone Typescript SDK is intended for server-side use only. Using the SDK within a browser context can **expose 
+The Pinecone Typescript SDK is intended for server-side use only. Using the SDK within a browser context can **expose
 your API key(s)**. If you have deployed the SDK to production in a browser, **please rotate your API keys.**


### PR DESCRIPTION
## Problem

Since we removed runtime checks, we need to remove the part in our README about the `PINECONE_DISABLE_RUNTIME_VALIDATIONS` env var (missed 1st time around): https://github.com/pinecone-io/pinecone-ts-client/pull/249/files#diff-a54261af011358e447a9f3ef717ee8e5d5bb4258f8d95e246b39cf3666244f1fL275

<img width="1274" alt="Screenshot 2024-08-26 at 5 23 35 PM" src="https://github.com/user-attachments/assets/cad55314-47a6-4236-a16c-afeb436e2ed3">


## Solution

Remove it :) 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)
