### PR TITLE
Update naming of Vercel token + add vercel.json 

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Check out current repository (pinecone-ts-client)
       uses: actions/checkout@v4
@@ -63,7 +63,7 @@ runs:
       run: npm install -g pnpm
       shell: bash
 
-    - name: Install dependencies with pnpm
+    - name: Install rag app dependencies with pnpm
       run: pnpm install
       shell: bash
 
@@ -79,6 +79,18 @@ runs:
       run: pnpm add -g vercel
       shell: bash
 
+    - name: Create vercel.json file
+      run: |
+        echo '{
+          "version": 2,
+          "public": false,
+          "github": {
+            "enabled": false
+          },
+          "builds": [{ "src": "src/*", "use": "@vercel/static" }]
+        }' > vercel.json
+      shell: bash
+
     - name: Deploy to Vercel
       env:
         VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
@@ -88,5 +100,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: vercel deploy --token=$VERCEL_TOKEN --scope=$VERCEL_TEAM_SCOPE
+      run: vercel --yes --logs --token=$VERCEL_TOKEN --scope=$VERCEL_TEAM_SCOPE
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -28,9 +28,9 @@ runs:
     - name: Setup Vercel
       uses: amondnet/vercel-action@master
       env:
-        VERCEL_TOKEN: ${{ inputs.VERCEL_TOKEN }}
-        VERCEL_PROJECT_ID: ${{ inputs.VERCEL_PROJECT_ID }}
-        VERCEL_ORG_ID: ${{ inputs.VERCEL_ORG_ID }}
+        vercel-token: ${{ inputs.VERCEL_TOKEN }}
+        vercel-project-id: ${{ inputs.VERCEL_PROJECT_ID }}
+        vercel-org-id: ${{ inputs.VERCEL_ORG_ID }}
 
     - name: Build pinecone-ts-client code
       run: npm run build
@@ -94,11 +94,11 @@ runs:
     - name: Deploy to Vercel
       env:
         VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
-        VERCEL_TOKEN: ${{ inputs.VERCEL_TOKEN }}
+        vercel-token: ${{ inputs.VERCEL_TOKEN }}
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
         PINECONE_REGION: us-west-2
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: vercel --yes --logs --token=$VERCEL_TOKEN --scope=$VERCEL_TEAM_SCOPE
+      run: vercel --yes --logs --token=$vercel-token --scope=$VERCEL_TEAM_SCOPE
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -87,7 +87,14 @@ runs:
           "github": {
             "enabled": false
           },
-          "builds": [{ "src": ".", "use": "@vercel/static" }]
+          "buildCommand": "next build",
+          "framework": "nextjs",
+          "functions": {
+            "src/app/**/*.{ts,tsx}": {
+              "runtime": "edge",
+              "includeFiles": "src/app/**/*"
+            }
+          }
         }' > vercel.json
       shell: bash
 

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -87,7 +87,7 @@ runs:
           "github": {
             "enabled": false
           },
-          "builds": [{ "src": "src/*", "use": "@vercel/static" }]
+          "builds": [{ "src": ".", "use": "@vercel/static" }]
         }' > vercel.json
       shell: bash
 

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -17,9 +17,9 @@ jobs:
       - name: Run e2e tests for edge runtime
         uses: ./.github/actions/e2e-testing/edge
         with:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}


### PR DESCRIPTION
## Problem

The latest test run of the new e2e Edge testing CI failed with the following error: 

> Error: Input required and not supplied: vercel-token
    at Object.getInput (/home/runner/work/_actions/amondnet/vercel-action/master/dist/index.js:212:15)
    at /home/runner/work/_actions/amondnet/vercel-action/master/dist/index.js:32582:26
    at /home/runner/work/_actions/amondnet/vercel-action/master/dist/index.js:32991:3
    at Object.<anonymous> (/home/runner/work/_actions/amondnet/vercel-action/master/dist/index.js:32994:12)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:[120](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10588113496/job/29340074646#step:4:133)8:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49

The first solve I think might resolve this error is to change the naming of the Vercel token from `VERCEL_TOKEN`  to `vercel-token`, as it is in the example yamls in [the Vercel GH action's repo](https://github.com/amondnet/vercel-action?tab=readme-ov-file#method-2---via-verceljson).

I also noticed while reading the Vercel GH action's repo that I didn't add a `vercel.json` file, which seemingly is needed to properly deploy a Vercel project via GH actions. So, this PR adds that as well. Info about `vercel.json` here: https://vercel.com/docs/projects/project-configuration#functions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

