### PR TITLE
Remove `with` section of `Deploy to Vercel` step in action.yml file

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -103,14 +103,6 @@ runs:
       shell: bash
 
     - name: Deploy to Vercel
-      with:
-        VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
-        vercel-token: ${{ inputs.vercel-token }}
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: us-west-2
-        PINECONE_INDEX: end-to-end-edge-test
-        PINECONE_CLOUD: aws
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       env:
         VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
         vercel-token: ${{ inputs.vercel-token }}


### PR DESCRIPTION
## Problem

The last e2d Edge CI run [failed](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10602446618/job/29384504189#step:4:3) seemingly because my use of the `with` section made the pipeline think I was trying to use a prebuilt action, which I am not.  

## Solution

Remove `with` section and solely rely on `env` section for `Deploy to Vercel` step.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

