### PR TITLE
Fix `_id` and `_score` in records APIs

### DIFF
--- a/src/data/vectors/types.ts
+++ b/src/data/vectors/types.ts
@@ -134,8 +134,9 @@ export type OperationUsage = {
 };
 
 /**
- * Integrated records require an `id` field in addition to any relevant model fields, or metadata.
+ * Integrated records require an `id` or `_id` field in addition to any relevant model fields, or metadata.
  */
 export type IntegratedRecord<T extends RecordMetadata = RecordMetadata> = {
-  id: string;
+  id?: string;
+  _id?: string;
 } & T;

--- a/src/pinecone-generated-ts-fetch/db_data/models/Hit.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/Hit.ts
@@ -24,13 +24,13 @@ export interface Hit {
      * @type {string}
      * @memberof Hit
      */
-    id: string;
+    _id: string;
     /**
      * The similarity score of the returned record.
      * @type {number}
      * @memberof Hit
      */
-    score: number;
+    _score: number;
     /**
      * The selected record fields associated with the search hit.
      * @type {object}
@@ -44,8 +44,8 @@ export interface Hit {
  */
 export function instanceOfHit(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "id" in value;
-    isInstance = isInstance && "score" in value;
+    isInstance = isInstance && "_id" in value;
+    isInstance = isInstance && "_score" in value;
     isInstance = isInstance && "fields" in value;
 
     return isInstance;
@@ -61,8 +61,8 @@ export function HitFromJSONTyped(json: any, ignoreDiscriminator: boolean): Hit {
     }
     return {
         
-        'id': json['_id'],
-        'score': json['_score'],
+        '_id': json['_id'],
+        '_score': json['_score'],
         'fields': json['fields'],
     };
 }
@@ -76,8 +76,8 @@ export function HitToJSON(value?: Hit | null): any {
     }
     return {
         
-        '_id': value.id,
-        '_score': value.score,
+        '_id': value._id,
+        '_score': value._score,
         'fields': value.fields,
     };
 }


### PR DESCRIPTION
## Problem
Code generation from OpenAPI specs has some quirks, one of which is trying to get rid of leading underscores in objects and classes in some languages. We currently use `_id` and `_score` in our records API to denote reserved keys. We previously needed to add some logic during codegen in python to prevent this same issue.

Currently:
- You cannot call `upsertRecords` with records containing `_id`.
- When calling `searchRecords` the resulting object has the keys mapped from `_id` -> `id` and `_score` -> `score`.

## Solution
- Updated `IntegratedRecord` type which resolves the problem with `upsertRecords`
- Add a new function to the `build-oas.sh` script that handles massaging the `Hit.ts` file fields to maintain the shape of the API.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI Unit + Integration