### PR TITLE
Setup-vercel repo having issues so change version to @master

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -26,7 +26,7 @@ runs:
         node-version: '18.20.3'
 
     - name: Setup Vercel
-      uses: amondnet/setup-vercel@v25
+      uses: amondnet/setup-vercel@master
       env:
         VERCEL_TOKEN: ${{ inputs.VERCEL_TOKEN }}
         VERCEL_PROJECT_ID: ${{ inputs.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Problem

The `amondnet/vercel-action@25` seems not to work, but [users are saying](https://github.com/amondnet/vercel-action/issues/40#issuecomment-705274931) change it to `@master` works. So, trying that! 


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

