### PR TITLE
Remove "bulk" language from README wrt `Import` operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ In order to import vectors from object storage, they must be stored in Parquet f
 [file format](https://docs.pinecone.io/guides/data/understanding-imports#parquet-file-format). Your object storage
 must also adhere to the necessary [directory structure](https://docs.pinecone.io/guides/data/understanding-imports#directory-structure).
 
-The following example imports 10 vectors from an Amazon S3 bucket into a Pinecone serverless index:
+The following example imports vectors from an Amazon S3 bucket into a Pinecone serverless index:
 
 ```typescript
 import { Pinecone } from '@pinecone-database/pinecone';

--- a/README.md
+++ b/README.md
@@ -693,10 +693,10 @@ const vectors = [
 await index.upsert(vectors);
 ```
 
-### Bulk import vectors from object storage
+### Import vectors from object storage
 
 You can now [import vectors en masse](https://docs.pinecone.io/guides/data/understanding-imports) from object
-storage. Bulk Import is a long-running, asynchronous operation that imports large numbers of records into a Pinecone
+storage. `Import` is a long-running, asynchronous operation that imports large numbers of records into a Pinecone
 serverless index.
 
 In order to import vectors from object storage, they must be stored in Parquet files and adhere to the necessary
@@ -737,8 +737,8 @@ You can [start, cancel, and check the status](https://docs.pinecone.io/guides/da
 
 **Notes:**
 
-- Bulk Import only works with Serverless indexes
-- Bulk Import is in [public preview](https://docs.pinecone.io/release-notes/feature-availability)
+- `Import` only works with Serverless indexes
+- `Import` is in [public preview](https://docs.pinecone.io/release-notes/feature-availability)
 - The only object storage provider currently supported is [Amazon S3](https://docs.pinecone.io/guides/operations/integrations/integrate-with-amazon-s3)
 - Vectors will take _at least 10 minutes_ to appear in your index upon completion of the import operation, since
   this operation is optimized for very large workloads

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -25,7 +25,6 @@ import { ListImportsCommand } from './bulk/listImports';
 import { DescribeImportCommand } from './bulk/describeImport';
 import { CancelImportCommand } from './bulk/cancelImport';
 import { BulkOperationsProvider } from './bulk/bulkOperationsProvider';
-import { prerelease } from '../utils/prerelease';
 
 export type {
   PineconeConfiguration,
@@ -564,7 +563,6 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * even if some records fail to import. To inspect failures in "Continue" mode, send a request to {@link listImports}. Pass
    * "Abort" to stop the import operation if any records fail to import.
    */
-  @prerelease('2024-10')
   async startImport(uri: string, errorMode?: string, integration?: string) {
     return await this._startImportCommand.run(uri, errorMode, integration);
   }
@@ -599,7 +597,6 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    * @param limit - (Optional) Max number of import operations to return per page.
    * @param paginationToken - (Optional) Pagination token to continue a previous listing operation.
    */
-  @prerelease('2024-10')
   async listImports(limit?: number, paginationToken?: string) {
     return await this._listImportsCommand.run(limit, paginationToken);
   }
@@ -628,7 +625,6 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @param id - The id of the import operation to describe.
    */
-  @prerelease('2024-10')
   async describeImport(id: string) {
     return await this._describeImportCommand.run(id);
   }
@@ -648,7 +644,6 @@ export class Index<T extends RecordMetadata = RecordMetadata> {
    *
    * @param id - The id of the import operation to cancel.
    */
-  @prerelease('2024-10')
   async cancelImport(id: string) {
     return await this._cancelImportCommand.run(id);
   }


### PR DESCRIPTION
## Summary

We have decided to remove the word "bulk" from our language when talking about `Import` operations.

## Note
- Also decided to clean up the `prerelease` tags for `Import` ops, so you'll see a commit removing those in this PR, too.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208585802928336
  - https://app.asana.com/0/0/1208543496626632