### PR TITLE
Update cleanupResources workflow to check for deletionProtection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-inferrable-types": "off",
-    "import/no-cycle": "error"
+    "import/no-cycle": "error",
+    "@typescript-eslint/no-var-requires": "off" // Add this line
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,6 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-inferrable-types": "off",
-    "import/no-cycle": "error",
-    "@typescript-eslint/no-var-requires": "off"
+    "import/no-cycle": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,6 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "import/no-cycle": "error",
-    "@typescript-eslint/no-var-requires": "off" // Add this line
+    "@typescript-eslint/no-var-requires": "off"
   }
 }

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-  #      - name: Run tests
-  #        env:
-  #          CI: true
-  #        run: npm run test:unit -- --coverage
+      - name: Run tests
+        env:
+          CI: true
+        run: npm run test:unit -- --coverage
 
   integration-tests:
     name: Run integration tests
@@ -29,15 +29,15 @@ jobs:
         pinecone_env:
           - prod
           # - staging
-        node_version: [18.x] #[18.x, 20.x]
-        config: [{ runner: 'npm', jest_env: 'node' }]
-    #          [
-    #            { runner: 'npm', jest_env: 'node' },
-    #            { runner: 'npm', jest_env: 'edge' },
-    #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
-    #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
-    #            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
-    #          ]
+        node_version: [18.x, 20.x]
+        config:
+              [
+                { runner: 'npm', jest_env: 'node' },
+                { runner: 'npm', jest_env: 'edge' },
+                { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
+                { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
+                { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
+              ]
 
     steps:
       - name: Checkout
@@ -91,95 +91,95 @@ jobs:
           CI: true
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         run: npm run test:integration:cleanup
-#  typescript-compilation-tests:
-#    name: TS compile
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        tsVersion:
-#          [
-#            '~4.1.0',
-#            '~4.2.0',
-#            '~4.3.0',
-#            '~4.4.0',
-#            '~4.5.0',
-#            '~4.6.0',
-#            '~4.7.0',
-#            '~4.8.0',
-#            '~4.9.0',
-#            '~5.0.0',
-#            '~5.1.0',
-#            '~5.2.0',
-#            'latest',
-#          ]
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#      - name: Setup Node
-#        uses: actions/setup-node@v4
-#        with:
-#          node-version: 18.x
-#          registry-url: 'https://registry.npmjs.org'
-#      - name: Install npm packages
-#        run: |
-#          npm install --ignore-scripts
-#        shell: bash
-#      - name: Build TypeScript for Pinecone
-#        run: npm run build
-#        shell: bash
-#      - name: install, compile, and run sample app
-#        shell: bash
-#        env:
-#          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-#        run: |
-#          set -x
-#          cd ..
-#          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
-#          cd ts-compilation-test
-#          npm install typescript@${{ matrix.tsVersion }} --no-cache
-#          npm install '../pinecone-ts-client' --no-cache
-#          cat package.json
-#          cat package-lock.json
-#          npm run tsc-version
-#          npm run build
-#          npm run start
+  typescript-compilation-tests:
+    name: TS compile
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tsVersion:
+          [
+            '~4.1.0',
+            '~4.2.0',
+            '~4.3.0',
+            '~4.4.0',
+            '~4.5.0',
+            '~4.6.0',
+            '~4.7.0',
+            '~4.8.0',
+            '~4.9.0',
+            '~5.0.0',
+            '~5.1.0',
+            '~5.2.0',
+            'latest',
+          ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install npm packages
+        run: |
+          npm install --ignore-scripts
+        shell: bash
+      - name: Build TypeScript for Pinecone
+        run: npm run build
+        shell: bash
+      - name: install, compile, and run sample app
+        shell: bash
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+        run: |
+          set -x
+          cd ..
+          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
+          cd ts-compilation-test
+          npm install typescript@${{ matrix.tsVersion }} --no-cache
+          npm install '../pinecone-ts-client' --no-cache
+          cat package.json
+          cat package-lock.json
+          npm run tsc-version
+          npm run build
+          npm run start
 
-#  example-app-semantic-search:
-#    name: 'Example app: semantic search'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout pinecone-ts-client
-#        uses: actions/checkout@v4
-#        with:
-#          path: pinecone-ts-client
-#      - name: Checkout semantic-search-example
-#        uses: actions/checkout@v4
-#        with:
-#          repository: pinecone-io/semantic-search-example
-#          ref: spruce
-#          path: semantic-search-example
-#      - name: Install and build client
-#        shell: bash
-#        run: |
-#          cd pinecone-ts-client
-#          npm install --ignore-scripts
-#          npm run build
-#      - name: Install and build sample app
-#        shell: bash
-#        run: |
-#          cd semantic-search-example
-#          npm install --no-cache
-#          npm install '../pinecone-ts-client'
-#          cat package.json
-#      - name: Run example tests with dev version of client
-#        env:
-#          CI: true
-#          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-#          PINECONE_INDEX: 'semantic-search'
-#          PINECONE_CLOUD: 'aws'
-#          PINECONE_REGION: 'us-west-2'
-#        shell: bash
-#        run: |
-#          cd semantic-search-example
-#          npm run test
+  example-app-semantic-search:
+    name: 'Example app: semantic search'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pinecone-ts-client
+        uses: actions/checkout@v4
+        with:
+          path: pinecone-ts-client
+      - name: Checkout semantic-search-example
+        uses: actions/checkout@v4
+        with:
+          repository: pinecone-io/semantic-search-example
+          ref: spruce
+          path: semantic-search-example
+      - name: Install and build client
+        shell: bash
+        run: |
+          cd pinecone-ts-client
+          npm install --ignore-scripts
+          npm run build
+      - name: Install and build sample app
+        shell: bash
+        run: |
+          cd semantic-search-example
+          npm install --no-cache
+          npm install '../pinecone-ts-client'
+          cat package.json
+      - name: Run example tests with dev version of client
+        env:
+          CI: true
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_INDEX: 'semantic-search'
+          PINECONE_CLOUD: 'aws'
+          PINECONE_REGION: 'us-west-2'
+        shell: bash
+        run: |
+          cd semantic-search-example
+          npm run test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Run tests
-        env:
-          CI: true
-        run: npm run test:unit -- --coverage
+  #      - name: Run tests
+  #        env:
+  #          CI: true
+  #        run: npm run test:unit -- --coverage
 
   integration-tests:
     name: Run integration tests
@@ -29,15 +29,15 @@ jobs:
         pinecone_env:
           - prod
           # - staging
-        node_version: [18.x, 20.x]
-        config:
-          [
-            { runner: 'npm', jest_env: 'node' },
-            { runner: 'npm', jest_env: 'edge' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
-          ]
+        node_version: [18.x] #[18.x, 20.x]
+        config: [{ runner: 'npm', jest_env: 'node' }]
+    #          [
+    #            { runner: 'npm', jest_env: 'node' },
+    #            { runner: 'npm', jest_env: 'edge' },
+    #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
+    #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
+    #            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
+    #          ]
 
     steps:
       - name: Checkout
@@ -91,96 +91,95 @@ jobs:
           CI: true
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         run: npm run test:integration:cleanup
+#  typescript-compilation-tests:
+#    name: TS compile
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        tsVersion:
+#          [
+#            '~4.1.0',
+#            '~4.2.0',
+#            '~4.3.0',
+#            '~4.4.0',
+#            '~4.5.0',
+#            '~4.6.0',
+#            '~4.7.0',
+#            '~4.8.0',
+#            '~4.9.0',
+#            '~5.0.0',
+#            '~5.1.0',
+#            '~5.2.0',
+#            'latest',
+#          ]
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#      - name: Setup Node
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: 18.x
+#          registry-url: 'https://registry.npmjs.org'
+#      - name: Install npm packages
+#        run: |
+#          npm install --ignore-scripts
+#        shell: bash
+#      - name: Build TypeScript for Pinecone
+#        run: npm run build
+#        shell: bash
+#      - name: install, compile, and run sample app
+#        shell: bash
+#        env:
+#          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+#        run: |
+#          set -x
+#          cd ..
+#          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
+#          cd ts-compilation-test
+#          npm install typescript@${{ matrix.tsVersion }} --no-cache
+#          npm install '../pinecone-ts-client' --no-cache
+#          cat package.json
+#          cat package-lock.json
+#          npm run tsc-version
+#          npm run build
+#          npm run start
 
-  typescript-compilation-tests:
-    name: TS compile
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        tsVersion:
-          [
-            '~4.1.0',
-            '~4.2.0',
-            '~4.3.0',
-            '~4.4.0',
-            '~4.5.0',
-            '~4.6.0',
-            '~4.7.0',
-            '~4.8.0',
-            '~4.9.0',
-            '~5.0.0',
-            '~5.1.0',
-            '~5.2.0',
-            'latest',
-          ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-          registry-url: 'https://registry.npmjs.org'
-      - name: Install npm packages
-        run: |
-          npm install --ignore-scripts
-        shell: bash
-      - name: Build TypeScript for Pinecone
-        run: npm run build
-        shell: bash
-      - name: install, compile, and run sample app
-        shell: bash
-        env:
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-        run: |
-          set -x
-          cd ..
-          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
-          cd ts-compilation-test
-          npm install typescript@${{ matrix.tsVersion }} --no-cache
-          npm install '../pinecone-ts-client' --no-cache
-          cat package.json
-          cat package-lock.json
-          npm run tsc-version
-          npm run build
-          npm run start
-
-  example-app-semantic-search:
-    name: 'Example app: semantic search'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout pinecone-ts-client
-        uses: actions/checkout@v4
-        with:
-          path: pinecone-ts-client
-      - name: Checkout semantic-search-example
-        uses: actions/checkout@v4
-        with:
-          repository: pinecone-io/semantic-search-example
-          ref: spruce
-          path: semantic-search-example
-      - name: Install and build client
-        shell: bash
-        run: |
-          cd pinecone-ts-client
-          npm install --ignore-scripts
-          npm run build
-      - name: Install and build sample app
-        shell: bash
-        run: |
-          cd semantic-search-example
-          npm install --no-cache
-          npm install '../pinecone-ts-client'
-          cat package.json
-      - name: Run example tests with dev version of client
-        env:
-          CI: true
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          PINECONE_INDEX: 'semantic-search'
-          PINECONE_CLOUD: 'aws'
-          PINECONE_REGION: 'us-west-2'
-        shell: bash
-        run: |
-          cd semantic-search-example
-          npm run test
+#  example-app-semantic-search:
+#    name: 'Example app: semantic search'
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout pinecone-ts-client
+#        uses: actions/checkout@v4
+#        with:
+#          path: pinecone-ts-client
+#      - name: Checkout semantic-search-example
+#        uses: actions/checkout@v4
+#        with:
+#          repository: pinecone-io/semantic-search-example
+#          ref: spruce
+#          path: semantic-search-example
+#      - name: Install and build client
+#        shell: bash
+#        run: |
+#          cd pinecone-ts-client
+#          npm install --ignore-scripts
+#          npm run build
+#      - name: Install and build sample app
+#        shell: bash
+#        run: |
+#          cd semantic-search-example
+#          npm install --no-cache
+#          npm install '../pinecone-ts-client'
+#          cat package.json
+#      - name: Run example tests with dev version of client
+#        env:
+#          CI: true
+#          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+#          PINECONE_INDEX: 'semantic-search'
+#          PINECONE_CLOUD: 'aws'
+#          PINECONE_REGION: 'us-west-2'
+#        shell: bash
+#        run: |
+#          cd semantic-search-example
+#          npm run test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,13 +31,13 @@ jobs:
           # - staging
         node_version: [18.x, 20.x]
         config:
-              [
-                { runner: 'npm', jest_env: 'node' },
-                { runner: 'npm', jest_env: 'edge' },
-                { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
-                { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
-                { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
-              ]
+          [
+            { runner: 'npm', jest_env: 'node' },
+            { runner: 'npm', jest_env: 'edge' },
+            { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
+            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
+            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
+          ]
 
     steps:
       - name: Checkout

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -1,4 +1,7 @@
-var dotenv = require('dotenv');
+import dotenv from 'dotenv';
+
+import pinecone from '../dist';
+
 dotenv.config();
 
 for (const envVar of ['PINECONE_API_KEY']) {
@@ -8,23 +11,27 @@ for (const envVar of ['PINECONE_API_KEY']) {
     console.log(`INFO Found environment variable ${envVar} in .env file`);
   }
 }
-
-var pinecone = require('../dist');
-
 (async () => {
   const p = new pinecone.Pinecone();
 
   const collectionList = await p.listCollections();
-  for (const collection of collectionList.collections) {
-    console.log(`Deleting collection ${collection.name}`);
-    await p.deleteCollection(collection.name);
+  if (collectionList.collections) {
+    for (const collection of collectionList.collections) {
+      console.log(`Deleting collection ${collection.name}`);
+      await p.deleteCollection(collection.name);
+    }
   }
 
   const response = await p.listIndexes();
-  for (const index of response.indexes) {
-    console.log(`Deleting index ${index.name}`);
-    await p.deleteIndex(index.name);
-  }
+  if (response.indexes) {
+    for (const index of response.indexes) {
+      if (index.deletionProtection == 'enabled') {
+        index.deletionProtection = 'disabled';
+      }
+      console.log(`Deleting index ${index.name}`);
+      await p.deleteIndex(index.name);
+    }
 
-  process.exit();
+    process.exit();
+  }
 })();

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -1,6 +1,6 @@
-var dotenv = require('dotenv');
+const dotenv = require('dotenv');
 
-var pinecone = require('../dist');
+const pinecone = require('../dist');
 
 dotenv.config();
 
@@ -26,7 +26,7 @@ for (const envVar of ['PINECONE_API_KEY']) {
   if (response.indexes) {
     for (const index of response.indexes) {
       if (index.deletionProtection == 'enabled') {
-        index.deletionProtection = 'disabled';
+        p.configureIndex(index.name, { deletionProtection: 'disabled' });
       }
       console.log(`Deleting index ${index.name}`);
       await p.deleteIndex(index.name);

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+var dotenv = require('dotenv');
 
-import pinecone from '../dist';
+var pinecone = require('../dist');
 
 dotenv.config();
 

--- a/utils/cleanupResources.ts
+++ b/utils/cleanupResources.ts
@@ -25,13 +25,19 @@ for (const envVar of ['PINECONE_API_KEY']) {
   const response = await p.listIndexes();
   if (response.indexes) {
     for (const index of response.indexes) {
-      if (index.deletionProtection == 'enabled') {
-        p.configureIndex(index.name, { deletionProtection: 'disabled' });
+      if (index.deletionProtection === 'enabled') {
+        console.log(
+          'Changing deletionProtection status for index...',
+          index.name
+        );
+        await p.configureIndex(index.name, { deletionProtection: 'disabled' });
+        console.log(`Deleting index ${index.name}...`);
+        await p.deleteIndex(index.name);
+      } else {
+        console.log(`Deleting index ${index.name}`);
+        await p.deleteIndex(index.name);
       }
-      console.log(`Deleting index ${index.name}`);
-      await p.deleteIndex(index.name);
     }
-
     process.exit();
   }
 })();

--- a/utils/replInit.ts
+++ b/utils/replInit.ts
@@ -2,7 +2,7 @@
 // and import top level exports of the built version of the library so it can be easily used for
 // manual testing. It will typically be invoked via `npm run repl`.
 
-var dotenv = require('dotenv');
+const dotenv = require('dotenv');
 dotenv.config();
 
 const expectedVars = ['PINECONE_API_KEY'];
@@ -14,8 +14,8 @@ for (const envVar of expectedVars) {
   }
 }
 
-var myrepl = require('repl').start();
-var pinecone = require('../dist');
+const myrepl = require('repl').start();
+const pinecone = require('../dist');
 
 // Automatically import all top-level exports from the built version of the library.
 for (const [key, value] of Object.entries(pinecone)) {


### PR DESCRIPTION
## Problem

Currently, the `cleanupResources` script [fails](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/10623637432/job/29452705669?pr=278) to delete some indexes that spin up during our integration test suite because some of these indexes have `deletionProtection` `enabled`. 

## Solution

Check for `deletionProtection` being `enabled`; if it is, set it to `disabled`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208192096733434
  - https://app.asana.com/0/0/1208186698556887