### PR TITLE
Remove extra call to delete an already-deleted index in `bulkImport` integration test

### DIFF
--- a/src/integration/data/bulk/bulkImport.test.ts
+++ b/src/integration/data/bulk/bulkImport.test.ts
@@ -27,7 +27,6 @@ describe('bulk import', () => {
 
   afterAll(async () => {
     await retryDeletes(pinecone, indexName);
-    await pinecone.deleteIndex(indexName);
   });
 
   test('verify bulk import', async () => {


### PR DESCRIPTION
## Problem

We kept getting errors in CI that part of the `bulkImport` integration test was failing because it could not find the given index name. 

## Solution

Turns out, we accidentally left in an extra call to `delete` after we had already deleted the index! This PR just removes that call :)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes w/flying colors 🚀 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208633891828391