### PR TITLE
Add npm install step to e2e action

### DIFF
--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -25,6 +25,10 @@ runs:
       with:
         node-version: '18.20.3'
 
+    - name: Install pinecone-ts-client deps
+      run: npm install
+      shelL: bash
+
     - name: Build pinecone-ts-client code
       run: npm run build && echo "Step 3, building pinecone-ts-client!"
       shell: bash


### PR DESCRIPTION
## Problem

The l[atest e2e Edge workflow](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10604556881) run failed at `npm run build` because it couldn't find some `types` declared in `tsconfig`, it seems. 

<img width="956" alt="Screenshot 2024-08-28 at 2 24 05 PM" src="https://github.com/user-attachments/assets/3c3aa14f-211a-4b2e-8d84-18b08d383dcf">


It looks like the action doesn't actually run `npm install` when in the root dir, so that's likely the culprit.

## Solution

Add `npm install` step.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

