### PR TITLE
Add `sleep` to codegen script

### DIFF
--- a/codegen/build-oas.sh
+++ b/codegen/build-oas.sh
@@ -79,4 +79,5 @@ mkdir -p "${destination}"
 
 for module in "${modules[@]}"; do
 	generate_client $module
+	sleep 1
 done


### PR DESCRIPTION
## Problem

Since adding 3 new directories to our codegen script with the advent of Assistant (see the add-assistant branch), our codegen has non-deterministically failed (being "unable to build" certain Assistant models). After troubleshooting a bit, I've found that I can deterministically generate each directory's code if I do so individually. So, I played around with a few sleep values in the for-loop in our codegen script. Turns out, if we simply add a 1s sleep in between each round of code generation, we get no failures ever. So, this is our current workaround. My guess is that things in the generator's docker image need a little bit of time to finish executing, and subsequent iterations of our for-loop were beginning before those processes had finished completely.
