### PR TITLE
Add NextJS install step

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -63,6 +63,10 @@ runs:
       run: npm install pinecone-database-pinecone-*.tgz
       shell: bash
 
+    - name: Install NextJS explicitly
+      run: npm install -g next@latest
+      shell: bash
+
     - name: Install pnpm
       run: npm install -g pnpm
       shell: bash
@@ -93,11 +97,9 @@ runs:
           },
           "buildCommand": "next build",
           "installCommand": "npm install"
-          "framework": "nextjs",
           "functions": {
             "src/app/**/*.{ts,tsx}": {
               "runtime": "edge",
-              "includeFiles": "src/app/**/*"
             }
           }
         }' > vercel.json

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -97,6 +97,7 @@ runs:
           },
           "buildCommand": "next build",
           "installCommand": "npm install"
+          "framework": "nextjs",
           "functions": {
             "src/app/**/*.{ts,tsx}": {
               "runtime": "edge",


### PR DESCRIPTION
## Problem

The [most recent](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10602693291) e2e Edge workflow run failed because it still couldn't find `NextJS`. 

<img width="1280" alt="Screenshot 2024-08-28 at 11 58 38 AM" src="https://github.com/user-attachments/assets/d681c35b-6655-4599-8f07-2b20d9b673d2">


## Solution

I removed the `includeFiles` section in order to avoid limiting Vercel's project scope in any unintended way + added an explicitly `npm install` step that installs `NextJS` globally.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

