### PR TITLE
Refactor + bug fix for assertWithRetries mechanism

### DIFF
--- a/src/integration/control/configureIndex.test.ts
+++ b/src/integration/control/configureIndex.test.ts
@@ -1,6 +1,6 @@
 import { BasePineconeError, PineconeBadRequestError } from '../../errors';
 import { Pinecone } from '../../index';
-import { randomIndexName, waitUntilReady } from '../test-helpers';
+import { randomIndexName, waitUntilReady } from '../testHelpers';
 
 describe('configure index', () => {
   let podIndexName, serverlessIndexName;

--- a/src/integration/control/createIndex.test.ts
+++ b/src/integration/control/createIndex.test.ts
@@ -1,6 +1,6 @@
 import { PineconeNotFoundError } from '../../errors';
 import { Pinecone } from '../../index';
-import { randomIndexName } from '../test-helpers';
+import { randomIndexName } from '../testHelpers';
 
 describe('create index', () => {
   let indexName;

--- a/src/integration/control/describeIndex.test.ts
+++ b/src/integration/control/describeIndex.test.ts
@@ -1,6 +1,6 @@
 import { PineconeNotFoundError } from '../../errors';
 import { Pinecone } from '../../index';
-import { randomIndexName } from '../test-helpers';
+import { randomIndexName } from '../testHelpers';
 
 describe('describe index', () => {
   let indexName;

--- a/src/integration/control/listIndexes.test.ts
+++ b/src/integration/control/listIndexes.test.ts
@@ -1,5 +1,5 @@
 import { Pinecone } from '../../index';
-import { randomIndexName } from '../test-helpers';
+import { randomIndexName } from '../testHelpers';
 
 describe('list indexes', () => {
   let indexName;

--- a/src/integration/data/delete.test.ts
+++ b/src/integration/data/delete.test.ts
@@ -66,7 +66,7 @@ describe('delete', () => {
       } else {
         throw new Error(
           'Did not find expected records. Fetch result was ' +
-          JSON.stringify(results)
+            JSON.stringify(results)
         );
       }
     });

--- a/src/integration/data/delete.test.ts
+++ b/src/integration/data/delete.test.ts
@@ -1,11 +1,12 @@
 import { Pinecone, Index } from '../../index';
 import {
-  assertWithRetries,
   randomString,
   generateRecords,
   INDEX_NAME,
   waitUntilRecordsReady,
-} from '../test-helpers';
+} from '../testHelpers';
+
+import { retry } from '../../utils/retry';
 
 describe('delete', () => {
   let pinecone: Pinecone,
@@ -57,108 +58,105 @@ describe('delete', () => {
     }
 
     // Look more closely at one of the records to make sure values set
-    const fetchAssertions = (results) => {
+    await retry(async () => {
+      const results = await ns.fetch(['0']);
       if (results.records) {
         expect(results.records['0'].id).toEqual('0');
         expect(results.records['0'].values.length).toEqual(5);
       } else {
-        fail(
+        throw new Error(
           'Did not find expected records. Fetch result was ' +
             JSON.stringify(results)
         );
       }
-    };
+    });
 
-    await assertWithRetries(() => ns.fetch(['0']), fetchAssertions);
-
-    // Try deleting the record
-    await ns.deleteOne('0');
-
-    // Verify the record is removed
-    const deleteAssertions = (stats) => {
-      expect(stats.namespaces[namespace]).toBeUndefined();
-    };
-
-    await assertWithRetries(() => ns.describeIndexStats(), deleteAssertions);
-  });
-
-  test('verify deleteMany with ids', async () => {
-    const recordsToUpsert = generateRecords({ dimension: 5, quantity: 3 });
-    recordIds = recordsToUpsert.map((r) => r.id);
-    expect(recordsToUpsert).toHaveLength(3);
-    expect(recordsToUpsert[0].id).toEqual('0');
-    expect(recordsToUpsert[1].id).toEqual('1');
-    expect(recordsToUpsert[2].id).toEqual('2');
-
-    await ns.upsert(recordsToUpsert);
-
-    // Await record freshness, and check records upserted
-    const stats = await waitUntilRecordsReady(ns, namespace, recordIds);
-    if (stats.namespaces) {
-      expect(stats.namespaces[namespace].recordCount).toEqual(3);
-    } else {
-      fail('Expected namespaces to be defined');
-    }
-
-    // Look more closely at one of the records to make sure values set
-    const fetchAssertions = (results) => {
-      if (results.records) {
-        expect(results.records['0'].id).toEqual('0');
-        expect(results.records['0'].values.length).toEqual(5);
-      } else {
-        fail(
-          'Did not find expected records. Fetch result was ' +
-            JSON.stringify(results)
-        );
-      }
-    };
-
-    await assertWithRetries(() => ns.fetch(['0']), fetchAssertions);
-
-    // Try deleting 2 of 3 records
-    await ns.deleteMany(['0', '2']);
-
-    const deleteAssertions = (stats) => {
-      if (stats.namespaces) {
-        expect(stats.namespaces[namespace].recordCount).toEqual(1);
-      } else {
-        fail(
-          'Expected namespaces to be defined (second call). Stats were ' +
-            JSON.stringify(stats)
-        );
-      }
-    };
-
-    await assertWithRetries(() => ns.describeIndexStats(), deleteAssertions);
-
-    // Check that record id='1' still exists
-    const fetchAssertions2 = (results) => {
-      if (results.records2) {
-        expect(results.records2['1']).not.toBeUndefined();
-      } else {
-        fail(
-          'Expected record 2 to be defined. Fetch result was ' +
-            JSON.stringify(results)
-        );
-      }
-    };
-
-    await assertWithRetries(() => ns.fetch(['1']), fetchAssertions2);
-
-    // deleting non-existent records should not throw
-    await ns.deleteMany(['0', '1', '2', '3']);
-
-    // Verify all are now removed
-    const deleteAssertions2 = (stats) => {
+    await retry(async () => {
+      await ns.deleteOne('0');
+      const stats = await ns.describeIndexStats();
       if (stats.namespaces) {
         expect(stats.namespaces[namespace]).toBeUndefined();
-      } else {
-        // no-op. This shouldn't actually happen unless there
-        // are leftover namespaces from previous runs that
-        // failed or stopped without proper cleanup.
       }
-    };
-
-    await assertWithRetries(() => ns.describeIndexStats(), deleteAssertions2);
+    });
   });
+
+  // test('verify deleteMany with ids', async () => {
+  //   const recordsToUpsert = generateRecords({ dimension: 5, quantity: 3 });
+  //   recordIds = recordsToUpsert.map((r) => r.id);
+  //   expect(recordsToUpsert).toHaveLength(3);
+  //   expect(recordsToUpsert[0].id).toEqual('0');
+  //   expect(recordsToUpsert[1].id).toEqual('1');
+  //   expect(recordsToUpsert[2].id).toEqual('2');
+  //
+  //   await ns.upsert(recordsToUpsert);
+  //
+  //   // Await record freshness, and check records upserted
+  //   const stats = await waitUntilRecordsReady(ns, namespace, recordIds);
+  //   if (stats.namespaces) {
+  //     expect(stats.namespaces[namespace].recordCount).toEqual(3);
+  //   } else {
+  //     fail('Expected namespaces to be defined');
+  //   }
+  //
+  //   // Look more closely at one of the records to make sure values set
+  //   const fetchAssertions = (results) => {
+  //     if (results.records) {
+  //       expect(results.records['0'].id).toEqual('0');
+  //       expect(results.records['0'].values.length).toEqual(5);
+  //     } else {
+  //       fail(
+  //         'Did not find expected records. Fetch result was ' +
+  //           JSON.stringify(results)
+  //       );
+  //     }
+  //   };
+  //
+  //   await retry(() => ns.fetch(['0']), fetchAssertions);
+  //
+  //   // Try deleting 2 of 3 records
+  //   await ns.deleteMany(['0', '2']);
+  //
+  //   const deleteAssertions = (stats) => {
+  //     if (stats.namespaces) {
+  //       expect(stats.namespaces[namespace].recordCount).toEqual(1);
+  //     } else {
+  //       fail(
+  //         'Expected namespaces to be defined (second call). Stats were ' +
+  //           JSON.stringify(stats)
+  //       );
+  //     }
+  //   };
+  //
+  //   await retry(() => ns.describeIndexStats(), deleteAssertions);
+  //
+  //   // Check that record id='1' still exists
+  //   const fetchAssertions2 = (results) => {
+  //     if (results.records2) {
+  //       expect(results.records2['1']).not.toBeUndefined();
+  //     } else {
+  //       fail(
+  //         'Expected record 2 to be defined. Fetch result was ' +
+  //           JSON.stringify(results)
+  //       );
+  //     }
+  //   };
+  //
+  //   await retry(() => ns.fetch(['1']), fetchAssertions2);
+  //
+  //   // deleting non-existent records should not throw
+  //   await ns.deleteMany(['0', '1', '2', '3']);
+  //
+  //   // Verify all are now removed
+  //   const deleteAssertions2 = (stats) => {
+  //     if (stats.namespaces) {
+  //       expect(stats.namespaces[namespace]).toBeUndefined();
+  //     } else {
+  //       // no-op. This shouldn't actually happen unless there
+  //       // are leftover namespaces from previous runs that
+  //       // failed or stopped without proper cleanup.
+  //     }
+  //   };
+  //
+  //   await retry(() => ns.describeIndexStats(), deleteAssertions2);
+  // });
 });

--- a/src/integration/data/delete.test.ts
+++ b/src/integration/data/delete.test.ts
@@ -1,8 +1,8 @@
-import { Pinecone, Index } from '../../index';
+import { Index, Pinecone } from '../../index';
 import {
-  randomString,
   generateRecords,
   INDEX_NAME,
+  randomString,
   waitUntilRecordsReady,
 } from '../testHelpers';
 
@@ -66,7 +66,7 @@ describe('delete', () => {
       } else {
         throw new Error(
           'Did not find expected records. Fetch result was ' +
-            JSON.stringify(results)
+          JSON.stringify(results)
         );
       }
     });
@@ -80,83 +80,92 @@ describe('delete', () => {
     });
   });
 
-  // test('verify deleteMany with ids', async () => {
-  //   const recordsToUpsert = generateRecords({ dimension: 5, quantity: 3 });
-  //   recordIds = recordsToUpsert.map((r) => r.id);
-  //   expect(recordsToUpsert).toHaveLength(3);
-  //   expect(recordsToUpsert[0].id).toEqual('0');
-  //   expect(recordsToUpsert[1].id).toEqual('1');
-  //   expect(recordsToUpsert[2].id).toEqual('2');
-  //
-  //   await ns.upsert(recordsToUpsert);
-  //
-  //   // Await record freshness, and check records upserted
-  //   const stats = await waitUntilRecordsReady(ns, namespace, recordIds);
-  //   if (stats.namespaces) {
-  //     expect(stats.namespaces[namespace].recordCount).toEqual(3);
-  //   } else {
-  //     fail('Expected namespaces to be defined');
-  //   }
-  //
-  //   // Look more closely at one of the records to make sure values set
-  //   const fetchAssertions = (results) => {
-  //     if (results.records) {
-  //       expect(results.records['0'].id).toEqual('0');
-  //       expect(results.records['0'].values.length).toEqual(5);
-  //     } else {
-  //       fail(
-  //         'Did not find expected records. Fetch result was ' +
-  //           JSON.stringify(results)
-  //       );
-  //     }
-  //   };
-  //
-  //   await retry(() => ns.fetch(['0']), fetchAssertions);
-  //
-  //   // Try deleting 2 of 3 records
-  //   await ns.deleteMany(['0', '2']);
-  //
-  //   const deleteAssertions = (stats) => {
-  //     if (stats.namespaces) {
-  //       expect(stats.namespaces[namespace].recordCount).toEqual(1);
-  //     } else {
-  //       fail(
-  //         'Expected namespaces to be defined (second call). Stats were ' +
-  //           JSON.stringify(stats)
-  //       );
-  //     }
-  //   };
-  //
-  //   await retry(() => ns.describeIndexStats(), deleteAssertions);
-  //
-  //   // Check that record id='1' still exists
-  //   const fetchAssertions2 = (results) => {
-  //     if (results.records2) {
-  //       expect(results.records2['1']).not.toBeUndefined();
-  //     } else {
-  //       fail(
-  //         'Expected record 2 to be defined. Fetch result was ' +
-  //           JSON.stringify(results)
-  //       );
-  //     }
-  //   };
-  //
-  //   await retry(() => ns.fetch(['1']), fetchAssertions2);
-  //
-  //   // deleting non-existent records should not throw
-  //   await ns.deleteMany(['0', '1', '2', '3']);
-  //
-  //   // Verify all are now removed
-  //   const deleteAssertions2 = (stats) => {
-  //     if (stats.namespaces) {
-  //       expect(stats.namespaces[namespace]).toBeUndefined();
-  //     } else {
-  //       // no-op. This shouldn't actually happen unless there
-  //       // are leftover namespaces from previous runs that
-  //       // failed or stopped without proper cleanup.
-  //     }
-  //   };
-  //
-  //   await retry(() => ns.describeIndexStats(), deleteAssertions2);
-  // });
+  test('verify deleteMany with ids', async () => {
+    const recordsToUpsert = generateRecords({ dimension: 5, quantity: 3 });
+    recordIds = recordsToUpsert.map((r) => r.id);
+    expect(recordsToUpsert).toHaveLength(3);
+    expect(recordsToUpsert[0].id).toEqual('0');
+    expect(recordsToUpsert[1].id).toEqual('1');
+    expect(recordsToUpsert[2].id).toEqual('2');
+
+    await ns.upsert(recordsToUpsert);
+
+    // Await record freshness, and check records upserted
+    const stats = await waitUntilRecordsReady(ns, namespace, recordIds);
+
+    if (stats.namespaces) {
+      expect(stats.namespaces[namespace].recordCount).toEqual(3);
+    } else {
+      fail('Expected namespaces to be defined');
+    }
+
+    // Look more closely at one of the records to make sure values set
+    await retry(async () => {
+      const resp = await ns.fetch(['0']);
+      if (resp.records) {
+        expect(resp.records['0'].id).toEqual('0');
+        expect(resp.records['0'].values.length).toEqual(5);
+      } else {
+        fail(
+          'Did not find expected records. Fetch result was ' +
+            JSON.stringify(resp)
+        );
+      }
+    });
+
+    // Try deleting 2 of 3 records
+    await ns.deleteMany(['0', '2']);
+
+    await retry(async () => {
+      const stats = await ns.describeIndexStats();
+      if (stats.namespaces) {
+        expect(stats.namespaces[namespace].recordCount).toEqual(1);
+      } else {
+        fail(
+          'Expected namespaces to be defined (second call). Stats were ' +
+            JSON.stringify(stats)
+        );
+      }
+    });
+
+    await retry(async () => {
+      const results = await ns.fetch(['1']);
+      if (results.records) {
+        expect(results.records['1']).not.toBeUndefined();
+      } else {
+        fail(
+          'Expected record 2 to be defined. Fetch result was ' +
+            JSON.stringify(results)
+        );
+      }
+    });
+
+    // Check that record id='1' still exists
+    await retry(async () => {
+      const results = await ns.fetch(['1']);
+      if (results.records) {
+        expect(results.records['1']).not.toBeUndefined();
+      } else {
+        fail(
+          'Expected record 2 to be defined. Fetch result was ' +
+            JSON.stringify(results)
+        );
+      }
+    });
+
+    // deleting non-existent records should not throw
+    await ns.deleteMany(['0', '1', '2', '3']);
+
+    // Verify all are now removed
+    await retry(async () => {
+      const stats = await ns.describeIndexStats();
+      if (stats.namespaces) {
+        expect(stats.namespaces[namespace]).toBeUndefined();
+      } else {
+        // no-op. This shouldn't actually happen unless there
+        // are leftover namespaces from previous runs that
+        // failed or stopped without proper cleanup.
+      }
+    });
+  });
 });

--- a/src/integration/data/fetch.test.ts
+++ b/src/integration/data/fetch.test.ts
@@ -4,7 +4,7 @@ import {
   randomString,
   INDEX_NAME,
   waitUntilRecordsReady,
-} from '../test-helpers';
+} from '../testHelpers';
 
 describe('fetch', () => {
   let pinecone: Pinecone,

--- a/src/integration/data/list.test.ts
+++ b/src/integration/data/list.test.ts
@@ -4,7 +4,7 @@ import {
   randomString,
   INDEX_NAME,
   waitUntilRecordsReady,
-} from '../test-helpers';
+} from '../testHelpers';
 
 describe('list', () => {
   let pinecone: Pinecone,

--- a/src/integration/data/query.test.ts
+++ b/src/integration/data/query.test.ts
@@ -1,11 +1,12 @@
-import { Pinecone, Index } from '../../index';
+import { Index, Pinecone } from '../../index';
 import {
-  randomString,
   generateRecords,
   INDEX_NAME,
+  randomString,
   waitUntilRecordsReady,
-  assertWithRetries,
-} from '../test-helpers';
+} from '../testHelpers';
+
+import { retry } from '../../utils/retry';
 
 describe('query', () => {
   let pinecone: Pinecone,
@@ -21,7 +22,7 @@ describe('query', () => {
     await pinecone.createIndex({
       name: INDEX_NAME,
       dimension: 5,
-      metric: 'cosine',
+      metric: 'dotproduct',
       spec: {
         serverless: {
           region: 'us-west-2',
@@ -60,63 +61,62 @@ describe('query', () => {
   test('query by id', async () => {
     const topK = 2;
     const queryId = recordIds[0];
-    const assertions = (results) => {
+
+    await retry(async () => {
+      const results = await ns.query({ id: queryId, topK });
       expect(results.matches).toBeDefined();
       expect(results.matches?.length).toEqual(topK);
-      expect(results.usage.readUnits).toBeDefined();
+      if (results.usage) {
+        expect(results.usage.readUnits).toBeDefined();
+      }
       expect(results.matches).toEqual(
         expect.arrayContaining([expect.objectContaining({ id: queryId })])
       );
-    };
-
-    await assertWithRetries(() => ns.query({ id: queryId, topK }), assertions);
+    });
   });
 
   test('query when topK is greater than number of records', async () => {
     const topK = numberOfRecords + 2;
     const queryId = recordIds[1];
-    const assertions = (results) => {
+
+    await retry(async () => {
+      const results = await ns.query({ id: queryId, topK });
       expect(results.matches).toBeDefined();
       expect(results.matches?.length).toEqual(numberOfRecords);
-      expect(results.usage.readUnits).toBeDefined();
-    };
-
-    await assertWithRetries(() => ns.query({ id: queryId, topK }), assertions);
+      if (results.usage) {
+        expect(results.usage.readUnits).toBeDefined();
+      }
+    });
   });
 
   test('with invalid id, returns empty results', async () => {
     const topK = 2;
-    const assertions = (results) => {
+
+    await retry(async () => {
+      const results = await ns.query({ id: '12354523423', topK });
       expect(results.matches).toBeDefined();
       expect(results.matches?.length).toEqual(0);
-    };
-
-    await assertWithRetries(
-      () => ns.query({ id: '12354523423', topK }),
-      assertions
-    );
+    });
   });
 
   test('query with vector and sparseVector values', async () => {
     const topK = 1;
-    const assertions = (results) => {
+
+    await retry(async () => {
+      const results = await ns.query({
+        vector: [0.11, 0.22, 0.33, 0.44, 0.55],
+        sparseVector: {
+          indices: [32, 5, 3, 2, 1],
+          values: [0.11, 0.22, 0.33, 0.44, 0.55],
+        },
+        topK,
+      });
       expect(results.matches).toBeDefined();
       expect(results.matches?.length).toEqual(topK);
-      expect(results.usage.readUnits).toBeDefined();
-    };
-
-    await assertWithRetries(
-      () =>
-        ns.query({
-          vector: [0.11, 0.22, 0.33, 0.44, 0.55],
-          sparseVector: {
-            indices: [32, 5, 3, 2, 1],
-            values: [0.11, 0.22, 0.33, 0.44, 0.55],
-          },
-          topK,
-        }),
-      assertions
-    );
+      if (results.usage) {
+        expect(results.usage.readUnits).toBeDefined();
+      }
+    });
   });
 
   test('query with includeValues: true', async () => {
@@ -126,22 +126,19 @@ describe('query', () => {
       values: Array.from({ length: 5 }, () => Math.random()),
     };
 
-    const assertions = (results) => {
+    await retry(async () => {
+      const results = await ns.query({
+        vector: queryVec,
+        sparseVector: sparseVec,
+        topK: 2,
+        includeValues: true,
+        includeMetadata: true,
+      });
       expect(results.matches).toBeDefined();
       expect(results.matches?.length).toEqual(2);
-      expect(results.usage.readUnits).toBeDefined();
-    };
-
-    await assertWithRetries(
-      () =>
-        ns.query({
-          vector: queryVec,
-          sparseVector: sparseVec,
-          topK: 2,
-          includeValues: true,
-          includeMetadata: true,
-        }),
-      assertions
-    );
+      if (results.usage) {
+        expect(results.usage.readUnits).toBeDefined();
+      }
+    });
   });
 });

--- a/src/integration/data/upsertAndUpdate.test.ts
+++ b/src/integration/data/upsertAndUpdate.test.ts
@@ -1,11 +1,12 @@
 import { Pinecone, Index } from '../../index';
 import {
-  assertWithRetries,
   randomString,
   generateRecords,
   INDEX_NAME,
   waitUntilRecordsReady,
-} from '../test-helpers';
+} from '../testHelpers';
+
+import { retry } from '../../utils/retry';
 
 describe('upsert and update', () => {
   let pinecone: Pinecone,
@@ -55,16 +56,12 @@ describe('upsert and update', () => {
     await ns.upsert(recordToUpsert);
     await waitUntilRecordsReady(ns, namespace, recordIds);
 
-    // Fetch and inspect records to validate upsert
-    const preUpdateAssertions = (response) => {
-      expect(response.records['0']).toBeDefined();
-      expect(response.records['0'].values).toEqual(recordToUpsert[0].values);
-      expect(response.records['0'].metadata).toEqual(
-        recordToUpsert[0].metadata
-      );
-    };
-
-    await assertWithRetries(() => ns.fetch(recordIds), preUpdateAssertions);
+    await retry(async () => {
+      const results = await ns.fetch(recordIds);
+      expect(results.records['0']).toBeDefined();
+      expect(results.records['0'].values).toEqual(recordToUpsert[0].values);
+      expect(results.records['0'].metadata).toEqual(recordToUpsert[0].metadata);
+    });
 
     // Update record values
     const newValues = [0.5, 0.4, 0.3, 0.2, 0.1];
@@ -75,14 +72,13 @@ describe('upsert and update', () => {
       metadata: newMetadata,
     });
 
-    const postUpdateAssertions = (response) => {
-      expect(response.records['0'].values).toEqual(newValues);
-      expect(response.records['0'].metadata).toEqual({
+    await retry(async () => {
+      const results = await ns.fetch(['0']);
+      expect(results.records['0'].values).toEqual(newValues);
+      expect(results.records['0'].metadata).toEqual({
         ...oldMetadata,
         ...newMetadata,
       });
-    };
-
-    await assertWithRetries(() => ns.fetch(['0']), postUpdateAssertions);
+    });
   });
 });

--- a/src/integration/testHelpers.ts
+++ b/src/integration/testHelpers.ts
@@ -132,31 +132,3 @@ export const waitUntilRecordsReady = async (
 
   return indexStats;
 };
-
-type Assertions = (result: any) => void;
-
-export const assertWithRetries = async (
-  asyncFn: () => Promise<any>,
-  assertionsFn: Assertions,
-  maxRetries: number = 5,
-  delay: number = 3000
-) => {
-  let attempts = 0;
-
-  while (attempts < maxRetries) {
-    try {
-      const result = await asyncFn();
-      assertionsFn(result);
-      return;
-    } catch (error) {
-      attempts++;
-      if (attempts <= maxRetries) {
-        await sleep(delay);
-        // Double the delay for exponential backoff
-        delay *= 2;
-      } else {
-        throw error;
-      }
-    }
-  }
-};

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -2,8 +2,8 @@ import { sleep } from '../../integration/testHelpers';
 import { retry } from '../retry';
 
 // Mock only `sleep`, keep other functions in testHelpers.ts as-is
-jest.mock('../testHelpers', () => ({
-  ...jest.requireActual('../testHelpers'),
+jest.mock('../../integration/testHelpers', () => ({
+  ...jest.requireActual('../../integration/testHelpers'),
   sleep: jest.fn().mockResolvedValue(undefined), // Directly mock sleep here
 }));
 

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -1,0 +1,56 @@
+import { sleep } from '../../integration/testHelpers';
+import { retry } from '../retry';
+
+// Mock only `sleep`, keep other functions in testHelpers.ts as-is
+jest.mock('../testHelpers', () => ({
+  ...jest.requireActual('../testHelpers'),
+  sleep: jest.fn().mockResolvedValue(undefined), // Directly mock sleep here
+}));
+
+describe('retry function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks(); // Clear mocks between tests
+  });
+
+  // Unit test
+  test('Should call asyncFn once if it succeeds initially', async () => {
+    const asyncFn = jest.fn().mockResolvedValue('success');
+    const result = await retry(asyncFn);
+    expect(asyncFn).toHaveBeenCalledTimes(1);
+    expect(result).toBe('success');
+  });
+
+  // Unit test
+  test('Should retry if asyncFn fails initially but eventually succeeds', async () => {
+    const asyncFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('First try failed'))
+      .mockResolvedValue('success');
+
+    const result = await retry(asyncFn);
+    expect(asyncFn).toHaveBeenCalledTimes(2);
+    expect(result).toBe('success');
+  });
+
+  // Unit Test
+  test('Should throw an error if maxRetries is reached', async () => {
+    const asyncFn = jest.fn().mockRejectedValue(new Error('Some failure'));
+    await expect(retry(asyncFn, 3, 10)).rejects.toThrowError('Some failure');
+    expect(asyncFn).toHaveBeenCalledTimes(3);
+  });
+
+  // Unit Test
+  test('Delay should increase exponentially with each retry', async () => {
+    const asyncFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Failing function')) // 1st attempt fails
+      .mockRejectedValueOnce(new Error('Failing function')) // 2nd attempt fails
+      .mockRejectedValueOnce(new Error('Failing function')) // 3rd attempt fails
+      .mockResolvedValue('success'); // 4th attempt succeeds
+
+    await retry(asyncFn, 5, 10, sleep);
+    expect(sleep).toHaveBeenCalledWith(10);
+    expect(sleep).toHaveBeenCalledWith(20);
+    expect(sleep).toHaveBeenCalledWith(40);
+  });
+});

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,24 @@
+import { sleep } from '../integration/testHelpers';
+
+export const retry = async (
+  asyncFn: () => Promise<any>,
+  maxRetries: number = 5,
+  delay: number = 3000,
+  sleepFn = sleep
+) => {
+  let attempts = 0;
+
+  while (attempts < maxRetries) {
+    try {
+      return await asyncFn();
+    } catch (error) {
+      attempts++;
+      if (attempts < maxRetries) {
+        const expDelay = delay * Math.pow(2, attempts - 1); // Exponential backoff
+        await sleepFn(expDelay);
+      } else {
+        throw error as Error;
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Problem

We uncovered a bug with the current implementation of a test helper called `assertWithRetries` where it does not seem to be acting as expected, resulting in hanging behavior.

## Solution

1. Since this helper function is likely useful to our users more generally, I moved it into `utils` for easier discoverability.
2. I changed the signature of the function to just focus on retries (instead of retries + asserts). I think the function itself is cleaner this way, separates concerns, and is simpler to test. One can still pass whatever`assertions` they want to the `retry` function by way of the `asyncFn` param, which is still in the signature.
3. I changed the `<=` to `<`, since that seemed to be the root of the problem -- the function would never enter the final `else` statement, since when `attempts` === `maxRetries`, it became truthy and returned a resolved Promise, even though that Promise's value was `undefined`. 
4. I added unit tests to ensure this function works as expected.
5. A comment in the original code let me to believe the intent w/this function was to have an _exponential_ `delay` in it, but the current `delay` was actually multiplicative; it's now actually exponential.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

New unit tests pass + existing integration tests that made use of `assertWithRetries` pass w/the new function.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208439494339500