### PR TITLE
add specific edge-runtime versionm

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -100,7 +100,7 @@ runs:
           "framework": "nextjs",
           "functions": {
             "src/app/**/*.{ts,tsx}": {
-              "runtime": "edge",
+              "runtime": "edge-runtime@3.0.1",
             }
           }
         }' > vercel.json


### PR DESCRIPTION
## Problem

The [latest e2e Edge workflow run](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10602830879) failed. 
<img width="1246" alt="Screenshot 2024-08-28 at 12 16 43 PM" src="https://github.com/user-attachments/assets/ff4e98c4-eec9-431d-89de-eec3fb2b0364">



I tried deploying again with my same `vercel.json` file declared in the workflow, but locally, and I got the following error: 
<img width="733" alt="Screenshot 2024-08-28 at 12 15 08 PM" src="https://github.com/user-attachments/assets/b959b302-fa13-4849-8f87-1e87f394bcf1">

Upon declaring a specific `edge-runtime` version in `vercel.json`, I was able to deploy locally.

## Solution

Try the same approach but in CI. Hoping maybe being unable to find a `NextJS` version was a red herring error, since it was uncorroborated by me after running locally.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

