### PR TITLE
Perform housekeeping on RC Github worfklow

### DIFF
--- a/.github/actions/npm-rc-release/action.yml
+++ b/.github/actions/npm-rc-release/action.yml
@@ -23,9 +23,9 @@ runs:
         git config --global user.name "${{ inputs.git_username }}"
     - name: 'Bump version'
       shell: bash
-      run: npm version prerelease --preid=rc."${{ inputs.nameRc }}" --no-git-tag-version
+      run: npm version prerelease --preid=rc."${{ inputs.rc_name }}" --no-git-tag-version
     - name: 'Publish to npm'
-      run: npm publish
+      run: npm publish --tag=RC
       shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs.npm_token }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -3,7 +3,7 @@ name: 'Release RC build'
 on:
   workflow_dispatch:
     inputs:
-      nameRc:
+      rc_name:
         description: 'Input which RC your code changes are for'
         required: true
         type: string
@@ -32,4 +32,4 @@ jobs:
           git_email: clients@pinecone.io
           git_username: ${{ github.actor }}
           npm_token: ${{ secrets.NPM_TOKEN }}
-          nameRc: ${{ inputs.nameRc }}
+          nameRc: ${{ inputs.rc_name }}


### PR DESCRIPTION
## Problem

On [a recent RC release run](https://github.com/pinecone-io/pinecone-ts-client/actions/runs/11018817395), we ran into warnings about the variable `nameRc`. We also noticed that the current RC Github workflow automatically labels the RC build as the `latest` version on `npm` by way of not specifying a `--tag`. 

## Solution

This PR changes `nameRc` to `rc_name` and adds a `--tag=RC` to the `npm publish` step, so that all RC builds have an `RC` tag, instead of latest.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208381566824292
  - https://app.asana.com/0/0/1208381566824295