### PR TITLE
Change location of env vars from `with` to `env` in workflow file

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -16,12 +16,11 @@ jobs:
 
       - name: Run e2e tests for edge runtime
         uses: ./.github/actions/e2e-testing/edge
-        with:
+        env:
+          CI: true
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}
-        env:
-          CI: true


### PR DESCRIPTION
## Problem

The [last test of the e2e Edge GH workflow file](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10602204562/job/29383732233) at the `Run e2e tests for edge runtime` step in the workflow file because it still couldn't find the `vercel-token` environment variable.

## Solution

I think me having the env vars in the `with` section instead of the `env` section is causing the error, so this PR moves them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

