### PR TITLE
Add necessary env vars in both `with` and `env` sections of workflow and action files

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -103,6 +103,14 @@ runs:
       shell: bash
 
     - name: Deploy to Vercel
+      with:
+        VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
+        vercel-token: ${{ inputs.vercel-token }}
+        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        PINECONE_REGION: us-west-2
+        PINECONE_INDEX: end-to-end-edge-test
+        PINECONE_CLOUD: aws
+        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       env:
         VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
         vercel-token: ${{ inputs.vercel-token }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -1,11 +1,11 @@
 name: Spin up Vercel App
 
 inputs:
-  VERCEL_TOKEN:
+  vercel-token:
     required: true
-  VERCEL_PROJECT_ID:
+  vercel-project-id:
     required: true
-  VERCEL_ORG_ID:
+  vercel-org-id:
     required: true
   PINECONE_API_KEY:
     required: true
@@ -27,10 +27,14 @@ runs:
 
     - name: Setup Vercel
       uses: amondnet/vercel-action@master
+      with:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
       env:
-        vercel-token: ${{ inputs.VERCEL_TOKEN }}
-        vercel-project-id: ${{ inputs.VERCEL_PROJECT_ID }}
-        vercel-org-id: ${{ inputs.VERCEL_ORG_ID }}
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
 
     - name: Build pinecone-ts-client code
       run: npm run build
@@ -101,7 +105,7 @@ runs:
     - name: Deploy to Vercel
       env:
         VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
-        vercel-token: ${{ inputs.VERCEL_TOKEN }}
+        vercel-token: ${{ inputs.vercel-token }}
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
         PINECONE_REGION: us-west-2
         PINECONE_INDEX: end-to-end-edge-test

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -16,6 +16,14 @@ jobs:
 
       - name: Run e2e tests for edge runtime
         uses: ./.github/actions/e2e-testing/edge
+        with:
+          CI: true
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}
         env:
           CI: true
           vercel-token: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem

The previous e2e Edge GH workflow run failed due to not being able to find the `vercel-token` environment variable. From what I read, everything was set up correctly, but since it's still failing, I'm putting all environment in both the `with` and `env` sections of in both the action and workflow files.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

