### PR TITLE
Add new Github action that deploys sample Vercel app

### DIFF
--- a/.github/actions/e2d-testing/edge/hitVercelAppEndpoints.ts
+++ b/.github/actions/e2d-testing/edge/hitVercelAppEndpoints.ts
@@ -1,0 +1,1 @@
+console.log('test');

--- a/.github/actions/e2d-testing/edge/vercel-deploy.yml
+++ b/.github/actions/e2d-testing/edge/vercel-deploy.yml
@@ -1,0 +1,109 @@
+name: Spin up Vercel App
+
+on:
+  pull_request: {}
+  push:
+  branches:
+    - main
+  workflow_call:
+    secrets:
+      PINECONE_API_KEY:
+        required: true
+      VERCEL_TOKEN:
+        required: true
+      VERCEL_PROJECT_ID:
+        required: true
+      VERCEL_ORG_ID:
+        required: true
+
+# todo: set up with different node versions
+jobs:
+  spin-up-vercel-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.20.3'
+
+      - name: Setup Vercel
+        uses: amondnet/setup-vercel@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+
+      - name: Check out current repository (pinecone-ts-client)
+        uses: actions/checkout@v4
+
+      - name: Build pinecone-ts-client code
+        run: npm run build
+
+      - name: Package pinecone-ts-client code
+        run: npm pack
+
+      - name: Clone Pinecone Vercel app into pinecone-ts-client
+        run:  git clone git@github.com:pinecone-io/pinecone-rag-demo.git && cd pinecone-rag-demo && git pull origin main
+
+      - name: Move package to pinecone-rag-demo
+        run: mv ../pinecone-database-pinecone-*.tgz .
+
+      - name: Install Pinecone Vercel app dependencies
+        run: npm install
+
+      - name: Install pinecone-ts-client "main" branch code into the Vercel app
+        run: npm install pinecone-database-pinecone-*.tgz
+
+      - name: Set up environment variables
+        with:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_REGION: us-west-2
+          PINECONE_INDEX: end-to-end-edge-test
+          PINECONE_CLOUD: aws
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Install pnpm
+        run: npm install pnpm
+
+      - name: Install dependencies
+        run: pnpm i
+
+        # todo: remove linting
+      - name: remove linting temporarily
+        run: rm -rf ./eslintrc.json
+
+      - name: Build Pinecone Vercel app
+        run: pnpm run build
+
+      - name: Install Vercel CLI
+        run: pnpm add vercel
+
+      - name: Deploy to Vercel
+        run: vercel deploy --scope=${{ secrets.VERCEL_TEAM_SCOPE }}
+
+      # todo: how to interact with vercel cli in ci?
+      #      - name: Build Pinecone Vercel app
+      #        run: |
+      #          npm run build
+      #          npm install -g pnpm
+      #          pnpm setup
+      #          source ~/.zshrc
+      #          pnpm i -g vercel
+      #          pnpm i
+      #          vercel deploy  --scope=${{ secrets.VERCEL_TEAM_SCOPE }}
+
+#      - name: Run Vercel app tests
+#        run: npm run test:e2e
+
+
+#      - name: Install playwright
+#        run: npm i playwright && npx playwright test
+#        env:
+#          BASE_URL: https://vercel.live/link/pinecone-rag-demo-4rrbeb03q-pinecone-io.vercel.app?via=deployment-domains-list-commit
+
+        # todo: figure out how to log into vercel while inside playwright
+        # todo: figure out how to override localhost in actual test file -- maybe just make your own?
+        # or don't? because we don't care about the ui...
+
+#      - name: Hit endpoints
+#        run: npx hitVercelAppEndpoints.ts # tsc? need tsconfig.json etc?

--- a/.github/actions/e2d-testing/edge/vercel-deploy.yml
+++ b/.github/actions/e2d-testing/edge/vercel-deploy.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm pack
 
       - name: Clone Pinecone Vercel app into pinecone-ts-client
-        run:  git clone git@github.com:pinecone-io/pinecone-rag-demo.git && cd pinecone-rag-demo && git pull origin main
+        run: git clone git@github.com:pinecone-io/pinecone-rag-demo.git && cd pinecone-rag-demo && git pull origin main
 
       - name: Move package to pinecone-rag-demo
         run: mv ../pinecone-database-pinecone-*.tgz .
@@ -91,19 +91,17 @@ jobs:
       #          pnpm i -g vercel
       #          pnpm i
       #          vercel deploy  --scope=${{ secrets.VERCEL_TEAM_SCOPE }}
-
 #      - name: Run Vercel app tests
 #        run: npm run test:e2e
-
 
 #      - name: Install playwright
 #        run: npm i playwright && npx playwright test
 #        env:
 #          BASE_URL: https://vercel.live/link/pinecone-rag-demo-4rrbeb03q-pinecone-io.vercel.app?via=deployment-domains-list-commit
 
-        # todo: figure out how to log into vercel while inside playwright
-        # todo: figure out how to override localhost in actual test file -- maybe just make your own?
-        # or don't? because we don't care about the ui...
+# todo: figure out how to log into vercel while inside playwright
+# todo: figure out how to override localhost in actual test file -- maybe just make your own?
+# or don't? because we don't care about the ui...
 
 #      - name: Hit endpoints
 #        run: npx hitVercelAppEndpoints.ts # tsc? need tsconfig.json etc?

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ npm install @pinecone-database/pinecone
 The Pinecone Typescript SDK is intended for **server-side use only**. Using the SDK within a browser context can **expose
 your API key(s)**. If you have deployed the SDK to production in a browser, **please rotate your API keys.**
 
-
 ## Usage
 
 ### Initializing the client


### PR DESCRIPTION
## Problem

As part of a larger effort to set up e2e testing for different runtimes, we'd like to implement a new Github action that would run on PRs that spins up [a sample Vercel app](https://github.com/pinecone-io/pinecone-rag-demo/tree/main) that runs in the Edge runtime.

## Solution

Upload this action as a test.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes
