### PR TITLE
Refactor `listPaginated` tests + make README clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,7 +931,7 @@ Notes:
 
 - When you do not specify a `prefix`, the default prefix is an empty string, which returns all vector IDs
   in your index
-- There is a hard limit of `300` vector IDs if no `limit` is specified. Consequently, if there are fewer than `300`
+- There is a hard limit of `100` vector IDs if no `limit` is specified. Consequently, if there are fewer than `100`
   vector IDs that match a given `prefix` in your index, and you do not specify a `limit`, your `paginationToken`
   will be `undefined`
 

--- a/README.md
+++ b/README.md
@@ -935,14 +935,14 @@ Notes:
   vector IDs that match a given `prefix` in your index, and you do not specify a `limit`, your `paginationToken`
   will be `undefined`
 
-The following example shows how to grab both pages of vector IDs for vectors whose IDs contain the prefix `doc1#`,
+The following example shows how to fetch both pages of vector IDs for vectors whose IDs contain the prefix `doc1#`,
 assuming a `limit` of `3` and `doc1` document being [chunked](https://www.pinecone.io/learn/chunking-strategies/) into `4` vectors.
 
 ```typescript
 const pc = new Pinecone();
 const index = pc.index('my-index').namespace('my-namespace');
 
-// Grab the 1st 3 vector IDs matching prefix 'doc1#'
+// Fetch the 1st 3 vector IDs matching prefix 'doc1#'
 const results = await index.listPaginated({ limit: 3, prefix: 'doc1#' });
 console.log(results);
 // {
@@ -959,7 +959,7 @@ console.log(results);
 //   usage: { readUnits: 1 }
 // }
 
-// Grab the final vector ID matching prefix 'doc1#' using the paginationToken returned by the previous call
+// Fetch the final vector ID matching prefix 'doc1#' using the paginationToken returned by the previous call
 const nextResults = await index.listPaginated({
   prefix: 'doc1#',
   paginationToken: results.pagination?.next,

--- a/src/integration/data/vectors/list.test.ts
+++ b/src/integration/data/vectors/list.test.ts
@@ -18,7 +18,8 @@ describe('listPaginated, serverless index', () => {
   test('test listPaginated with no arguments', async () => {
     const listResults = await serverlessIndex.listPaginated();
     expect(listResults).toBeDefined();
-    // expect(listResults.pagination).toBeDefined(); todo: re-enable this once pagination bug is fixed (https://app.asana.com/0/1204819992273155/1207992392793971/f)
+    expect(listResults.pagination).toBeUndefined(); // Only 11 records in the index, so no pag token returned; 300
+    // is when a pag token is automatically returned b/c that's the hard limit of vector to return on the server side
     expect(listResults.vectors?.length).toBe(11);
     expect(listResults.namespace).toBe(globalNamespaceOne);
   });
@@ -29,7 +30,7 @@ describe('listPaginated, serverless index', () => {
     });
     expect(listResults.namespace).toBe(globalNamespaceOne);
     expect(listResults.vectors?.length).toBe(1);
-    // expect(listResults.pagination).toBeDefined(); todo: re-enable this once pagination bug is fixed (https://app.asana.com/0/1204819992273155/1207992392793971/f)
+    expect(listResults.pagination).toBeUndefined();
   });
 
   test('test listPaginated with limit and pagination', async () => {
@@ -39,7 +40,7 @@ describe('listPaginated, serverless index', () => {
     });
     expect(listResults.namespace).toBe(globalNamespaceOne);
     expect(listResults.vectors?.length).toBe(3);
-    // expect(listResults.pagination).toBeDefined(); todo: re-enable this once pagination bug is fixed (https://app.asana.com/0/1204819992273155/1207992392793971/f)
+    expect(listResults.pagination).toBeDefined();
 
     const listResultsPg2 = await serverlessIndex.listPaginated({
       prefix,

--- a/src/integration/data/vectors/list.test.ts
+++ b/src/integration/data/vectors/list.test.ts
@@ -18,8 +18,7 @@ describe('listPaginated, serverless index', () => {
   test('test listPaginated with no arguments', async () => {
     const listResults = await serverlessIndex.listPaginated();
     expect(listResults).toBeDefined();
-    expect(listResults.pagination).toBeUndefined(); // Only 11 records in the index, so no pag token returned; 300
-    // is when a pag token is automatically returned b/c that's the hard limit of vector to return on the server side
+    expect(listResults.pagination).toBeUndefined(); // Only 11 records in the index, so no pag token returned
     expect(listResults.vectors?.length).toBe(11);
     expect(listResults.namespace).toBe(globalNamespaceOne);
   });


### PR DESCRIPTION
## Problem

The core DB previously had [a race-condition bug](https://app.asana.com/0/1203260648987893/1207992392793971/f) that resulted in [pagination tokens being non-deterministically returned to the user](https://github.com/pinecone-io/pinecone-ts-client/issues/266) when they'd call the `listPaginated` endpoint (not just in the TS client). 

## Solution

The core DB team has [fixed this bug](https://github.com/pinecone-io/pinecone-db/pull/7285). Now that it's fixed, this PR updates previously-commented-out tests + updates the README to be more precise regarding how this method works. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208246198758491