### PR TITLE
Move secrets in workflow file to `with` block

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -15,11 +15,13 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run e2e tests for edge runtime
-        env:
-          CI: true
+        uses: ./.github/actions/e2e-testing/edge
+        with:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        uses: ./.github/actions/e2e-testing/edge
+          VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}
+        env:
+          CI: true


### PR DESCRIPTION
## Problem

The last end to end testing workflow run failed due to `inputs` being unrecognized: 

> [Run end-to-end tests](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10587412603/job/29338090995#step:4:1)
/home/runner/work/pinecone-ts-client/pinecone-ts-client/./.github/actions/e2e-testing/edge/action.yml (Line: 34, Col: 25): Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.VERCEL_TOKEN

## Solution

ChatGPT let me know that I should actually put my `secrets` into a `with` block in my workflow file instead.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)
