### PR TITLE
Add final, working Vercel app e2e Edge GH workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,11 @@
     "es2021": true,
     "node": true
   },
-  "ignorePatterns": ["dist", "src/pinecone-generated-ts-fetch", "pinecone-rag-demo"],
+  "ignorePatterns": [
+    "dist",
+    "src/pinecone-generated-ts-fetch",
+    "pinecone-rag-demo"
+  ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true,
     "node": true
   },
-  "ignorePatterns": ["dist", "src/pinecone-generated-ts-fetch"],
+  "ignorePatterns": ["dist", "src/pinecone-generated-ts-fetch", "pinecone-rag-demo"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -3,20 +3,20 @@ name: Spin up Vercel App
 inputs:
   vercel-token:
     required: true
-  vercel-project-id:
-    required: true
-  vercel-org-id:
-    required: true
-  PINECONE_API_KEY:
-    required: true
-  PINECONE_INDEX:
-    required: true
-  PINECONE_CLOUD:
-    required: true
-  PINECONE_REGION:
-    required: true
-  OPENAI_API_KEY:
-    required: true
+#  vercel-project-id:
+#    required: true
+#  vercel-org-id:
+#    required: true
+#  PINECONE_API_KEY:
+#    required: true
+#  PINECONE_INDEX:
+#    required: true
+#  PINECONE_CLOUD:
+#    required: true
+#  PINECONE_REGION:
+#    required: true
+#  OPENAI_API_KEY:
+#    required: true
 
 runs:
   using: 'composite'
@@ -60,47 +60,16 @@ runs:
       run: cd pinecone-rag-demo && npm install vercel
       shell: bash
 
-# todo:  think i only want `pull` if env vars are in project settings...
-#    - name: Pull Vercel Environment Information
-#      run: |
-#        cd pinecone-rag-demo
-#        vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }} --scope=pinecone-io
-#      env:
-#        vercel-token: ${{ inputs.vercel-token }}
-#        vercel-project-id: ${{ inputs.vercel-project-id }}
-#        vercel-org-id: ${{ inputs.vercel-org-id }}
-#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-#        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-#        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-#        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-#      shell: bash
-
-#    - name: Build Project Artifacts
-#      run: |
-#        cd pinecone-rag-demo
-#        vercel build --yes --token=${{ inputs.vercel-token }} --scope=pinecone-io
-#      env:
-#        vercel-token: ${{ inputs.vercel-token }}
-#        vercel-project-id: ${{ inputs.vercel-project-id }}
-#        vercel-org-id: ${{ inputs.vercel-org-id }}
-#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-#        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-#        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-#        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-#      shell: bash
-
     - name: Deploy Project Artifacts to Vercel
       run: |
         cd pinecone-rag-demo
-        vercel --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io --token=${{ inputs.vercel-token }} --yes
-      env:
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+        vercel --scope=pinecone-io --token=${{ inputs.vercel-token }} --yes
+#      env:
+#        vercel-project-id: ${{ inputs.vercel-project-id }}
+#        vercel-org-id: ${{ inputs.vercel-org-id }}
+#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+#        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
+#        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+#        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
+#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -65,8 +65,11 @@ runs:
       shell: bash
 
     - name: Add Global Bin dir needed for pnmp
-      run: cd pinecone-rag-demo && pnpm setup
-      shell: bash
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+#      run: cd pinecone-rag-demo && pnpm setup
+#      shell: bash
 
 #    - name: Build Pinecone Vercel app
 #      run: cd pinecone-rag-demo && pnpm run build

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -64,9 +64,9 @@ runs:
       run: cd pinecone-rag-demo && rm -rf .eslintrc.json
       shell: bash
 
-    - name: Build Pinecone Vercel app
-      run: cd pinecone-rag-demo && pnpm run build
-      shell: bash
+#    - name: Build Pinecone Vercel app
+#      run: cd pinecone-rag-demo && pnpm run build
+#      shell: bash
 
     - name: Install Vercel CLI
       run: cd pinecone-rag-demo && pnpm add -g vercel

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -115,5 +115,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=${{ inputs.vercel-org-id }}
+      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -132,7 +132,7 @@ runs:
 #      shell: bash
 
     - name: Pull Vercel Environment Information
-      run: cd pinecone-rag-demo && vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }}
+      run: cd pinecone-rag-demo && vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }} --scope=pinecone-io
       env:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -95,6 +95,9 @@ runs:
           "buildCommand": "next build",
           "installCommand": "npm install",
           "framework": "nextjs",
+          "builds": [
+            { "src": "pinecone-rag-demo/src", "use": "@vercel/static" }
+          ],
           "functions": {
             "src/app/**/*.{ts,tsx}": {
               "runtime": "edge",
@@ -105,7 +108,6 @@ runs:
       shell: bash
 
     - name: Deploy to Vercel
-      working-directory: pinecone-rag-demo
       env:
         VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
         vercel-token: ${{ inputs.vercel-token }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -37,7 +37,6 @@ runs:
       run: |
         git clone git@github.com:pinecone-io/pinecone-rag-demo.git
         cd pinecone-rag-demo
-        git pull origin main
       shell: bash
 
     - name: Move package to pinecone-rag-demo

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -85,6 +85,7 @@ runs:
 
     - name: Create vercel.json file
       run: |
+        cd pinecone-rag-demo
         echo '{
           "version": 2,
           "public": false,
@@ -92,7 +93,7 @@ runs:
             "enabled": false
           },
           "buildCommand": "next build",
-          "installCommand": "npm install"
+          "installCommand": "npm install",
           "framework": "nextjs",
           "functions": {
             "src/app/**/*.{ts,tsx}": {

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -97,9 +97,9 @@ runs:
         }' > vercel.json
       shell: bash
 
-    - name: Test Vercel Auth
-      run: cd pinecone-rag-demo && vercel build --yes --token=${{ inputs.vercel-token }}
-      shell: bash
+#    - name: Test Vercel Auth
+#      run: cd pinecone-rag-demo && vercel build --yes --token=${{ inputs.vercel-token }}
+#      shell: bash
 
     - name: Deploy to Vercel
       env:
@@ -111,5 +111,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel pinecone-rag-demo --yes --logs --token=$vercel-token --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
+      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -51,10 +51,10 @@ runs:
 #    - name: Install pinecone-ts-client "main" branch code into the Vercel app
 #      run: cd pinecone-rag-demo && npm install pinecone-database-pinecone-*.tgz
 #      shell: bash
-
-    - name: Install pnpm
-      run: cd pinecone-rag-demo && npm install -g pnpm
-      shell: bash
+#
+#    - name: Install pnpm
+#      run: cd pinecone-rag-demo && npm install -g pnpm
+#      shell: bash
 
 #    - name: Install rag app dependencies with pnpm
 #      run: cd pinecone-rag-demo && pnpm install
@@ -64,10 +64,10 @@ runs:
 #      run: cd pinecone-rag-demo && rm -rf .eslintrc.json
 #      shell: bash
 
-    - name: Add Global Bin dir needed for pnmp
-      uses: pnpm/action-setup@v4
-      with:
-        version: 9
+#    - name: Add Global Bin dir needed for pnmp
+#      uses: pnpm/action-setup@v4
+#      with:
+#        version: 9
 #      run: cd pinecone-rag-demo && pnpm setup
 #      shell: bash
 
@@ -76,15 +76,15 @@ runs:
 #      shell: bash
 
     - name: Install rag-demo deps
-      run: cd pinecone-rag-demo && pnpm i
+      run: cd pinecone-rag-demo && npm install
       shell: bash
 
     - name: Install pinecone-ts-client "main" branch code into the Vercel app
-      run: cd pinecone-rag-demo && pnpm add -P ./pinecone-database-pinecone-*.tgz
+      run: cd pinecone-rag-demo && npm install pinecone-database-pinecone-*.tgz
       shell: bash
 
     - name: Install Vercel CLI
-      run: cd pinecone-rag-demo && pnpm add -g vercel@latest
+      run: cd pinecone-rag-demo && npm install vercel
       shell: bash
 
 #    - name: Log into Vercel

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -110,5 +110,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo &&  && vercel --yes --logs --token=$vercel-token --scope=$VERCEL_TEAM_SCOPE
+      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=$VERCEL_TEAM_SCOPE
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -111,5 +111,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --logs --token=${{ inputs.vercel-token }} --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
+      run: cd pinecone-rag-demo && vercel --yes --logs --token=${{ inputs.vercel-token }} --scope=${{ inputs.vercel-project-id }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -80,7 +80,11 @@ runs:
       shell: bash
 
     - name: Ensure you are in the pinecone-io scope
-      run: cd pinecone-rag-demo && vercel switch pinecone-io
+      env:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+      run: cd pinecone-rag-demo && vercel switch pinecone-io  --token=${{ inputs.vercel-token }}
       shell: bash
 
     - name: Pull Vercel Environment Information
@@ -92,11 +96,6 @@ runs:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: us-west-2
-        PINECONE_INDEX: end-to-end-edge-test
-        PINECONE_CLOUD: aws
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       run: cd pinecone-rag-demo && vercel build --prod --token=${{ inputs.vercel-token }}
       shell: bash
 

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -84,7 +84,7 @@ runs:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
-      run: cd pinecone-rag-demo && vercel switch pinecone-io  --token=${{ inputs.vercel-token }}
+      run: cd pinecone-rag-demo && vercel switch pinecone-io
       shell: bash
 
     - name: Pull Vercel Environment Information

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -111,5 +111,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --token=${{ inputs.vercel-token }} --scope=${{ inputs.vercel-project-id }}
+      run: cd pinecone-rag-demo && vercel --yes --token=${{ inputs.vercel-token }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -33,7 +33,7 @@ runs:
       run: npm pack
       shell: bash
 
-    - name: Clone Vercel app -- test
+    - name: Clone Vercel app
       uses: GuillaumeFalourd/clone-github-repo-action@main
       with:
         owner: 'pinecone-io'
@@ -82,8 +82,6 @@ runs:
     - name: Install pinecone-ts-client "main" branch code into the Vercel app
       run: cd pinecone-rag-demo && pnpm add -P ./pinecone-database-pinecone-*.tgz
       shell: bash
-
-      # todo: maybe need pnpm add ts-client too?
 
     - name: Install Vercel CLI
       run: cd pinecone-rag-demo && pnpm add -g vercel@latest
@@ -142,37 +140,3 @@ runs:
       run: cd pinecone-rag-demo && vercel --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
-#    - name: Create vercel.json file
-#      run: |
-#        cd pinecone-rag-demo
-#        echo '{
-#          "version": 2,
-#          "public": false,
-#          "github": {
-#            "enabled": false
-#          },
-#          "functions": {
-#            "src/app/**/*.{ts,tsx}": {
-#              "runtime": "edge-runtime@3.0.1",
-#              "includeFiles": "src/app/**/*"
-#            }
-#          }
-#        }' > vercel.json
-#      shell: bash
-
-#    - name: Test Vercel Auth
-#      run: cd pinecone-rag-demo && vercel build --yes --token=${{ inputs.vercel-token }}
-#      shell: bash
-
-#    - name: Deploy to Vercel
-#      env:
-#        vercel-token: ${{ inputs.vercel-token }}
-#        vercel-project-id: ${{ inputs.vercel-project-id }}
-#        vercel-org-id: ${{ inputs.vercel-org-id }}
-#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-#        PINECONE_REGION: us-west-2
-#        PINECONE_INDEX: end-to-end-edge-test
-#        PINECONE_CLOUD: aws
-#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-#      run: cd pinecone-rag-demo && vercel --yes --token=${{ inputs.vercel-token }}
-#      shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -76,32 +76,14 @@ runs:
 #      shell: bash
 
     - name: Install Vercel CLI
-      run: cd pinecone-rag-demo && pnpm add -g vercel
+      run: cd pinecone-rag-demo && pnpm add -g vercel@latest
       shell: bash
 
-    - name: Create vercel.json file
-      run: |
-        cd pinecone-rag-demo
-        echo '{
-          "version": 2,
-          "public": false,
-          "github": {
-            "enabled": false
-          },
-          "functions": {
-            "src/app/**/*.{ts,tsx}": {
-              "runtime": "edge-runtime@3.0.1",
-              "includeFiles": "src/app/**/*"
-            }
-          }
-        }' > vercel.json
+    - name: Pull Vercel Environment Information
+      run: cd pinecone-rag-demo && vercel pull --yes --environment=production --token=${{ inputs.vercel-token }}
       shell: bash
 
-#    - name: Test Vercel Auth
-#      run: cd pinecone-rag-demo && vercel build --yes --token=${{ inputs.vercel-token }}
-#      shell: bash
-
-    - name: Deploy to Vercel
+    - name: Build Project Artifacts
       env:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
@@ -111,5 +93,51 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --token=${{ inputs.vercel-token }}
-      shell: bash
+      run: cd pinecone-rag-demo && vercel build --prod --token=${{ inputs.vercel-token }}
+
+    - name: Deploy Project Artifacts to Vercel
+      env:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        PINECONE_REGION: us-west-2
+        PINECONE_INDEX: end-to-end-edge-test
+        PINECONE_CLOUD: aws
+        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+      run: cd pinecone-rag-demo && vercel deploy --prebuilt --prod --token=${{ inputs.vercel-token }}
+
+#    - name: Create vercel.json file
+#      run: |
+#        cd pinecone-rag-demo
+#        echo '{
+#          "version": 2,
+#          "public": false,
+#          "github": {
+#            "enabled": false
+#          },
+#          "functions": {
+#            "src/app/**/*.{ts,tsx}": {
+#              "runtime": "edge-runtime@3.0.1",
+#              "includeFiles": "src/app/**/*"
+#            }
+#          }
+#        }' > vercel.json
+#      shell: bash
+
+#    - name: Test Vercel Auth
+#      run: cd pinecone-rag-demo && vercel build --yes --token=${{ inputs.vercel-token }}
+#      shell: bash
+
+#    - name: Deploy to Vercel
+#      env:
+#        vercel-token: ${{ inputs.vercel-token }}
+#        vercel-project-id: ${{ inputs.vercel-project-id }}
+#        vercel-org-id: ${{ inputs.vercel-org-id }}
+#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+#        PINECONE_REGION: us-west-2
+#        PINECONE_INDEX: end-to-end-edge-test
+#        PINECONE_CLOUD: aws
+#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+#      run: cd pinecone-rag-demo && vercel --yes --token=${{ inputs.vercel-token }}
+#      shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -60,9 +60,9 @@ runs:
       run: cd pinecone-rag-demo && pnpm install
       shell: bash
 
-    - name: Remove linting temporarily
-      run: cd pinecone-rag-demo && rm -rf .eslintrc.json
-      shell: bash
+#    - name: Remove linting temporarily
+#      run: cd pinecone-rag-demo && rm -rf .eslintrc.json
+#      shell: bash
 
     - name: Add Global Bin dir needed for pnmp
       uses: pnpm/action-setup@v4
@@ -104,7 +104,10 @@ runs:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
-      run: cd pinecone-rag-demo && vercel build --token=${{ inputs.vercel-token }} --scope=pinecone-io
+      run: |
+        cd pinecone-rag-demo
+        rm -f .eslintrc.json
+        vercel build --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
     - name: Deploy Project Artifacts to Vercel

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -94,19 +94,19 @@ runs:
 #        vercel-org-id: ${{ inputs.vercel-org-id }}
 #      run: cd pinecone-rag-demo && vercel switch pinecone-io  --scope=pinecone-io
 #      shell: bash
-    - name: Try next-build instead of vercel-build
-      run: cd pinecone-rag-demo && pnpm run build
-      env:
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: us-west-2
-        PINECONE_INDEX: end-to-end-edge-test
-        PINECONE_CLOUD: aws
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      shell: bash
+#    - name: Try next-build instead of vercel-build
+#      run: cd pinecone-rag-demo && pnpm run build
+#      env:
+#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+#        PINECONE_REGION: us-west-2
+#        PINECONE_INDEX: end-to-end-edge-test
+#        PINECONE_CLOUD: aws
+#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+#      shell: bash
 
-    - name: Pull Vercel Environment Information
-      run: cd pinecone-rag-demo && vercel pull --yes --token=${{ inputs.vercel-token }} --scope=pinecone-io
-      shell: bash
+#    - name: Pull Vercel Environment Information
+#      run: cd pinecone-rag-demo && vercel pull --yes --token=${{ inputs.vercel-token }} --scope=pinecone-io
+#      shell: bash
 
 #    - name: Build Project Artifacts
 #      env:
@@ -129,7 +129,7 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel deploy --token=${{ inputs.vercel-token }} --scope=pinecone-io
+      run: cd pinecone-rag-demo && vercel --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
 #    - name: Create vercel.json file

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -60,6 +60,7 @@ runs:
       run: cd pinecone-rag-demo && npm install vercel
       shell: bash
 
+# todo:  think i only want `pull` if env vars are in project settings...
     - name: Pull Vercel Environment Information
       run: |
         cd pinecone-rag-demo
@@ -93,14 +94,7 @@ runs:
     - name: Deploy Project Artifacts to Vercel
       run: |
         cd pinecone-rag-demo
-        vercel \
-        --build-env vercel-token=${{ inputs.vercel-token }} \
-        --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} \
-        --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} \ 
-        --build-env PINECONE_INDEX=${{ inputs.PINECONE_INDEX }} \
-        --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} \
-        --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} \
-        --scope=pinecone-io
+        vercel --build-env vercel-token=${{ inputs.vercel-token }} --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{ inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io
 #        vercel deploy --prebuilt --token=${{ inputs.vercel-token }} --scope=pinecone-io
       env:
         vercel-token: ${{ inputs.vercel-token }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -104,6 +104,8 @@ runs:
     - name: Deploy to Vercel
       env:
         vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
         PINECONE_REGION: us-west-2
         PINECONE_INDEX: end-to-end-edge-test

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -25,6 +25,9 @@ runs:
       with:
         node-version: '18.20.3'
 
+    - name: Authenticate into Vercel
+      run:
+
     - name: Setup Vercel
       uses: amondnet/vercel-action@master
       with:
@@ -35,6 +38,9 @@ runs:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
+
+    - name: Test Vercel Auth
+      run: vercel build --yes --token=${{ inputs.vercel-token }}
 
     - name: Build pinecone-ts-client code
       run: npm run build
@@ -111,5 +117,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token
+      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=${{ inputs.vercel-org-id }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -52,35 +52,35 @@ runs:
       shell: bash
 
     - name: Move package to pinecone-rag-demo
-      run: mv pinecone-database-pinecone-*.tgz .
+      run: cd pinecone-rag-demo && mv ../pinecone-database-pinecone-*.tgz .
       shell: bash
 
     - name: Install Pinecone Vercel app dependencies
-      run: npm install
+      run: cd pinecone-rag-demo && npm install
       shell: bash
 
     - name: Install pinecone-ts-client "main" branch code into the Vercel app
-      run: npm install pinecone-database-pinecone-*.tgz
+      run: cd pinecone-rag-demo && npm install pinecone-database-pinecone-*.tgz
       shell: bash
 
     - name: Install pnpm
-      run: npm install -g pnpm
+      run: cd pinecone-rag-demo && npm install -g pnpm
       shell: bash
 
     - name: Install rag app dependencies with pnpm
-      run: pnpm install
+      run: cd pinecone-rag-demo && pnpm install
       shell: bash
 
     - name: Remove linting temporarily
-      run: rm -rf .eslintrc.json
+      run: cd pinecone-rag-demo && rm -rf .eslintrc.json
       shell: bash
 
     - name: Build Pinecone Vercel app
-      run: pnpm run build
+      run: cd pinecone-rag-demo && pnpm run build
       shell: bash
 
     - name: Install Vercel CLI
-      run: pnpm add -g vercel
+      run: cd pinecone-rag-demo && pnpm add -g vercel
       shell: bash
 
     - name: Create vercel.json file
@@ -113,5 +113,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: vercel --yes --logs --token=$vercel-token --scope=$VERCEL_TEAM_SCOPE
+      run: cd pinecone-rag-demo &&  && vercel --yes --logs --token=$vercel-token --scope=$VERCEL_TEAM_SCOPE
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -44,21 +44,21 @@ runs:
       run: cd pinecone-rag-demo && mv ../pinecone-database-pinecone-*.tgz .
       shell: bash
 
-    - name: Install Pinecone Vercel app dependencies
-      run: cd pinecone-rag-demo && npm install
-      shell: bash
+#    - name: Install Pinecone Vercel app dependencies
+#      run: cd pinecone-rag-demo && npm install
+#      shell: bash
 
-    - name: Install pinecone-ts-client "main" branch code into the Vercel app
-      run: cd pinecone-rag-demo && npm install pinecone-database-pinecone-*.tgz
-      shell: bash
+#    - name: Install pinecone-ts-client "main" branch code into the Vercel app
+#      run: cd pinecone-rag-demo && npm install pinecone-database-pinecone-*.tgz
+#      shell: bash
 
     - name: Install pnpm
       run: cd pinecone-rag-demo && npm install -g pnpm
       shell: bash
 
-    - name: Install rag app dependencies with pnpm
-      run: cd pinecone-rag-demo && pnpm install
-      shell: bash
+#    - name: Install rag app dependencies with pnpm
+#      run: cd pinecone-rag-demo && pnpm install
+#      shell: bash
 
 #    - name: Remove linting temporarily
 #      run: cd pinecone-rag-demo && rm -rf .eslintrc.json
@@ -74,6 +74,16 @@ runs:
 #    - name: Build Pinecone Vercel app
 #      run: cd pinecone-rag-demo && pnpm run build
 #      shell: bash
+
+    - name: Install rag-demo deps
+      run: cd pinecone-rag-demo && pnpm i
+      shell: bash
+
+    - name: Install pinecone-ts-client "main" branch code into the Vercel app
+      run: cd pinecone-rag-demo && pnpm i pinecone-database-pinecone-*.tgz
+      shell: bash
+
+      # todo: maybe need pnpm add ts-client too?
 
     - name: Install Vercel CLI
       run: cd pinecone-rag-demo && pnpm add -g vercel@latest

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -79,6 +79,10 @@ runs:
       run: cd pinecone-rag-demo && pnpm add -g vercel@latest
       shell: bash
 
+    - name: Ensure you are in the pinecone-io scope
+      run: cd pinecone-rag-demo && vercel switch pinecone-io
+      shell: bash
+
     - name: Pull Vercel Environment Information
       run: cd pinecone-rag-demo && vercel pull --yes --environment=production --token=${{ inputs.vercel-token }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -94,6 +94,7 @@ runs:
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       run: cd pinecone-rag-demo && vercel build --prod --token=${{ inputs.vercel-token }}
+      shell: bash
 
     - name: Deploy Project Artifacts to Vercel
       env:
@@ -106,6 +107,7 @@ runs:
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       run: cd pinecone-rag-demo && vercel deploy --prebuilt --prod --token=${{ inputs.vercel-token }}
+      shell: bash
 
 #    - name: Create vercel.json file
 #      run: |

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -94,10 +94,6 @@ runs:
           },
           "buildCommand": "next build",
           "installCommand": "npm install",
-          "framework": "nextjs",
-          "builds": [
-            { "src": "pinecone-rag-demo/src", "use": "@vercel/static" }
-          ],
           "functions": {
             "src/app/**/*.{ts,tsx}": {
               "runtime": "edge",

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
 
     - name: Install pinecone-ts-client "main" branch code into the Vercel app
-      run: cd pinecone-rag-demo && pnpm add pinecone-database-pinecone-*.tgz
+      run: cd pinecone-rag-demo && pnpm add -P ./pinecone-database-pinecone-*.tgz
       shell: bash
 
       # todo: maybe need pnpm add ts-client too?

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -141,6 +141,6 @@ runs:
         PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
         PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --token=${{ inputs.vercel-token }} --scope=pinecone-io
+      run: cd pinecone-rag-demo && vercel --debug --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -92,6 +92,7 @@ runs:
             "enabled": false
           },
           "buildCommand": "next build",
+          "installCommand": "npm install"
           "framework": "nextjs",
           "functions": {
             "src/app/**/*.{ts,tsx}": {

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -94,21 +94,30 @@ runs:
 #        vercel-org-id: ${{ inputs.vercel-org-id }}
 #      run: cd pinecone-rag-demo && vercel switch pinecone-io  --scope=pinecone-io
 #      shell: bash
+    - name: Try next-build instead of vercel-build
+      run: cd pinecone-rag-demo && next build
+      env:
+        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        PINECONE_REGION: us-west-2
+        PINECONE_INDEX: end-to-end-edge-test
+        PINECONE_CLOUD: aws
+        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+      shell: bash
 
     - name: Pull Vercel Environment Information
       run: cd pinecone-rag-demo && vercel pull --yes --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
-    - name: Build Project Artifacts
-      env:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-      run: |
-        cd pinecone-rag-demo
-        rm -f .eslintrc.json
-        vercel build --token=${{ inputs.vercel-token }} --scope=pinecone-io
-      shell: bash
+#    - name: Build Project Artifacts
+#      env:
+#        vercel-token: ${{ inputs.vercel-token }}
+#        vercel-project-id: ${{ inputs.vercel-project-id }}
+#        vercel-org-id: ${{ inputs.vercel-org-id }}
+#      run: |
+#        cd pinecone-rag-demo
+#        rm -f .eslintrc.json
+#        vercel build --token=${{ inputs.vercel-token }} --scope=pinecone-io
+#      shell: bash
 
     - name: Deploy Project Artifacts to Vercel
       env:

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -92,8 +92,6 @@ runs:
           "github": {
             "enabled": false
           },
-          "buildCommand": "next build",
-          "installCommand": "npm install",
           "functions": {
             "src/app/**/*.{ts,tsx}": {
               "runtime": "edge-runtime@3.0.1",

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -64,6 +64,10 @@ runs:
       run: cd pinecone-rag-demo && rm -rf .eslintrc.json
       shell: bash
 
+    - name: Add Global Bin dir needed for pnmp
+      run: cd pinecone-rag-demo && pnpm setup
+      shell: bash
+
 #    - name: Build Pinecone Vercel app
 #      run: cd pinecone-rag-demo && pnpm run build
 #      shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -33,6 +33,13 @@ runs:
       run: npm pack
       shell: bash
 
+    - name: Clone Vercel app -- test
+      uses: GuillaumeFalourd/clone-github-repo-action@main
+      with:
+        owner: 'pinecone-io'
+        repository: 'pinecone-rag-demo'
+        branch: 'main'
+
     - name: Clone Pinecone Vercel app into pinecone-ts-client
       run: |
         git clone git@github.com:pinecone-io/pinecone-rag-demo.git

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -26,7 +26,7 @@ runs:
         node-version: '18.20.3'
 
     - name: Build pinecone-ts-client code
-      run: npm run build
+      run: npm install && npm run build
       shell: bash
 
     - name: Package pinecone-ts-client code

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -3,20 +3,6 @@ name: Spin up Vercel App
 inputs:
   vercel-token:
     required: true
-#  vercel-project-id:
-#    required: true
-#  vercel-org-id:
-#    required: true
-#  PINECONE_API_KEY:
-#    required: true
-#  PINECONE_INDEX:
-#    required: true
-#  PINECONE_CLOUD:
-#    required: true
-#  PINECONE_REGION:
-#    required: true
-#  OPENAI_API_KEY:
-#    required: true
 
 runs:
   using: 'composite'
@@ -64,12 +50,4 @@ runs:
       run: |
         cd pinecone-rag-demo
         vercel --scope=pinecone-io --token=${{ inputs.vercel-token }} --yes
-#      env:
-#        vercel-project-id: ${{ inputs.vercel-project-id }}
-#        vercel-org-id: ${{ inputs.vercel-org-id }}
-#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-#        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-#        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-#        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -36,10 +36,6 @@ runs:
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
 
-    - name: Test Vercel Auth
-      run: vercel build --yes --token=${{ inputs.vercel-token }}
-      shell: bash
-
     - name: Build pinecone-ts-client code
       run: npm run build
       shell: bash
@@ -103,6 +99,10 @@ runs:
             }
           }
         }' > vercel.json
+      shell: bash
+
+    - name: Test Vercel Auth
+      run: cd pinecone-rag-demo && vercel build --yes --token=${{ inputs.vercel-token }}
       shell: bash
 
     - name: Deploy to Vercel

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -120,7 +120,7 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel deploy --prebuilt --prod --token=${{ inputs.vercel-token }} --scope=pinecone-io
+      run: cd pinecone-rag-demo && vercel deploy --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
 #    - name: Create vercel.json file

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -9,9 +9,13 @@ inputs:
     required: true
   PINECONE_API_KEY:
     required: true
-  OPENAI_API_KEY:
+  PINECONE_INDEX:
     required: true
-  VERCEL_TEAM_SCOPE:
+  PINECONE_CLOUD:
+    required: true
+  PINECONE_REGION:
+    required: true
+  OPENAI_API_KEY:
     required: true
 
 runs:
@@ -133,9 +137,9 @@ runs:
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: us-west-2
-        PINECONE_INDEX: end-to-end-edge-test
-        PINECONE_CLOUD: aws
+        PINECONE_REGION: ${{ PINECONE_REGION }}
+        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
       run: cd pinecone-rag-demo && vercel --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -111,5 +111,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
+      run: cd pinecone-rag-demo && vercel --yes --logs --token=${{ inputs.vercel-token }} --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -95,7 +95,7 @@ runs:
 #      run: cd pinecone-rag-demo && vercel switch pinecone-io  --scope=pinecone-io
 #      shell: bash
     - name: Try next-build instead of vercel-build
-      run: cd pinecone-rag-demo && next build
+      run: cd pinecone-rag-demo && pnpm run build
       env:
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
         PINECONE_REGION: us-west-2

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -105,6 +105,7 @@ runs:
       shell: bash
 
     - name: Deploy to Vercel
+      working-directory: pinecone-rag-demo
       env:
         VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
         vercel-token: ${{ inputs.vercel-token }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -25,17 +25,6 @@ runs:
       with:
         node-version: '18.20.3'
 
-    - name: Setup Vercel
-      uses: amondnet/vercel-action@master
-      with:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-      env:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-
     - name: Build pinecone-ts-client code
       run: npm run build
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -94,9 +94,8 @@ runs:
     - name: Deploy Project Artifacts to Vercel
       run: |
         cd pinecone-rag-demo
-        vercel --build-env vercel-token=${{ inputs.vercel-token }} --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io --token=${{ inputs.vercel-token }} --yes
+        vercel --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io --token=${{ inputs.vercel-token }} --yes
       env:
-        vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -115,5 +115,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
+      run: cd pinecone-rag-demo && vercel pinecone-rag-demo --yes --logs --token=$vercel-token --scope=${{ inputs.VERCEL_TEAM_SCOPE }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -79,16 +79,24 @@ runs:
       run: cd pinecone-rag-demo && pnpm add -g vercel@latest
       shell: bash
 
-    - name: Ensure you are in the pinecone-io scope
-      env:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-      run: cd pinecone-rag-demo && vercel switch pinecone-io
-      shell: bash
+#    - name: Log into Vercel
+#      env:
+#        vercel-token: ${{ inputs.vercel-token }}
+#        vercel-project-id: ${{ inputs.vercel-project-id }}
+#        vercel-org-id: ${{ inputs.vercel-org-id }}
+#      run: vercel login --token=${{ inputs.vercel-token }}
+#      shell: bash
+
+#    - name: Ensure you are in the pinecone-io scope
+#      env:
+#        vercel-token: ${{ inputs.vercel-token }}
+#        vercel-project-id: ${{ inputs.vercel-project-id }}
+#        vercel-org-id: ${{ inputs.vercel-org-id }}
+#      run: cd pinecone-rag-demo && vercel switch pinecone-io  --scope=pinecone-io
+#      shell: bash
 
     - name: Pull Vercel Environment Information
-      run: cd pinecone-rag-demo && vercel pull --yes --environment=production --token=${{ inputs.vercel-token }}
+      run: cd pinecone-rag-demo && vercel pull --yes --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
     - name: Build Project Artifacts
@@ -96,7 +104,7 @@ runs:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
-      run: cd pinecone-rag-demo && vercel build --prod --token=${{ inputs.vercel-token }}
+      run: cd pinecone-rag-demo && vercel build --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
     - name: Deploy Project Artifacts to Vercel
@@ -109,7 +117,7 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel deploy --prebuilt --prod --token=${{ inputs.vercel-token }}
+      run: cd pinecone-rag-demo && vercel deploy --prebuilt --prod --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
 
 #    - name: Create vercel.json file

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -103,12 +103,11 @@ runs:
 
     - name: Deploy to Vercel
       env:
-        VERCEL_TEAM_SCOPE: ${{ inputs.VERCEL_TEAM_SCOPE }}
         vercel-token: ${{ inputs.vercel-token }}
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
         PINECONE_REGION: us-west-2
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token --scope=$VERCEL_TEAM_SCOPE
+      run: cd pinecone-rag-demo && vercel --yes --logs --token=$vercel-token
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -25,9 +25,6 @@ runs:
       with:
         node-version: '18.20.3'
 
-    - name: Authenticate into Vercel
-      run:
-
     - name: Setup Vercel
       uses: amondnet/vercel-action@master
       with:
@@ -41,6 +38,7 @@ runs:
 
     - name: Test Vercel Auth
       run: vercel build --yes --token=${{ inputs.vercel-token }}
+      shell: bash
 
     - name: Build pinecone-ts-client code
       run: npm run build

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -94,8 +94,7 @@ runs:
     - name: Deploy Project Artifacts to Vercel
       run: |
         cd pinecone-rag-demo
-        vercel --build-env vercel-token=${{ inputs.vercel-token }} --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{ inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io
-#        vercel deploy --prebuilt --token=${{ inputs.vercel-token }} --scope=pinecone-io
+        vercel --build-env vercel-token=${{ inputs.vercel-token }} --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{ inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io --token=${{ inputs.vercel-token }}
       env:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
 
     - name: Install pinecone-ts-client "main" branch code into the Vercel app
-      run: cd pinecone-rag-demo && pnpm i pinecone-database-pinecone-*.tgz
+      run: cd pinecone-rag-demo && pnpm add pinecone-database-pinecone-*.tgz
       shell: bash
 
       # todo: maybe need pnpm add ts-client too?

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -61,20 +61,20 @@ runs:
       shell: bash
 
 # todo:  think i only want `pull` if env vars are in project settings...
-    - name: Pull Vercel Environment Information
-      run: |
-        cd pinecone-rag-demo
-        vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }} --scope=pinecone-io
-      env:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      shell: bash
+#    - name: Pull Vercel Environment Information
+#      run: |
+#        cd pinecone-rag-demo
+#        vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }} --scope=pinecone-io
+#      env:
+#        vercel-token: ${{ inputs.vercel-token }}
+#        vercel-project-id: ${{ inputs.vercel-project-id }}
+#        vercel-org-id: ${{ inputs.vercel-org-id }}
+#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+#        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
+#        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+#        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
+#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+#      shell: bash
 
 #    - name: Build Project Artifacts
 #      run: |

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -111,5 +111,5 @@ runs:
         PINECONE_INDEX: end-to-end-edge-test
         PINECONE_CLOUD: aws
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --yes --logs --token=${{ inputs.vercel-token }} --scope=${{ inputs.vercel-project-id }}
+      run: cd pinecone-rag-demo && vercel --yes --token=${{ inputs.vercel-token }} --scope=${{ inputs.vercel-project-id }}
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -96,7 +96,7 @@ runs:
           "installCommand": "npm install",
           "functions": {
             "src/app/**/*.{ts,tsx}": {
-              "runtime": "edge",
+              "runtime": "edge-runtime@3.0.1",
               "includeFiles": "src/app/**/*"
             }
           }

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -48,37 +48,6 @@ runs:
       run: cd pinecone-rag-demo && mv ../pinecone-database-pinecone-*.tgz .
       shell: bash
 
-#    - name: Install Pinecone Vercel app dependencies
-#      run: cd pinecone-rag-demo && npm install
-#      shell: bash
-
-#    - name: Install pinecone-ts-client "main" branch code into the Vercel app
-#      run: cd pinecone-rag-demo && npm install pinecone-database-pinecone-*.tgz
-#      shell: bash
-#
-#    - name: Install pnpm
-#      run: cd pinecone-rag-demo && npm install -g pnpm
-#      shell: bash
-
-#    - name: Install rag app dependencies with pnpm
-#      run: cd pinecone-rag-demo && pnpm install
-#      shell: bash
-
-#    - name: Remove linting temporarily
-#      run: cd pinecone-rag-demo && rm -rf .eslintrc.json
-#      shell: bash
-
-#    - name: Add Global Bin dir needed for pnmp
-#      uses: pnpm/action-setup@v4
-#      with:
-#        version: 9
-#      run: cd pinecone-rag-demo && pnpm setup
-#      shell: bash
-
-#    - name: Build Pinecone Vercel app
-#      run: cd pinecone-rag-demo && pnpm run build
-#      shell: bash
-
     - name: Install rag-demo deps
       run: cd pinecone-rag-demo && npm install
       shell: bash
@@ -91,86 +60,25 @@ runs:
       run: cd pinecone-rag-demo && npm install vercel
       shell: bash
 
-#    - name: Log into Vercel
-#      env:
-#        vercel-token: ${{ inputs.vercel-token }}
-#        vercel-project-id: ${{ inputs.vercel-project-id }}
-#        vercel-org-id: ${{ inputs.vercel-org-id }}
-#      run: vercel login --token=${{ inputs.vercel-token }}
-#      shell: bash
-
-#    - name: Ensure you are in the pinecone-io scope
-#      env:
-#        vercel-token: ${{ inputs.vercel-token }}
-#        vercel-project-id: ${{ inputs.vercel-project-id }}
-#        vercel-org-id: ${{ inputs.vercel-org-id }}
-#      run: cd pinecone-rag-demo && vercel switch pinecone-io  --scope=pinecone-io
-#      shell: bash
-#    - name: Try next-build instead of vercel-build
-#      run: cd pinecone-rag-demo && pnpm run build
-#      env:
-#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-#        PINECONE_REGION: us-west-2
-#        PINECONE_INDEX: end-to-end-edge-test
-#        PINECONE_CLOUD: aws
-#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-#      shell: bash
-
-#    - name: Pull Vercel Environment Information
-#      run: cd pinecone-rag-demo && vercel pull --yes --token=${{ inputs.vercel-token }} --scope=pinecone-io
-#      shell: bash
+    - name: Pull Vercel Environment Information
+      run: |
+        cd pinecone-rag-demo
+        vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }} --scope=pinecone-io
+      env:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
+        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
+        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+      shell: bash
 
 #    - name: Build Project Artifacts
-#      env:
-#        vercel-token: ${{ inputs.vercel-token }}
-#        vercel-project-id: ${{ inputs.vercel-project-id }}
-#        vercel-org-id: ${{ inputs.vercel-org-id }}
 #      run: |
 #        cd pinecone-rag-demo
-#        rm -f .eslintrc.json
-#        vercel build --token=${{ inputs.vercel-token }} --scope=pinecone-io
-#      shell: bash
-
-    - name: Pull Vercel Environment Information
-      run: cd pinecone-rag-demo && vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }} --scope=pinecone-io
-      env:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      shell: bash
-
-    - name: Build Project Artifacts
-      run: cd pinecone-rag-demo && vercel build --token=${{ inputs.vercel-token }}
-      env:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      shell: bash
-
-    - name: Deploy Project Artifacts to Vercel
-      run: cd pinecone-rag-demo && vercel deploy --prebuilt --token=${{ inputs.vercel-token }} --scope=pinecone-io
-      env:
-        vercel-token: ${{ inputs.vercel-token }}
-        vercel-project-id: ${{ inputs.vercel-project-id }}
-        vercel-org-id: ${{ inputs.vercel-org-id }}
-        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
-        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
-        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
-        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      shell: bash
-
-#    - name: Deploy Project Artifacts to Vercel
+#        vercel build --yes --token=${{ inputs.vercel-token }} --scope=pinecone-io
 #      env:
 #        vercel-token: ${{ inputs.vercel-token }}
 #        vercel-project-id: ${{ inputs.vercel-project-id }}
@@ -180,6 +88,27 @@ runs:
 #        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
 #        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
 #        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-#      run: cd pinecone-rag-demo && vercel --debug --token=${{ inputs.vercel-token }} --scope=pinecone-io
 #      shell: bash
 
+    - name: Deploy Project Artifacts to Vercel
+      run: |
+        cd pinecone-rag-demo
+        vercel \
+        --build-env vercel-token=${{ inputs.vercel-token }} \
+        --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} \
+        --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} \ 
+        --build-env PINECONE_INDEX=${{ inputs.PINECONE_INDEX }} \
+        --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} \
+        --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} \
+        --scope=pinecone-io
+#        vercel deploy --prebuilt --token=${{ inputs.vercel-token }} --scope=pinecone-io
+      env:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
+        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
+        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+      shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -131,7 +131,8 @@ runs:
 #        vercel build --token=${{ inputs.vercel-token }} --scope=pinecone-io
 #      shell: bash
 
-    - name: Deploy Project Artifacts to Vercel
+    - name: Pull Vercel Environment Information
+      run: cd pinecone-rag-demo && vercel pull --yes --environment=preview --token=${{ inputs.vercel-token }}
       env:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}
@@ -141,6 +142,44 @@ runs:
         PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
         PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
-      run: cd pinecone-rag-demo && vercel --debug --token=${{ inputs.vercel-token }} --scope=pinecone-io
       shell: bash
+
+    - name: Build Project Artifacts
+      run: cd pinecone-rag-demo && vercel build --token=${{ inputs.vercel-token }}
+      env:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
+        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
+        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+      shell: bash
+
+    - name: Deploy Project Artifacts to Vercel
+      run: cd pinecone-rag-demo && vercel deploy --prebuilt --token=${{ inputs.vercel-token }} --scope=pinecone-io
+      env:
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
+        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
+        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+      shell: bash
+
+#    - name: Deploy Project Artifacts to Vercel
+#      env:
+#        vercel-token: ${{ inputs.vercel-token }}
+#        vercel-project-id: ${{ inputs.vercel-project-id }}
+#        vercel-org-id: ${{ inputs.vercel-org-id }}
+#        PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+#        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
+#        PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
+#        PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
+#        OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}
+#      run: cd pinecone-rag-demo && vercel --debug --token=${{ inputs.vercel-token }} --scope=pinecone-io
+#      shell: bash
 

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -40,12 +40,6 @@ runs:
         repository: 'pinecone-rag-demo'
         branch: 'main'
 
-    - name: Clone Pinecone Vercel app into pinecone-ts-client
-      run: |
-        git clone git@github.com:pinecone-io/pinecone-rag-demo.git
-        cd pinecone-rag-demo
-      shell: bash
-
     - name: Move package to pinecone-rag-demo
       run: cd pinecone-rag-demo && mv ../pinecone-database-pinecone-*.tgz .
       shell: bash

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -137,7 +137,7 @@ runs:
         vercel-project-id: ${{ inputs.vercel-project-id }}
         vercel-org-id: ${{ inputs.vercel-org-id }}
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
-        PINECONE_REGION: ${{ PINECONE_REGION }}
+        PINECONE_REGION: ${{ inputs.PINECONE_REGION }}
         PINECONE_INDEX: ${{ inputs.PINECONE_INDEX }}
         PINECONE_CLOUD: ${{ inputs.PINECONE_CLOUD }}
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY }}

--- a/.github/actions/e2e-testing/edge/action.yml
+++ b/.github/actions/e2e-testing/edge/action.yml
@@ -94,7 +94,7 @@ runs:
     - name: Deploy Project Artifacts to Vercel
       run: |
         cd pinecone-rag-demo
-        vercel --build-env vercel-token=${{ inputs.vercel-token }} --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{ inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io --token=${{ inputs.vercel-token }}
+        vercel --build-env vercel-token=${{ inputs.vercel-token }} --build-env PINECONE_API_KEY=${{ inputs.PINECONE_API_KEY }} --build-env PINECONE_REGION=${{ inputs.PINECONE_REGION }} --build-env PINECONE_INDEX=${{inputs.PINECONE_INDEX }} --build-env PINECONE_CLOUD=${{ inputs.PINECONE_CLOUD }} --build-env OPENAI_API_KEY=${{ inputs.OPENAI_API_KEY }} --scope=pinecone-io --token=${{ inputs.vercel-token }} --yes
       env:
         vercel-token: ${{ inputs.vercel-token }}
         vercel-project-id: ${{ inputs.vercel-project-id }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -21,7 +21,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          PINECONE_INDEX: end-to-end-edge-test
+          PINECONE_INDEX: end-to-end-edge-test-boo
           PINECONE_CLOUD: aws
           PINECONE_REGION: us-west-2
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Run e2e tests for edge runtime
         uses: ./.github/actions/e2e-testing/edge
         with:
-          CI: true
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
@@ -25,7 +24,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}
         env:
-          CI: true
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -18,10 +18,10 @@ jobs:
         uses: ./.github/actions/e2e-testing/edge
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          PINECONE_INDEX: end-to-end-edge-test-boo
-          PINECONE_CLOUD: aws
-          PINECONE_REGION: us-west-2
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+#          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+#          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+#          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+#          PINECONE_INDEX: end-to-end-edge-test-boo
+#          PINECONE_CLOUD: aws
+#          PINECONE_REGION: us-west-2
+#          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -18,10 +18,3 @@ jobs:
         uses: ./.github/actions/e2e-testing/edge
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-#          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-#          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-#          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-#          PINECONE_INDEX: end-to-end-edge-test-boo
-#          PINECONE_CLOUD: aws
-#          PINECONE_REGION: us-west-2
-#          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -21,12 +21,7 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_INDEX: end-to-end-edge-test
+          PINECONE_CLOUD: aws
+          PINECONE_REGION: us-west-2
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}
-        env:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          VERCEL_TEAM_SCOPE: ${{ secrets.VERCEL_TEAM_SCOPE }}


### PR DESCRIPTION
## Problem

Setting the necessary Pinecone-related environment variables in the Vercel UI enabled us to finalize the e2e Edge GH workflow pipeline. Everything now deploys and is workable in the `preview` environment (all we need for right now). 

Final working preview: https://vercel.com/pinecone-io/pinecone-rag-demo/G6hqB1w2fdNyLbHhdjqYvx7pgVzo

## Solution

Pass Pinecone-related env vars needed by app through Vercel UI/dashboard.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208153851794098