### PR TITLE
Add installCommand to vercel.json to ensure package.json deps are installed

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -92,6 +92,7 @@ runs:
             "enabled": false
           },
           "buildCommand": "next build",
+          "installCommand": "npm install"
           "framework": "nextjs",
           "functions": {
             "src/app/**/*.{ts,tsx}": {


### PR DESCRIPTION
## Problem

The latest e2e Edge CI run tried to deploy the intended app to Vercel, but failed to find a `NextJS` version installed. I believe we have to install this via adding a `installCommand` field to the `vercel.json` we create in the action.

## Solution

Add `installCommand` field. This should install all deps within the project dir outlined in `package.json`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

