### PR TITLE
Remove extra logging from getFetch()

### DIFF
--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -10,9 +10,6 @@ export const getFetch = (config: PineconeConfiguration) => {
     // scope, use that. This should prevent confusing failures in
     // nextjs projects where @vercel/fetch is mandated and
     // other implementations are stubbed out.
-    console.log(
-      'Failed to find any user-provided fetch implementation. Using global fetch implementation.'
-    );
     return global.fetch;
   } else {
     throw new PineconeConfigurationError(


### PR DESCRIPTION
## Problem

getFetch() contained an extra log statement which is executed every time the API is used.

## Solution

Remove the log

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran code that accessed and interacted with Pinecone (fetched index, queried vectors)
