### PR TITLE
Remove instances of using run and uses in the same step

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -19,15 +19,11 @@ runs:
   steps:
     - name: Check out current repository (pinecone-ts-client)
       uses: actions/checkout@v4
-      run: echo "Step 1, Checking out current dir!"
-      shell: bash
 
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
         node-version: '18.20.3'
-      run: echo "Step 2, Setting up Node!"
-      shell: bash
 
     - name: Build pinecone-ts-client code
       run: npm run build && echo "Step 3, building pinecone-ts-client!"
@@ -55,8 +51,6 @@ runs:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
-      run: echo "Step 7, Setting Vercel!"
-      shell: bash
       env:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -10,13 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        run: echo "Step 1 WORKFLOW, checking out repo"
-        shell: bash
 
       - name: Setup
         uses: ./.github/actions/setup
-        run: echo "Step 2 WORKFLOW, setup"
-        shell: bash
 
       - name: Run e2e tests for edge runtime
         uses: ./.github/actions/e2e-testing/edge
@@ -28,8 +24,6 @@ jobs:
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}
-        run: echo "Step 3 WORKFLOW, running action"
-        shell: bash
         env:
           CI: true
           vercel-token: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem

One cannot use `run` and `uses` in the same step when making GH actions.

## Solution

Remove `run` when `uses` is present.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)
