### PR TITLE
Remove `git submodule` cmds and update Vercel cmds in `external-app` tests

### DIFF
--- a/.github/actions/external-app/edge/action.yml
+++ b/.github/actions/external-app/edge/action.yml
@@ -53,7 +53,7 @@ runs:
         cd ts-client-test-external-app
         npm install --global vercel@latest
         echo "installed vercel with npm"
-        vercel --token ${{ inputs.vercel-token }}
+        vercel --token ${{ inputs.vercel-token }} --yes
         echo "called vercel with token"
         vercel pull --yes --token ${{ inputs.vercel-token }}
         echo "called vercel pull"

--- a/.github/actions/external-app/edge/action.yml
+++ b/.github/actions/external-app/edge/action.yml
@@ -52,10 +52,15 @@ runs:
       run: |
         cd ts-client-test-external-app
         npm install vercel
+        echo "installed vercel with npm"
         vercel --token ${{ inputs.vercel-token }}
+        echo "called vercel with token"
         vercel pull --yes --token ${{ inputs.vercel-token }}
+        echo "called vercel pull"
         vercel build --token ${{ inputs.vercel-token }}
+        echo "called vercel build"
         vercel --token ${{ inputs.vercel-token }} --prod
+        echo "called vercel --prod"
       shell: bash
 
     - name: Hit Vercel app endpoint(s) via assertResponse.ts file

--- a/.github/actions/external-app/edge/action.yml
+++ b/.github/actions/external-app/edge/action.yml
@@ -52,15 +52,10 @@ runs:
       run: |
         cd ts-client-test-external-app
         npm install --global vercel@latest
-        echo "installed vercel with npm"
         vercel --token ${{ inputs.vercel-token }} --yes
-        echo "called vercel with token"
         vercel pull --yes --token ${{ inputs.vercel-token }}
-        echo "called vercel pull"
         vercel build --token ${{ inputs.vercel-token }}
-        echo "called vercel build"
         vercel --token ${{ inputs.vercel-token }} --prod
-        echo "called vercel --prod"
       shell: bash
 
     - name: Hit Vercel app endpoint(s) via assertResponse.ts file

--- a/.github/actions/external-app/edge/action.yml
+++ b/.github/actions/external-app/edge/action.yml
@@ -51,7 +51,7 @@ runs:
     - name: Install Vercel CLI and (re)deploy the app
       run: |
         cd ts-client-test-external-app
-        npm install vercel
+        npm install --global vercel@latest
         echo "installed vercel with npm"
         vercel --token ${{ inputs.vercel-token }}
         echo "called vercel with token"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,190 +26,190 @@ jobs:
           SERVERLESS_INDEX_NAME=$(npx ts-node ./src/integration/setup.ts | grep "SERVERLESS_INDEX_NAME=" | cut -d'=' -f2)
           echo "SERVERLESS_INDEX_NAME=$SERVERLESS_INDEX_NAME" >> $GITHUB_OUTPUT
 
-  #  unit-tests:
-  #    needs: setup
-  #    name: Run unit tests
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - name: Checkout
-  #        uses: actions/checkout@v4
-  #
-  #      - name: Setup
-  #        uses: ./.github/actions/setup
-  #
-  #      - name: Run tests
-  #        env:
-  #          CI: true
-  #        run: npm run test:unit -- --coverage
+    unit-tests:
+      needs: setup
+      name: Run unit tests
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
 
-  #  integration-tests:
-  #    needs: setup
-  #    name: Run integration tests
-  #    runs-on: ubuntu-latest
-  #    outputs:
-  #      serverlessIndexName: ${{ steps.runTests1.outputs.SERVERLESS_INDEX_NAME }}
-  #    strategy:
-  #      fail-fast: false
-  #      max-parallel: 2
-  #      matrix:
-  #        pinecone_env:
-  #          - prod
-  #          # - staging
-  #        node_version: [18.x, 20.x]
-  #        config:
-  #          [
-  #            { runner: 'npm', jest_env: 'node' },
-  #            { runner: 'npm', jest_env: 'edge' },
-  #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
-  #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
-  #            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
-  #          ]
-  #
-  #    steps:
-  #      - name: Checkout
-  #        uses: actions/checkout@v4
-  #
-  #      - name: Setup
-  #        uses: ./.github/actions/setup
-  #        with:
-  #          node_version: ${{ matrix.node_version }}
-  #
-  #      - name: Setup bun
-  #        if: matrix.config.bun_version
-  #        uses: oven-sh/setup-bun@v1
-  #        with:
-  #          bun-version: ${{ matrix.config.bun_version }}
-  #
-  #      - name: Run integration tests (Prod)
-  #        id: runTests1
-  #        if: matrix.pinecone_env == 'prod'
-  #        env:
-  #          CI: true
-  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-  #          SERVERLESS_INDEX_NAME: ${{ needs.setup.outputs.serverlessIndexName}}
-  #        run: |
-  #          ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
-  #          echo "SERVERLESS_INDEX_NAME=${{ needs.setup.outputs.serverlessIndexName}}" >> $GITHUB_OUTPUT
-  #
-  #      - name: Run integration tests (Staging)
-  #        if: matrix.pinecone_env == 'staging'
-  #        env:
-  #          CI: true
-  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-  #          PINECONE_CONTROLLER_HOST: 'https://api-staging.pinecone.io'
-  #        run: ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
+        - name: Setup
+          uses: ./.github/actions/setup
 
-  #  teardown:
-  #    name: Teardown
-  #    needs: integration-tests # Ensure teardown only runs after test jobs
-  #    runs-on: ubuntu-latest
-  #    if: always() # Run teardown even if the tests fail
-  #    steps:
-  #      - name: Checkout code
-  #        uses: actions/checkout@v4
-  #
-  #      - name: Install dependencies
-  #        run: npm ci
-  #
-  #      - name: Run teardown script
-  #        env:
-  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-  #          SERVERLESS_INDEX_NAME: ${{ needs.integration-tests.outputs.serverlessIndexName}}
-  #        run: |
-  #          npx ts-node ./src/integration/teardown.ts
+        - name: Run tests
+          env:
+            CI: true
+          run: npm run test:unit -- --coverage
 
-  #  typescript-compilation-tests:
-  #    name: TS compile
-  #    runs-on: ubuntu-latest
-  #    strategy:
-  #      fail-fast: false
-  #      matrix:
-  #        tsVersion:
-  #          [
-  #            '~4.1.0',
-  #            '~4.2.0',
-  #            '~4.3.0',
-  #            '~4.4.0',
-  #            '~4.5.0',
-  #            '~4.6.0',
-  #            '~4.7.0',
-  #            '~4.8.0',
-  #            '~4.9.0',
-  #            '~5.0.0',
-  #            '~5.1.0',
-  #            '~5.2.0',
-  #            'latest',
-  #          ]
-  #    steps:
-  #      - name: Checkout
-  #        uses: actions/checkout@v4
-  #      - name: Setup Node
-  #        uses: actions/setup-node@v4
-  #        with:
-  #          node-version: 18.x
-  #          registry-url: 'https://registry.npmjs.org'
-  #      - name: Install npm packages
-  #        run: |
-  #          npm install --ignore-scripts
-  #        shell: bash
-  #      - name: Build TypeScript for Pinecone
-  #        run: npm run build
-  #        shell: bash
-  #      - name: install, compile, and run sample app
-  #        shell: bash
-  #        env:
-  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-  #        run: |
-  #          set -x
-  #          cd ..
-  #          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
-  #          cd ts-compilation-test
-  #          npm install typescript@${{ matrix.tsVersion }} --no-cache
-  #          npm install '../pinecone-ts-client' --no-cache
-  #          cat package.json
-  #          cat package-lock.json
-  #          npm run tsc-version
-  #          npm run build
-  #          npm run start
-  #
-  #  example-app-semantic-search:
-  #    name: 'Example app: semantic search'
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - name: Checkout pinecone-ts-client
-  #        uses: actions/checkout@v4
-  #        with:
-  #          path: pinecone-ts-client
-  #      - name: Checkout semantic-search-example
-  #        uses: actions/checkout@v4
-  #        with:
-  #          repository: pinecone-io/semantic-search-example
-  #          ref: spruce
-  #          path: semantic-search-example
-  #      - name: Install and build client
-  #        shell: bash
-  #        run: |
-  #          cd pinecone-ts-client
-  #          npm install --ignore-scripts
-  #          npm run build
-  #      - name: Install and build sample app
-  #        shell: bash
-  #        run: |
-  #          cd semantic-search-example
-  #          npm install --no-cache
-  #          npm install '../pinecone-ts-client'
-  #          cat package.json
-  #      - name: Run example tests with dev version of client
-  #        env:
-  #          CI: true
-  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-  #          PINECONE_INDEX: 'semantic-search'
-  #          PINECONE_CLOUD: 'aws'
-  #          PINECONE_REGION: 'us-west-2'
-  #        shell: bash
-  #        run: |
-  #          cd semantic-search-example
-  #          npm run test
+    integration-tests:
+      needs: setup
+      name: Run integration tests
+      runs-on: ubuntu-latest
+      outputs:
+        serverlessIndexName: ${{ steps.runTests1.outputs.SERVERLESS_INDEX_NAME }}
+      strategy:
+        fail-fast: false
+        max-parallel: 2
+        matrix:
+          pinecone_env:
+            - prod
+            # - staging
+          node_version: [18.x, 20.x]
+          config:
+            [
+              { runner: 'npm', jest_env: 'node' },
+              { runner: 'npm', jest_env: 'edge' },
+              { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
+              { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
+              { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
+            ]
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup
+          uses: ./.github/actions/setup
+          with:
+            node_version: ${{ matrix.node_version }}
+
+        - name: Setup bun
+          if: matrix.config.bun_version
+          uses: oven-sh/setup-bun@v1
+          with:
+            bun-version: ${{ matrix.config.bun_version }}
+
+        - name: Run integration tests (Prod)
+          id: runTests1
+          if: matrix.pinecone_env == 'prod'
+          env:
+            CI: true
+            PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+            SERVERLESS_INDEX_NAME: ${{ needs.setup.outputs.serverlessIndexName}}
+          run: |
+            ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
+            echo "SERVERLESS_INDEX_NAME=${{ needs.setup.outputs.serverlessIndexName}}" >> $GITHUB_OUTPUT
+
+        - name: Run integration tests (Staging)
+          if: matrix.pinecone_env == 'staging'
+          env:
+            CI: true
+            PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+            PINECONE_CONTROLLER_HOST: 'https://api-staging.pinecone.io'
+          run: ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
+
+    teardown:
+      name: Teardown
+      needs: integration-tests # Ensure teardown only runs after test jobs
+      runs-on: ubuntu-latest
+      if: always() # Run teardown even if the tests fail
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Install dependencies
+          run: npm ci
+
+        - name: Run teardown script
+          env:
+            PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+            SERVERLESS_INDEX_NAME: ${{ needs.integration-tests.outputs.serverlessIndexName}}
+          run: |
+            npx ts-node ./src/integration/teardown.ts
+
+    typescript-compilation-tests:
+      name: TS compile
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          tsVersion:
+            [
+              '~4.1.0',
+              '~4.2.0',
+              '~4.3.0',
+              '~4.4.0',
+              '~4.5.0',
+              '~4.6.0',
+              '~4.7.0',
+              '~4.8.0',
+              '~4.9.0',
+              '~5.0.0',
+              '~5.1.0',
+              '~5.2.0',
+              'latest',
+            ]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Setup Node
+          uses: actions/setup-node@v4
+          with:
+            node-version: 18.x
+            registry-url: 'https://registry.npmjs.org'
+        - name: Install npm packages
+          run: |
+            npm install --ignore-scripts
+          shell: bash
+        - name: Build TypeScript for Pinecone
+          run: npm run build
+          shell: bash
+        - name: install, compile, and run sample app
+          shell: bash
+          env:
+            PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          run: |
+            set -x
+            cd ..
+            cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
+            cd ts-compilation-test
+            npm install typescript@${{ matrix.tsVersion }} --no-cache
+            npm install '../pinecone-ts-client' --no-cache
+            cat package.json
+            cat package-lock.json
+            npm run tsc-version
+            npm run build
+            npm run start
+
+    example-app-semantic-search:
+      name: 'Example app: semantic search'
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout pinecone-ts-client
+          uses: actions/checkout@v4
+          with:
+            path: pinecone-ts-client
+        - name: Checkout semantic-search-example
+          uses: actions/checkout@v4
+          with:
+            repository: pinecone-io/semantic-search-example
+            ref: spruce
+            path: semantic-search-example
+        - name: Install and build client
+          shell: bash
+          run: |
+            cd pinecone-ts-client
+            npm install --ignore-scripts
+            npm run build
+        - name: Install and build sample app
+          shell: bash
+          run: |
+            cd semantic-search-example
+            npm install --no-cache
+            npm install '../pinecone-ts-client'
+            cat package.json
+        - name: Run example tests with dev version of client
+          env:
+            CI: true
+            PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+            PINECONE_INDEX: 'semantic-search'
+            PINECONE_CLOUD: 'aws'
+            PINECONE_REGION: 'us-west-2'
+          shell: bash
+          run: |
+            cd semantic-search-example
+            npm run test
 
   external-app:
     name: external-app

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,190 +26,190 @@ jobs:
           SERVERLESS_INDEX_NAME=$(npx ts-node ./src/integration/setup.ts | grep "SERVERLESS_INDEX_NAME=" | cut -d'=' -f2)
           echo "SERVERLESS_INDEX_NAME=$SERVERLESS_INDEX_NAME" >> $GITHUB_OUTPUT
 
-  unit-tests:
-    needs: setup
-    name: Run unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  #  unit-tests:
+  #    needs: setup
+  #    name: Run unit tests
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #      - name: Checkout
+  #        uses: actions/checkout@v4
+  #
+  #      - name: Setup
+  #        uses: ./.github/actions/setup
+  #
+  #      - name: Run tests
+  #        env:
+  #          CI: true
+  #        run: npm run test:unit -- --coverage
 
-      - name: Setup
-        uses: ./.github/actions/setup
+  #  integration-tests:
+  #    needs: setup
+  #    name: Run integration tests
+  #    runs-on: ubuntu-latest
+  #    outputs:
+  #      serverlessIndexName: ${{ steps.runTests1.outputs.SERVERLESS_INDEX_NAME }}
+  #    strategy:
+  #      fail-fast: false
+  #      max-parallel: 2
+  #      matrix:
+  #        pinecone_env:
+  #          - prod
+  #          # - staging
+  #        node_version: [18.x, 20.x]
+  #        config:
+  #          [
+  #            { runner: 'npm', jest_env: 'node' },
+  #            { runner: 'npm', jest_env: 'edge' },
+  #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
+  #            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
+  #            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
+  #          ]
+  #
+  #    steps:
+  #      - name: Checkout
+  #        uses: actions/checkout@v4
+  #
+  #      - name: Setup
+  #        uses: ./.github/actions/setup
+  #        with:
+  #          node_version: ${{ matrix.node_version }}
+  #
+  #      - name: Setup bun
+  #        if: matrix.config.bun_version
+  #        uses: oven-sh/setup-bun@v1
+  #        with:
+  #          bun-version: ${{ matrix.config.bun_version }}
+  #
+  #      - name: Run integration tests (Prod)
+  #        id: runTests1
+  #        if: matrix.pinecone_env == 'prod'
+  #        env:
+  #          CI: true
+  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+  #          SERVERLESS_INDEX_NAME: ${{ needs.setup.outputs.serverlessIndexName}}
+  #        run: |
+  #          ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
+  #          echo "SERVERLESS_INDEX_NAME=${{ needs.setup.outputs.serverlessIndexName}}" >> $GITHUB_OUTPUT
+  #
+  #      - name: Run integration tests (Staging)
+  #        if: matrix.pinecone_env == 'staging'
+  #        env:
+  #          CI: true
+  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+  #          PINECONE_CONTROLLER_HOST: 'https://api-staging.pinecone.io'
+  #        run: ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
 
-      - name: Run tests
-        env:
-          CI: true
-        run: npm run test:unit -- --coverage
+  #  teardown:
+  #    name: Teardown
+  #    needs: integration-tests # Ensure teardown only runs after test jobs
+  #    runs-on: ubuntu-latest
+  #    if: always() # Run teardown even if the tests fail
+  #    steps:
+  #      - name: Checkout code
+  #        uses: actions/checkout@v4
+  #
+  #      - name: Install dependencies
+  #        run: npm ci
+  #
+  #      - name: Run teardown script
+  #        env:
+  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+  #          SERVERLESS_INDEX_NAME: ${{ needs.integration-tests.outputs.serverlessIndexName}}
+  #        run: |
+  #          npx ts-node ./src/integration/teardown.ts
 
-  integration-tests:
-    needs: setup
-    name: Run integration tests
-    runs-on: ubuntu-latest
-    outputs:
-      serverlessIndexName: ${{ steps.runTests1.outputs.SERVERLESS_INDEX_NAME }}
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        pinecone_env:
-          - prod
-          # - staging
-        node_version: [18.x, 20.x]
-        config:
-          [
-            { runner: 'npm', jest_env: 'node' },
-            { runner: 'npm', jest_env: 'edge' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.0' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.0.36' },
-            { runner: 'bun', jest_env: 'node', bun_version: '1.1.11' },
-          ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-        with:
-          node_version: ${{ matrix.node_version }}
-
-      - name: Setup bun
-        if: matrix.config.bun_version
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: ${{ matrix.config.bun_version }}
-
-      - name: Run integration tests (Prod)
-        id: runTests1
-        if: matrix.pinecone_env == 'prod'
-        env:
-          CI: true
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          SERVERLESS_INDEX_NAME: ${{ needs.setup.outputs.serverlessIndexName}}
-        run: |
-          ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
-          echo "SERVERLESS_INDEX_NAME=${{ needs.setup.outputs.serverlessIndexName}}" >> $GITHUB_OUTPUT
-
-      - name: Run integration tests (Staging)
-        if: matrix.pinecone_env == 'staging'
-        env:
-          CI: true
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          PINECONE_CONTROLLER_HOST: 'https://api-staging.pinecone.io'
-        run: ${{ matrix.config.runner }} run test:integration:${{ matrix.config.jest_env }}
-
-  teardown:
-    name: Teardown
-    needs: integration-tests # Ensure teardown only runs after test jobs
-    runs-on: ubuntu-latest
-    if: always() # Run teardown even if the tests fail
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run teardown script
-        env:
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          SERVERLESS_INDEX_NAME: ${{ needs.integration-tests.outputs.serverlessIndexName}}
-        run: |
-          npx ts-node ./src/integration/teardown.ts
-
-  typescript-compilation-tests:
-    name: TS compile
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        tsVersion:
-          [
-            '~4.1.0',
-            '~4.2.0',
-            '~4.3.0',
-            '~4.4.0',
-            '~4.5.0',
-            '~4.6.0',
-            '~4.7.0',
-            '~4.8.0',
-            '~4.9.0',
-            '~5.0.0',
-            '~5.1.0',
-            '~5.2.0',
-            'latest',
-          ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-          registry-url: 'https://registry.npmjs.org'
-      - name: Install npm packages
-        run: |
-          npm install --ignore-scripts
-        shell: bash
-      - name: Build TypeScript for Pinecone
-        run: npm run build
-        shell: bash
-      - name: install, compile, and run sample app
-        shell: bash
-        env:
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-        run: |
-          set -x
-          cd ..
-          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
-          cd ts-compilation-test
-          npm install typescript@${{ matrix.tsVersion }} --no-cache
-          npm install '../pinecone-ts-client' --no-cache
-          cat package.json
-          cat package-lock.json
-          npm run tsc-version
-          npm run build
-          npm run start
-
-  example-app-semantic-search:
-    name: 'Example app: semantic search'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout pinecone-ts-client
-        uses: actions/checkout@v4
-        with:
-          path: pinecone-ts-client
-      - name: Checkout semantic-search-example
-        uses: actions/checkout@v4
-        with:
-          repository: pinecone-io/semantic-search-example
-          ref: spruce
-          path: semantic-search-example
-      - name: Install and build client
-        shell: bash
-        run: |
-          cd pinecone-ts-client
-          npm install --ignore-scripts
-          npm run build
-      - name: Install and build sample app
-        shell: bash
-        run: |
-          cd semantic-search-example
-          npm install --no-cache
-          npm install '../pinecone-ts-client'
-          cat package.json
-      - name: Run example tests with dev version of client
-        env:
-          CI: true
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          PINECONE_INDEX: 'semantic-search'
-          PINECONE_CLOUD: 'aws'
-          PINECONE_REGION: 'us-west-2'
-        shell: bash
-        run: |
-          cd semantic-search-example
-          npm run test
+  #  typescript-compilation-tests:
+  #    name: TS compile
+  #    runs-on: ubuntu-latest
+  #    strategy:
+  #      fail-fast: false
+  #      matrix:
+  #        tsVersion:
+  #          [
+  #            '~4.1.0',
+  #            '~4.2.0',
+  #            '~4.3.0',
+  #            '~4.4.0',
+  #            '~4.5.0',
+  #            '~4.6.0',
+  #            '~4.7.0',
+  #            '~4.8.0',
+  #            '~4.9.0',
+  #            '~5.0.0',
+  #            '~5.1.0',
+  #            '~5.2.0',
+  #            'latest',
+  #          ]
+  #    steps:
+  #      - name: Checkout
+  #        uses: actions/checkout@v4
+  #      - name: Setup Node
+  #        uses: actions/setup-node@v4
+  #        with:
+  #          node-version: 18.x
+  #          registry-url: 'https://registry.npmjs.org'
+  #      - name: Install npm packages
+  #        run: |
+  #          npm install --ignore-scripts
+  #        shell: bash
+  #      - name: Build TypeScript for Pinecone
+  #        run: npm run build
+  #        shell: bash
+  #      - name: install, compile, and run sample app
+  #        shell: bash
+  #        env:
+  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+  #        run: |
+  #          set -x
+  #          cd ..
+  #          cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
+  #          cd ts-compilation-test
+  #          npm install typescript@${{ matrix.tsVersion }} --no-cache
+  #          npm install '../pinecone-ts-client' --no-cache
+  #          cat package.json
+  #          cat package-lock.json
+  #          npm run tsc-version
+  #          npm run build
+  #          npm run start
+  #
+  #  example-app-semantic-search:
+  #    name: 'Example app: semantic search'
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #      - name: Checkout pinecone-ts-client
+  #        uses: actions/checkout@v4
+  #        with:
+  #          path: pinecone-ts-client
+  #      - name: Checkout semantic-search-example
+  #        uses: actions/checkout@v4
+  #        with:
+  #          repository: pinecone-io/semantic-search-example
+  #          ref: spruce
+  #          path: semantic-search-example
+  #      - name: Install and build client
+  #        shell: bash
+  #        run: |
+  #          cd pinecone-ts-client
+  #          npm install --ignore-scripts
+  #          npm run build
+  #      - name: Install and build sample app
+  #        shell: bash
+  #        run: |
+  #          cd semantic-search-example
+  #          npm install --no-cache
+  #          npm install '../pinecone-ts-client'
+  #          cat package.json
+  #      - name: Run example tests with dev version of client
+  #        env:
+  #          CI: true
+  #          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+  #          PINECONE_INDEX: 'semantic-search'
+  #          PINECONE_CLOUD: 'aws'
+  #          PINECONE_REGION: 'us-west-2'
+  #        shell: bash
+  #        run: |
+  #          cd semantic-search-example
+  #          npm run test
 
   external-app:
     name: external-app

--- a/codegen/build-oas.sh
+++ b/codegen/build-oas.sh
@@ -10,11 +10,10 @@ build_dir="build"
 
 update_apis_repo() {
 	echo "Updating apis repo"
-	git submodule update --init --recursive
-	git submodule sync --recursive
 	pushd codegen/apis
+	  git fetch
 	  git checkout main
-	  git pull origin main
+	  git pull
     just build
 	popd
 }


### PR DESCRIPTION
## Problem

The addition of `git submodule...` commands was causing issues with the `ts-fetch` generator. Exactly why it was causing those issues remains an open question, but this way originally worked and the `git submodule` cmds were just added as a safety precaution. We can remove them since they're causing unnecessary cruft.

## Addition
This PR includes additional work done to the GH actions file for the external app Edge runtime testing: the Vercel cmds were out of date, causing CI to fail. 
