### PR TITLE
Move secrets only to workflow and not action file

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -1,8 +1,20 @@
 name: Spin up Vercel App
 
-on:
-  pull_request: {}
-  push: {}
+inputs:
+  VERCEL_TOKEN:
+    required: true
+  VERCEL_PROJECT_ID:
+    required: true
+  VERCEL_ORG_ID:
+    required: true
+  PINECONE_API_KEY:
+    required: true
+  OPENAI_API_KEY:
+    required: true
+  VERCEL_TEAM_SCOPE:
+    required: true
+
+
 
 jobs:
   spin-up-vercel-app:
@@ -18,10 +30,10 @@ jobs:
 
       - name: Setup Vercel
         uses: amondnet/setup-vercel@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+        env:
+          VERCEL_TOKEN: ${{ inputs.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ inputs.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ inputs.VERCEL_ORG_ID }}
 
       - name: Build pinecone-ts-client code
         run: npm run build
@@ -43,11 +55,11 @@ jobs:
 
       - name: Set up environment variables
         env:
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
           PINECONE_REGION: us-west-2
           PINECONE_INDEX: end-to-end-edge-test
           PINECONE_CLOUD: aws
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
 
       - name: Install pnpm
         run: npm install -g pnpm
@@ -67,6 +79,6 @@ jobs:
 
       - name: Deploy to Vercel
         env:
-          VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
+          VERCEL_TOKEN: ${{ inputs.VERCEL_TOKEN }}
         run: vercel deploy --token=$VERCEL_TOKEN --scope=$VERCEL_TEAM_SCOPE

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -11,5 +11,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run test
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run e2e tests for edge runtime
+        env:
+          CI: true
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         uses: ./.github/actions/e2e-testing/edge


### PR DESCRIPTION
## Problem

The end to end testing workflow was getting errors related to secrets, e.g.: 

> /home/runner/work/pinecone-ts-client/pinecone-ts-client/./.github/actions/e2e-testing/edge/action.yml (Line: 20, Col: 25): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.VERCEL_TOKEN

After reading this thread https://github.com/orgs/community/discussions/27054#discussioncomment-3254450 it seems that `secrets` might only be available in workflows and not actions. So, I've moved `secrets` to only be in the workflow file and the references to them to be in `inputs` in the `action.yml` file.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

