### PR TITLE
Implement models API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1364,12 +1364,101 @@ If you do not specify a namespace, the records in the default namespace `''` wil
 
 Use embedding and & reranking models hosted by Pinecone. Learn more about Inference in the [docs](https://docs.pinecone.io/guides/inference/understanding-inference).
 
-To see the available models:
+### Models
 
-- [Embedding](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models)
-- [Reranking](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models)
+To see available models you can use the `getModel` and `listModels` methods on the `Inference` class:
 
-## Create embeddings
+```typescript
+import { Pinecone } from '@pinecone-database/pinecone';
+
+const client = new Pinecone({ apiKey: '<Your API key from app.pinecone.io>' });
+
+const models = await pc.inference.listModels();
+console.log(models);
+// {
+//   models: [
+//     {
+//       model: 'llama-text-embed-v2',
+//       shortDescription: 'A high performance dense embedding model optimized for multilingual and cross-lingual text question-answering retrieval with support for long documents (up to 2048 tokens) and dynamic embedding size (Matryoshka Embeddings).',
+//       type: 'embed',
+//       vectorType: 'dense',
+//       defaultDimension: 1024,
+//       modality: 'text',
+//       maxSequenceLength: 2048,
+//       maxBatchSize: 96,
+//       providerName: 'NVIDIA',
+//       supportedDimensions: [Array],
+//       supportedMetrics: [Array],
+//       supportedParameters: [Array]
+//     },
+//     ...
+//     {
+//       model: 'pinecone-rerank-v0',
+//       shortDescription: 'A state of the art reranking model that out-performs competitors on widely accepted benchmarks. It can handle chunks up to 512 tokens (1-2 paragraphs)',
+//       type: 'rerank',
+//       vectorType: undefined,
+//       defaultDimension: undefined,
+//       modality: 'text',
+//       maxSequenceLength: 512,
+//       maxBatchSize: 100,
+//       providerName: 'Pinecone',
+//       supportedDimensions: undefined,
+//       supportedMetrics: undefined,
+//       supportedParameters: [Array]
+//     }
+//   ]
+// }
+
+const model = await pc.inference.getModel('pinecone-sparse-english-v0');
+console.log(model);
+// {
+//   model: 'pinecone-sparse-english-v0',
+//   shortDescription: 'A sparse embedding model for converting text to sparse vectors for keyword or hybrid semantic/keyword search. Built on the innovations of the DeepImpact architecture.',
+//   type: 'embed',
+//   vectorType: 'sparse',
+//   defaultDimension: undefined,
+//   modality: 'text',
+//   maxSequenceLength: 512,
+//   maxBatchSize: 96,
+//   providerName: 'Pinecone',
+//   supportedDimensions: undefined,
+//   supportedMetrics: [ 'DotProduct' ],
+//   supportedParameters: [
+//     {
+//       parameter: 'input_type',
+//       type: 'one_of',
+//       valueType: 'string',
+//       required: true,
+//       allowedValues: [Array],
+//       min: undefined,
+//       max: undefined,
+//       _default: undefined
+//     },
+//     {
+//       parameter: 'truncate',
+//       type: 'one_of',
+//       valueType: 'string',
+//       required: false,
+//       allowedValues: [Array],
+//       min: undefined,
+//       max: undefined,
+//       _default: 'END'
+//     },
+//     {
+//       parameter: 'return_tokens',
+//       type: 'any',
+//       valueType: 'boolean',
+//       required: false,
+//       allowedValues: undefined,
+//       min: undefined,
+//       max: undefined,
+//       _default: false
+//     }
+//   ]
+// }
+```
+
+### Create embeddings
 
 Generate embeddings for documents and queries.
 
@@ -1432,7 +1521,7 @@ generateQueryEmbeddings().then((embeddingsResponse) => {
 // << Send query to Pinecone to retrieve similar documents >>
 ```
 
-## Rerank documents
+### Rerank documents
 
 Rerank documents in descending relevance-order against a query.
 

--- a/src/data/__tests__/vectors/list.test.ts
+++ b/src/data/__tests__/vectors/list.test.ts
@@ -49,7 +49,7 @@ describe('list', () => {
     const toThrow = async () => {
       await listPaginatedFn({ limit: -3 });
     };
-    await expect(toThrow()).rejects.toThrowError(
+    await expect(toThrow()).rejects.toThrow(
       '`limit` property must be greater than 0'
     );
   });
@@ -61,7 +61,7 @@ describe('list', () => {
       // @ts-ignore
       await listPaginatedFn({ limitgadsf: -3 });
     };
-    await expect(toThrow()).rejects.toThrowError(
+    await expect(toThrow()).rejects.toThrow(
       'Object contained invalid properties: limitgadsf. Valid properties include prefix, limit, paginationToken.'
     );
   });
@@ -73,7 +73,7 @@ describe('list', () => {
       // @ts-ignore
       await listPaginatedFn({ limit: 3, testy: 'test' });
     };
-    await expect(toThrow()).rejects.toThrowError(
+    await expect(toThrow()).rejects.toThrow(
       'Object contained invalid properties: testy. Valid properties include prefix, limit, paginationToken.'
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { Assistant, ChatStream } from './assistant';
 export * as Errors from './errors';
 
 // Interface exports
-export type { RerankOptions } from './inference/inference';
+export type { RerankOptions } from './inference/rerank';
 export type {
   RerankResult,
   RerankResultUsage,

--- a/src/inference/__tests__/embed.test.ts
+++ b/src/inference/__tests__/embed.test.ts
@@ -22,10 +22,9 @@ describe('embed', () => {
     const inputs = ['input1', 'input2'];
     const expectedInputs = [{ text: 'input1' }, { text: 'input2' }];
     const params = { inputType: 'text', truncate: 'END' };
-    const options = { model, inputs, params };
 
     const IA = setupEmbedResponse(true);
-    await embed(IA)(options);
+    await embed(IA)(model, inputs, params);
     expect(IA.embed).toHaveBeenCalledWith(
       expect.objectContaining({
         embedRequest: expect.objectContaining({ inputs: expectedInputs }),

--- a/src/inference/__tests__/getModel.test.ts
+++ b/src/inference/__tests__/getModel.test.ts
@@ -1,0 +1,36 @@
+import type {
+  InferenceApi,
+  GetModelRequest,
+  ModelInfo,
+} from '../../pinecone-generated-ts-fetch/inference';
+import { getModel } from '../getModel';
+
+const setupGetModelResponse = (response = {}, isSuccessful = true) => {
+  const fakeGetModel: (req: GetModelRequest) => Promise<ModelInfo> = jest
+    .fn()
+    .mockImplementation(() =>
+      isSuccessful ? Promise.resolve(response) : Promise.reject(response)
+    );
+
+  const IA = { getModel: fakeGetModel } as InferenceApi;
+  return IA;
+};
+
+describe('getModel', () => {
+  test('Confirm throws error if no model name is passed', async () => {
+    const IA = setupGetModelResponse();
+    const getModelCmd = getModel(IA);
+    await expect(getModelCmd('')).rejects.toThrow(
+      new Error(
+        'You must pass a non-empty string for `modelName` in order to get a model'
+      )
+    );
+  });
+
+  test('calls OpenAPI getModel with correct request', async () => {
+    const modelName = 'test-model';
+    const IA = setupGetModelResponse();
+    await getModel(IA)(modelName);
+    expect(IA.getModel).toHaveBeenCalledWith({ modelName });
+  });
+});

--- a/src/inference/__tests__/listModels.test.ts
+++ b/src/inference/__tests__/listModels.test.ts
@@ -1,0 +1,29 @@
+import type {
+  InferenceApi,
+  ListModelsRequest,
+  ModelInfoList,
+} from '../../pinecone-generated-ts-fetch/inference';
+import { listModels } from '../listModels';
+
+const setupListModelsResponse = (response = {}, isSuccessful = true) => {
+  const fakeListModels: (req: ListModelsRequest) => Promise<ModelInfoList> =
+    jest
+      .fn()
+      .mockImplementation(() =>
+        isSuccessful ? Promise.resolve(response) : Promise.reject(response)
+      );
+
+  const IA = { listModels: fakeListModels } as InferenceApi;
+  return IA;
+};
+
+describe('listModels', () => {
+  test('calls OpenAPI listModels with correct request', async () => {
+    const IA = setupListModelsResponse();
+    await listModels(IA)({ type: 'embed', vectorType: 'sparse' });
+    expect(IA.listModels).toHaveBeenCalledWith({
+      type: 'embed',
+      vectorType: 'sparse',
+    });
+  });
+});

--- a/src/inference/__tests__/rerank.test.ts
+++ b/src/inference/__tests__/rerank.test.ts
@@ -2,99 +2,107 @@ import { Inference } from '../inference';
 import type { PineconeConfiguration } from '../../data';
 import { inferenceOperationsBuilder } from '../inferenceOperationsBuilder';
 import { PineconeArgumentError } from '../../errors';
-import { RerankResult } from '../../pinecone-generated-ts-fetch/inference';
+import {
+  InferenceApi,
+  RerankRequest,
+  RerankResult,
+} from '../../pinecone-generated-ts-fetch/inference';
+import { rerank } from '../rerank';
 
 let inference: Inference;
 const rerankModel = 'test-model';
 const myQuery = 'test-query';
 
-beforeAll(() => {
-  const config: PineconeConfiguration = { apiKey: 'test-api-key' };
-  const infApi = inferenceOperationsBuilder(config);
-  inference = new Inference(infApi);
-});
+const setupRerankResponse = (response = {}, isSuccess = true) => {
+  const fakeRerank: (req: RerankRequest) => Promise<RerankResult> = jest
+    .fn()
+    .mockImplementation(() =>
+      isSuccess ? Promise.resolve(response) : Promise.reject(response)
+    );
+  const IA = { rerank: fakeRerank } as InferenceApi;
+  return IA;
+};
 
-test('Confirm throws error if no documents are passed', async () => {
-  try {
-    await inference.rerank(rerankModel, myQuery, []);
-  } catch (error) {
-    expect(error).toEqual(
+describe('rerank', () => {
+  test('Confirm throws error if no documents are passed', async () => {
+    const IA = setupRerankResponse();
+    const rerankCmd = rerank(IA);
+    await expect(rerankCmd(rerankModel, myQuery, [], {})).rejects.toThrow(
       new PineconeArgumentError('You must pass at least one document to rerank')
     );
-  }
-});
-
-test('Confirm docs as list of strings is converted to list of objects with `text` key', async () => {
-  const myDocuments = ['doc1', 'doc2'];
-  const expectedDocuments = [{ text: 'doc1' }, { text: 'doc2' }];
-  const rerank = jest.spyOn(inference._inferenceApi, 'rerank');
-  rerank.mockResolvedValue({
-    model: 'some-model',
-    data: [{}],
-    usage: { rerankUnits: 1 },
-  } as RerankResult);
-  await inference.rerank(rerankModel, myQuery, myDocuments);
-
-  const expectedReq = {
-    model: rerankModel,
-    query: myQuery,
-    documents: expectedDocuments,
-    parameters: {},
-    rankFields: ['text'],
-    returnDocuments: true,
-    topN: 2,
-  };
-  expect(rerank).toHaveBeenCalledWith({ rerankRequest: expectedReq });
-});
-
-test('Confirm provided rankFields override default `text` field for reranking', async () => {
-  const myDocuments = [
-    { text: 'doc1', title: 'title1' },
-    { text: 'doc2', title: 'title2' },
-  ];
-  const rankFields = ['title'];
-  const rerank = jest.spyOn(inference._inferenceApi, 'rerank');
-  // @ts-ignore
-  rerank.mockResolvedValue({ rerankResponse: {} });
-  await inference.rerank(rerankModel, myQuery, myDocuments, {
-    rankFields,
   });
 
-  const expectedReq = {
-    model: rerankModel,
-    query: myQuery,
-    documents: myDocuments,
-    rankFields,
-    parameters: {},
-    returnDocuments: true,
-    topN: 2,
-  };
-  expect(rerank).toHaveBeenCalledWith({ rerankRequest: expectedReq });
-});
+  test('Confirm docs as list of strings is converted to list of objects with `text` key', async () => {
+    const myDocuments = ['doc1', 'doc2'];
+    const expectedDocuments = [{ text: 'doc1' }, { text: 'doc2' }];
 
-test('Confirm error thrown if query is missing', async () => {
-  const myQuery = '';
-  const myDocuments = [{ text: 'doc1' }, { text: 'doc2' }];
-  try {
-    await inference.rerank(rerankModel, myQuery, myDocuments);
-  } catch (error) {
-    expect(error).toEqual(
+    const IA = setupRerankResponse({
+      model: 'some-model',
+      data: [{}],
+      usage: { rerankUnits: 1 },
+    });
+    await rerank(IA)(rerankModel, myQuery, myDocuments, {});
+
+    const expectedReq = {
+      model: rerankModel,
+      query: myQuery,
+      documents: expectedDocuments,
+      parameters: {},
+      rankFields: ['text'],
+      returnDocuments: true,
+      topN: 2,
+    };
+    expect(IA.rerank).toHaveBeenCalledWith({ rerankRequest: expectedReq });
+  });
+
+  test('Confirm provided rankFields override default `text` field for reranking', async () => {
+    const myDocuments = [
+      { text: 'doc1', title: 'title1' },
+      { text: 'doc2', title: 'title2' },
+    ];
+    const rankFields = ['title'];
+
+    const IA = setupRerankResponse({ rerankResponse: {} });
+    await rerank(IA)(rerankModel, myQuery, myDocuments, {
+      rankFields,
+    });
+
+    const expectedReq = {
+      model: rerankModel,
+      query: myQuery,
+      documents: myDocuments,
+      rankFields,
+      parameters: {},
+      returnDocuments: true,
+      topN: 2,
+    };
+    expect(IA.rerank).toHaveBeenCalledWith({ rerankRequest: expectedReq });
+  });
+
+  test('Confirm error thrown if query is missing', async () => {
+    const myQuery = '';
+    const myDocuments = [{ text: 'doc1' }, { text: 'doc2' }];
+    const IA = setupRerankResponse();
+    const rerankCmd = rerank(IA);
+    await expect(
+      rerankCmd(rerankModel, myQuery, myDocuments, {})
+    ).rejects.toThrow(
       new PineconeArgumentError('You must pass a query to rerank')
     );
-  }
-});
+  });
 
-test('Confirm error thrown if model is missing', async () => {
-  const rerankModel = '';
-  const myDocuments = [{ text: 'doc1' }, { text: 'doc2' }];
-  try {
-    await inference.rerank(rerankModel, myQuery, myDocuments);
-  } catch (error) {
-    expect(error).toEqual(
+  test('Confirm error thrown if model is missing', async () => {
+    const rerankModel = '';
+    const myDocuments = [{ text: 'doc1' }, { text: 'doc2' }];
+    const IA = setupRerankResponse();
+    const rerankCmd = rerank(IA);
+    await expect(
+      rerankCmd(rerankModel, myQuery, myDocuments, {})
+    ).rejects.toThrow(
       new PineconeArgumentError(
         'You must pass the name of a supported reranking model in order to rerank' +
           ' documents. See https://docs.pinecone.io/models for supported models.'
       )
     );
-  }
+  });
 });

--- a/src/inference/__tests__/rerank.test.ts
+++ b/src/inference/__tests__/rerank.test.ts
@@ -1,6 +1,3 @@
-import { Inference } from '../inference';
-import type { PineconeConfiguration } from '../../data';
-import { inferenceOperationsBuilder } from '../inferenceOperationsBuilder';
 import { PineconeArgumentError } from '../../errors';
 import {
   InferenceApi,
@@ -9,7 +6,6 @@ import {
 } from '../../pinecone-generated-ts-fetch/inference';
 import { rerank } from '../rerank';
 
-let inference: Inference;
 const rerankModel = 'test-model';
 const myQuery = 'test-query';
 

--- a/src/inference/embed.ts
+++ b/src/inference/embed.ts
@@ -1,0 +1,37 @@
+import {
+  EmbeddingsList,
+  EmbedOperationRequest,
+  EmbedRequestInputsInner,
+  InferenceApi,
+} from '../pinecone-generated-ts-fetch/inference';
+
+export type EmbedOptions = {
+  model: string;
+  inputs: Array<string>;
+  params: Record<string, string>;
+};
+
+export const embed = (infApi: InferenceApi) => {
+  return async (options: EmbedOptions): Promise<EmbeddingsList> => {
+    const { model, inputs, params } = options;
+    const typedAndFormattedInputs: Array<EmbedRequestInputsInner> = inputs.map(
+      (str) => {
+        return { text: str };
+      }
+    );
+    if (params && params.inputType) {
+      // Rename `inputType` to `input_type`
+      params.input_type = params.inputType;
+      delete params.inputType;
+    }
+
+    const typedRequest: EmbedOperationRequest = {
+      embedRequest: {
+        model: model,
+        inputs: typedAndFormattedInputs,
+        parameters: params,
+      },
+    };
+    return await infApi.embed(typedRequest);
+  };
+};

--- a/src/inference/embed.ts
+++ b/src/inference/embed.ts
@@ -5,15 +5,12 @@ import {
   InferenceApi,
 } from '../pinecone-generated-ts-fetch/inference';
 
-export type EmbedOptions = {
-  model: string;
-  inputs: Array<string>;
-  params: Record<string, string>;
-};
-
 export const embed = (infApi: InferenceApi) => {
-  return async (options: EmbedOptions): Promise<EmbeddingsList> => {
-    const { model, inputs, params } = options;
+  return async (
+    model: string,
+    inputs: Array<string>,
+    params?: Record<string, string>
+  ): Promise<EmbeddingsList> => {
     const typedAndFormattedInputs: Array<EmbedRequestInputsInner> = inputs.map(
       (str) => {
         return { text: str };

--- a/src/inference/getModel.ts
+++ b/src/inference/getModel.ts
@@ -1,3 +1,4 @@
+import { PineconeArgumentError } from '../errors';
 import {
   ModelInfo,
   InferenceApi,
@@ -6,7 +7,7 @@ import {
 export const getModel = (infApi: InferenceApi) => {
   return async (modelName: string): Promise<ModelInfo> => {
     if (!modelName) {
-      throw new Error(
+      throw new PineconeArgumentError(
         'You must pass a non-empty string for `modelName` in order to get a model'
       );
     }

--- a/src/inference/getModel.ts
+++ b/src/inference/getModel.ts
@@ -1,0 +1,15 @@
+import {
+  ModelInfo,
+  InferenceApi,
+} from '../pinecone-generated-ts-fetch/inference';
+
+export const getModel = (infApi: InferenceApi) => {
+  return async (modelName: string): Promise<ModelInfo> => {
+    if (!modelName) {
+      throw new Error(
+        'You must pass a non-empty string for `modelName` in order to get a model'
+      );
+    }
+    return await infApi.getModel({ modelName });
+  };
+};

--- a/src/inference/inference.ts
+++ b/src/inference/inference.ts
@@ -1,64 +1,32 @@
 import {
   EmbeddingsList,
-  EmbedOperationRequest,
-  EmbedRequestInputsInner,
-  InferenceApi,
   RerankResult,
 } from '../pinecone-generated-ts-fetch/inference';
-import { PineconeArgumentError } from '../errors';
-
-/** Options one can send with a request to {@link rerank} *
- *
- * @param topN - The number of documents to return in the response. Default is the number of documents passed in the
- * request.
- * @param returnDocuments - Whether to return the documents in the response. Default is `true`.
- * @param rankFields - The fields by which to rank the documents. If no field is passed, default is `['text']`.
- * Note: some models only support 1 reranking field. See the [model documentation](https://docs.pinecone.io/guides/inference/understanding-inference#rerank) for more information.
- * @param parameters - Additional model-specific parameters to send with the request, e.g. {truncate: "END"}.
- * */
-export interface RerankOptions {
-  topN?: number;
-  returnDocuments?: boolean;
-  rankFields?: Array<string>;
-  parameters?: { [key: string]: string };
-}
+import { inferenceOperationsBuilder } from './inferenceOperationsBuilder';
+import { PineconeConfiguration } from '../data';
+import type { EmbedOptions } from './embed';
+import { embed } from './embed';
+import type { RerankOptions } from './rerank';
+import { rerank } from './rerank';
 
 /* This class is the class through which users interact with Pinecone's inference API.  */
 export class Inference {
-  _inferenceApi: InferenceApi;
+  /** @hidden */
+  _embed: ReturnType<typeof embed>;
+  /** @hidden */
+  _rerank: ReturnType<typeof rerank>;
+  /** @internal */
+  config: PineconeConfiguration;
 
-  constructor(inferenceApi: InferenceApi) {
-    this._inferenceApi = inferenceApi;
+  constructor(config: PineconeConfiguration) {
+    this.config = config;
+    const inferenceApi = inferenceOperationsBuilder(this.config);
+    this._embed = embed(inferenceApi);
+    this._rerank = rerank(inferenceApi);
   }
 
-  /* Format the input data into the correct format for the Inference API request. */
-  public _formatInputs(data: Array<string>): Array<EmbedRequestInputsInner> {
-    return data.map((str) => {
-      return { text: str };
-    });
-  }
-
-  /* Generate embeddings for a list of input strings using a specified embedding model. */
-  async embed(
-    model: string,
-    inputs: Array<string>,
-    params: Record<string, string>
-  ): Promise<EmbeddingsList> {
-    const typedAndFormattedInputs: Array<EmbedRequestInputsInner> =
-      this._formatInputs(inputs);
-    if (params && params.inputType) {
-      // Rename `inputType` to `input_type`
-      params.input_type = params.inputType;
-      delete params.inputType;
-    }
-    const typedRequest: EmbedOperationRequest = {
-      embedRequest: {
-        model: model,
-        inputs: typedAndFormattedInputs,
-        parameters: params,
-      },
-    };
-    return await this._inferenceApi.embed(typedRequest);
+  embed(options: EmbedOptions): Promise<EmbeddingsList> {
+    return this._embed(options);
   }
 
   /** Rerank documents against a query with a reranking model. Each document is ranked in descending relevance order
@@ -158,58 +126,6 @@ export class Inference {
     documents: Array<{ [key: string]: string } | string>,
     options: RerankOptions = {}
   ): Promise<RerankResult> {
-    if (documents.length == 0) {
-      throw new PineconeArgumentError(
-        'You must pass at least one document to rerank'
-      );
-    }
-    if (query.length == 0) {
-      throw new PineconeArgumentError('You must pass a query to rerank');
-    }
-    if (model.length == 0) {
-      throw new PineconeArgumentError(
-        'You must pass the name of a supported reranking model in order to rerank' +
-          ' documents. See https://docs.pinecone.io/models for supported models.'
-      );
-    }
-
-    const {
-      topN = documents.length,
-      returnDocuments = true,
-      parameters = {},
-    } = options;
-
-    let { rankFields = ['text'] } = options;
-
-    // Validate and standardize documents to ensure they are in object format
-    const newDocuments = documents.map((doc) =>
-      typeof doc === 'string' ? { text: doc } : doc
-    );
-
-    if (!options.rankFields) {
-      if (!newDocuments.every((doc) => typeof doc === 'object' && doc.text)) {
-        throw new PineconeArgumentError(
-          'Documents must be a list of strings or objects containing the "text" field'
-        );
-      }
-    }
-
-    if (options.rankFields) {
-      rankFields = options.rankFields;
-    }
-
-    const req = {
-      rerankRequest: {
-        model: model,
-        query: query,
-        documents: newDocuments,
-        topN: topN,
-        returnDocuments: returnDocuments,
-        rankFields: rankFields,
-        parameters: parameters,
-      },
-    };
-
-    return await this._inferenceApi.rerank(req);
+    return this._rerank(model, query, documents, options);
   }
 }

--- a/src/inference/inference.ts
+++ b/src/inference/inference.ts
@@ -139,7 +139,7 @@ export class Inference {
     return this._rerank(model, query, documents, options);
   }
 
-  async listModels(options: ListModelsOptions): Promise<ModelInfoList> {
+  async listModels(options?: ListModelsOptions): Promise<ModelInfoList> {
     return this._listModels(options);
   }
 

--- a/src/inference/inference.ts
+++ b/src/inference/inference.ts
@@ -6,14 +6,13 @@ import {
 } from '../pinecone-generated-ts-fetch/inference';
 import { inferenceOperationsBuilder } from './inferenceOperationsBuilder';
 import { PineconeConfiguration } from '../data';
-import type { EmbedOptions } from './embed';
 import { embed } from './embed';
 import type { RerankOptions } from './rerank';
 import { rerank } from './rerank';
 import { getModel } from './getModel';
 import { listModels, ListModelsOptions } from './listModels';
 
-/* This class is the class through which users interact with Pinecone's inference API.  */
+/* The Inference class uses the InferenceApi to generate embeddings, rerank documents, and work with models.  */
 export class Inference {
   /** @hidden */
   _embed: ReturnType<typeof embed>;
@@ -35,93 +34,126 @@ export class Inference {
     this._getModel = getModel(inferenceApi);
   }
 
-  embed(options: EmbedOptions): Promise<EmbeddingsList> {
-    return this._embed(options);
+  /**
+   * Generates embeddings for the provided inputs using the specified model and (optional) parameters.
+   *
+   * @example
+   * ````typescript
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const pc = new Pinecone();
+   *
+   * const inputs = ['Who created the first computer?'];
+   * const model = 'multilingual-e5-large';
+   * const parameters = {
+   *   inputType: 'passage',
+   *   truncate: 'END',
+   * };
+   * const embeddings = await pc.inference.embed(model, inputs, parameters);
+   * console.log(embeddings);
+   * // {
+   * //   model: 'multilingual-e5-large',
+   * //   vectorType: 'dense',
+   * //   data: [ { values: [Array], vectorType: 'dense' } ],
+   * //   usage: { totalTokens: 10 }
+   * // }
+   * ```
+   *
+   * @param model - The model to use for generating embeddings.
+   * @param inputs - A list of items to generate embeddings for.
+   * @param params - A dictionary of parameters to use when generating embeddings.
+   * @returns A promise that resolves to {@link EmbeddingsList}.
+   * */
+  embed(
+    model: string,
+    inputs: Array<string>,
+    params?: Record<string, string>
+  ): Promise<EmbeddingsList> {
+    return this._embed(model, inputs, params);
   }
 
-  /** Rerank documents against a query with a reranking model. Each document is ranked in descending relevance order
-   *  against the query provided.
+  /**
+   * Rerank documents against a query with a reranking model. Each document is ranked in descending relevance order
+   * against the query provided.
    *
-   *  @example
-   *  ````typescript
-   *  import { Pinecone } from '@pinecone-database/pinecone';
-   *  const pc = new Pinecone();
-   *  const rerankingModel = 'bge-reranker-v2-m3';
-   *  const myQuery = 'What are some good Turkey dishes for Thanksgiving?';
+   * @example
+   * ````typescript
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const pc = new Pinecone();
+   * const rerankingModel = 'bge-reranker-v2-m3';
+   * const myQuery = 'What are some good Turkey dishes for Thanksgiving?';
    *
-   *  // Option 1: Documents as an array of strings
-   *  const myDocsStrings = [
-   *    'I love turkey sandwiches with pastrami',
-   *    'A lemon brined Turkey with apple sausage stuffing is a classic Thanksgiving main',
-   *    'My favorite Thanksgiving dish is pumpkin pie',
-   *    'Turkey is a great source of protein',
-   *  ];
+   * // Option 1: Documents as an array of strings
+   * const myDocsStrings = [
+   *   'I love turkey sandwiches with pastrami',
+   *   'A lemon brined Turkey with apple sausage stuffing is a classic Thanksgiving main',
+   *   'My favorite Thanksgiving dish is pumpkin pie',
+   *   'Turkey is a great source of protein',
+   * ];
    *
-   *  // Option 1 response
-   *  const response = await pc.inference.rerank(
-   *    rerankingModel,
-   *    myQuery,
-   *    myDocsStrings
-   *  );
-   *  console.log(response);
-   *  // {
-   *  // model: 'bge-reranker-v2-m3',
-   *  // data: [
-   *  //   { index: 1, score: 0.5633179, document: [Object] },
-   *  //   { index: 2, score: 0.02013874, document: [Object] },
-   *  //   { index: 3, score: 0.00035419367, document: [Object] },
-   *  //   { index: 0, score: 0.00021485926, document: [Object] }
-   *  // ],
-   *  // usage: { rerankUnits: 1 }
-   *  // }
+   * // Option 1 response
+   * const response = await pc.inference.rerank(
+   *   rerankingModel,
+   *   myQuery,
+   *   myDocsStrings
+   * );
+   * console.log(response);
+   * // {
+   * // model: 'bge-reranker-v2-m3',
+   * // data: [
+   * //   { index: 1, score: 0.5633179, document: [Object] },
+   * //   { index: 2, score: 0.02013874, document: [Object] },
+   * //   { index: 3, score: 0.00035419367, document: [Object] },
+   * //   { index: 0, score: 0.00021485926, document: [Object] }
+   * // ],
+   * // usage: { rerankUnits: 1 }
+   * // }
    *
-   *  // Option 2: Documents as an array of objects
-   *  const myDocsObjs = [
-   *    {
-   *      title: 'Turkey Sandwiches',
-   *      body: 'I love turkey sandwiches with pastrami',
-   *    },
-   *    {
-   *      title: 'Lemon Turkey',
-   *      body: 'A lemon brined Turkey with apple sausage stuffing is a classic Thanksgiving main',
-   *    },
-   *    {
-   *      title: 'Thanksgiving',
-   *      body: 'My favorite Thanksgiving dish is pumpkin pie',
-   *    },
-   *    { title: 'Protein Sources', body: 'Turkey is a great source of protein' },
-   *  ];
+   * // Option 2: Documents as an array of objects
+   * const myDocsObjs = [
+   *   {
+   *     title: 'Turkey Sandwiches',
+   *     body: 'I love turkey sandwiches with pastrami',
+   *   },
+   *   {
+   *     title: 'Lemon Turkey',
+   *     body: 'A lemon brined Turkey with apple sausage stuffing is a classic Thanksgiving main',
+   *   },
+   *   {
+   *     title: 'Thanksgiving',
+   *     body: 'My favorite Thanksgiving dish is pumpkin pie',
+   *   },
+   *   { title: 'Protein Sources', body: 'Turkey is a great source of protein' },
+   * ];
    *
-   *  // Option 2: Options object declaring which custom key to rerank on
-   *  // Note: If no custom key is passed via `rankFields`, each doc must contain a `text` key, and that will act as
-   *   the default)
-   *  const rerankOptions = {
-   *    topN: 3,
-   *    returnDocuments: false,
-   *    rankFields: ['body'],
-   *    parameters: {
-   *      inputType: 'passage',
-   *      truncate: 'END',
-   *    },
-   *  };
+   * // Option 2: Options object declaring which custom key to rerank on
+   * // Note: If no custom key is passed via `rankFields`, each doc must contain a `text` key, and that will act as the default)
+   * const rerankOptions = {
+   *   topN: 3,
+   *   returnDocuments: false,
+   *   rankFields: ['body'],
+   *   parameters: {
+   *     inputType: 'passage',
+   *     truncate: 'END',
+   *   },
+   * };
    *
-   *  // Option 2 response
-   *  const response = await pc.inference.rerank(
-   *    rerankingModel,
-   *    myQuery,
-   *    myDocsObjs,
-   *    rerankOptions
-   *  );
-   *  console.log(response);
-   *  // {
-   *  // model: 'bge-reranker-v2-m3',
-   *  // data: [
-   *  //   { index: 1, score: 0.5633179, document: undefined },
-   *  //   { index: 2, score: 0.02013874, document: undefined },
-   *  //   { index: 3, score: 0.00035419367, document: undefined },
-   *  // ],
-   *  // usage: { rerankUnits: 1 }
-   *  //}
+   * // Option 2 response
+   * const response = await pc.inference.rerank(
+   *   rerankingModel,
+   *   myQuery,
+   *   myDocsObjs,
+   *   rerankOptions
+   * );
+   * console.log(response);
+   * // {
+   * // model: 'bge-reranker-v2-m3',
+   * // data: [
+   * //   { index: 1, score: 0.5633179, document: undefined },
+   * //   { index: 2, score: 0.02013874, document: undefined },
+   * //   { index: 3, score: 0.00035419367, document: undefined },
+   * // ],
+   * // usage: { rerankUnits: 1 }
+   * //}
    * ```
    *
    * @param model - (Required) The model to use for reranking. Currently, the only available model is "[bge-reranker-v2-m3](https://docs.pinecone.io/models/bge-reranker-v2-m3)"}.
@@ -134,15 +166,123 @@ export class Inference {
     model: string,
     query: string,
     documents: Array<{ [key: string]: string } | string>,
-    options: RerankOptions = {}
+    options?: RerankOptions
   ): Promise<RerankResult> {
     return this._rerank(model, query, documents, options);
   }
 
+  /**
+   * List available models hosted by Pinecone.
+   *
+   * @example
+   * ````typescript
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const pc = new Pinecone();
+   *
+   * const models = await pc.inference.listModels();
+   * console.log(models);
+   * // {
+   * //   models: [
+   * //     {
+   * //       model: 'llama-text-embed-v2',
+   * //       shortDescription: 'A high performance dense embedding model optimized for multilingual and cross-lingual text question-answering retrieval with support for long documents (up to 2048 tokens) and dynamic embedding size (Matryoshka Embeddings).',
+   * //       type: 'embed',
+   * //       vectorType: 'dense',
+   * //       defaultDimension: 1024,
+   * //       modality: 'text',
+   * //       maxSequenceLength: 2048,
+   * //       maxBatchSize: 96,
+   * //       providerName: 'NVIDIA',
+   * //       supportedDimensions: [Array],
+   * //       supportedMetrics: [Array],
+   * //       supportedParameters: [Array]
+   * //     },
+   * //     ...
+   * //     {
+   * //       model: 'pinecone-rerank-v0',
+   * //       shortDescription: 'A state of the art reranking model that out-performs competitors on widely accepted benchmarks. It can handle chunks up to 512 tokens (1-2 paragraphs)',
+   * //       type: 'rerank',
+   * //       vectorType: undefined,
+   * //       defaultDimension: undefined,
+   * //       modality: 'text',
+   * //       maxSequenceLength: 512,
+   * //       maxBatchSize: 100,
+   * //       providerName: 'Pinecone',
+   * //       supportedDimensions: undefined,
+   * //       supportedMetrics: undefined,
+   * //       supportedParameters: [Array]
+   * //     }
+   * //   ]
+   * // }
+   * ```
+   *
+   * @param options - (Optional) A {@link ListModelsOptions} object to filter the models returned.
+   * @returns A promise that resolves to {@link ModelInfoList}.
+   * */
   async listModels(options?: ListModelsOptions): Promise<ModelInfoList> {
     return this._listModels(options);
   }
 
+  /**
+   * Get the information for a model hosted by Pinecone.
+   *
+   * @example
+   * ````typescript
+   * import { Pinecone } from '@pinecone-database/pinecone';
+   * const pc = new Pinecone();
+   *
+   * const models = await pc.inference.listModels();
+   * console.log(models);
+   * // {
+   * //   model: 'pinecone-sparse-english-v0',
+   * //   shortDescription: 'A sparse embedding model for converting text to sparse vectors for keyword or hybrid semantic/keyword search. Built on the innovations of the DeepImpact architecture.',
+   * //   type: 'embed',
+   * //   vectorType: 'sparse',
+   * //   defaultDimension: undefined,
+   * //   modality: 'text',
+   * //   maxSequenceLength: 512,
+   * //   maxBatchSize: 96,
+   * //   providerName: 'Pinecone',
+   * //   supportedDimensions: undefined,
+   * //   supportedMetrics: [ 'DotProduct' ],
+   * //   supportedParameters: [
+   * //     {
+   * //       parameter: 'input_type',
+   * //       type: 'one_of',
+   * //       valueType: 'string',
+   * //       required: true,
+   * //       allowedValues: [Array],
+   * //       min: undefined,
+   * //       max: undefined,
+   * //       _default: undefined
+   * //     },
+   * //     {
+   * //       parameter: 'truncate',
+   * //       type: 'one_of',
+   * //       valueType: 'string',
+   * //       required: false,
+   * //       allowedValues: [Array],
+   * //       min: undefined,
+   * //       max: undefined,
+   * //       _default: 'END'
+   * //     },
+   * //     {
+   * //       parameter: 'return_tokens',
+   * //       type: 'any',
+   * //       valueType: 'boolean',
+   * //       required: false,
+   * //       allowedValues: undefined,
+   * //       min: undefined,
+   * //       max: undefined,
+   * //       _default: false
+   * //     }
+   * //   ]
+   * // }
+   * ```
+   *
+   * @param modelName - The model name you would like to describe.
+   * @returns A promise that resolves to {@link ModelInfo}.
+   * */
   async getModel(modelName: string): Promise<ModelInfo> {
     return this._getModel(modelName);
   }

--- a/src/inference/inference.ts
+++ b/src/inference/inference.ts
@@ -231,8 +231,8 @@ export class Inference {
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const pc = new Pinecone();
    *
-   * const models = await pc.inference.listModels();
-   * console.log(models);
+   * const model = await pc.inference.getModel('pinecone-sparse-english-v0');
+   * console.log(model);
    * // {
    * //   model: 'pinecone-sparse-english-v0',
    * //   shortDescription: 'A sparse embedding model for converting text to sparse vectors for keyword or hybrid semantic/keyword search. Built on the innovations of the DeepImpact architecture.',

--- a/src/inference/inference.ts
+++ b/src/inference/inference.ts
@@ -1,5 +1,7 @@
 import {
   EmbeddingsList,
+  ModelInfo,
+  ModelInfoList,
   RerankResult,
 } from '../pinecone-generated-ts-fetch/inference';
 import { inferenceOperationsBuilder } from './inferenceOperationsBuilder';
@@ -8,6 +10,8 @@ import type { EmbedOptions } from './embed';
 import { embed } from './embed';
 import type { RerankOptions } from './rerank';
 import { rerank } from './rerank';
+import { getModel } from './getModel';
+import { listModels, ListModelsOptions } from './listModels';
 
 /* This class is the class through which users interact with Pinecone's inference API.  */
 export class Inference {
@@ -15,6 +19,10 @@ export class Inference {
   _embed: ReturnType<typeof embed>;
   /** @hidden */
   _rerank: ReturnType<typeof rerank>;
+  /** @hidden */
+  _listModels: ReturnType<typeof listModels>;
+  /** @hidden */
+  _getModel: ReturnType<typeof getModel>;
   /** @internal */
   config: PineconeConfiguration;
 
@@ -23,6 +31,8 @@ export class Inference {
     const inferenceApi = inferenceOperationsBuilder(this.config);
     this._embed = embed(inferenceApi);
     this._rerank = rerank(inferenceApi);
+    this._listModels = listModels(inferenceApi);
+    this._getModel = getModel(inferenceApi);
   }
 
   embed(options: EmbedOptions): Promise<EmbeddingsList> {
@@ -127,5 +137,13 @@ export class Inference {
     options: RerankOptions = {}
   ): Promise<RerankResult> {
     return this._rerank(model, query, documents, options);
+  }
+
+  async listModels(options: ListModelsOptions): Promise<ModelInfoList> {
+    return this._listModels(options);
+  }
+
+  async getModel(modelName: string): Promise<ModelInfo> {
+    return this._getModel(modelName);
   }
 }

--- a/src/inference/listModels.ts
+++ b/src/inference/listModels.ts
@@ -11,7 +11,7 @@ export interface ListModelsOptions {
 }
 
 export const listModels = (infApi: InferenceApi) => {
-  return async (options: ListModelsOptions): Promise<ModelInfoList> => {
+  return async (options?: ListModelsOptions): Promise<ModelInfoList> => {
     return await infApi.listModels(options);
   };
 };

--- a/src/inference/listModels.ts
+++ b/src/inference/listModels.ts
@@ -1,0 +1,17 @@
+import {
+  ModelInfoList,
+  InferenceApi,
+  ListModelsTypeEnum,
+  ListModelsVectorTypeEnum,
+} from '../pinecone-generated-ts-fetch/inference';
+
+export interface ListModelsOptions {
+  type?: ListModelsTypeEnum;
+  vectorType?: ListModelsVectorTypeEnum;
+}
+
+export const listModels = (infApi: InferenceApi) => {
+  return async (options: ListModelsOptions): Promise<ModelInfoList> => {
+    return await infApi.listModels(options);
+  };
+};

--- a/src/inference/rerank.ts
+++ b/src/inference/rerank.ts
@@ -25,7 +25,7 @@ export const rerank = (infApi: InferenceApi) => {
     model: string,
     query: string,
     documents: Array<{ [key: string]: string } | string>,
-    options: RerankOptions
+    options: RerankOptions = {}
   ): Promise<RerankResult> => {
     if (documents.length == 0) {
       throw new PineconeArgumentError(

--- a/src/inference/rerank.ts
+++ b/src/inference/rerank.ts
@@ -1,0 +1,84 @@
+import {
+  RerankResult,
+  InferenceApi,
+} from '../pinecone-generated-ts-fetch/inference';
+import { PineconeArgumentError } from '../errors';
+
+/** Options one can send with a request to {@link rerank} *
+ *
+ * @param topN - The number of documents to return in the response. Default is the number of documents passed in the
+ * request.
+ * @param returnDocuments - Whether to return the documents in the response. Default is `true`.
+ * @param rankFields - The fields by which to rank the documents. If no field is passed, default is `['text']`.
+ * Note: some models only support 1 reranking field. See the [model documentation](https://docs.pinecone.io/guides/inference/understanding-inference#rerank) for more information.
+ * @param parameters - Additional model-specific parameters to send with the request, e.g. {truncate: "END"}.
+ * */
+export interface RerankOptions {
+  topN?: number;
+  returnDocuments?: boolean;
+  rankFields?: Array<string>;
+  parameters?: { [key: string]: string };
+}
+
+export const rerank = (infApi: InferenceApi) => {
+  return async (
+    model: string,
+    query: string,
+    documents: Array<{ [key: string]: string } | string>,
+    options: RerankOptions
+  ): Promise<RerankResult> => {
+    if (documents.length == 0) {
+      throw new PineconeArgumentError(
+        'You must pass at least one document to rerank'
+      );
+    }
+    if (query.length == 0) {
+      throw new PineconeArgumentError('You must pass a query to rerank');
+    }
+    if (model.length == 0) {
+      throw new PineconeArgumentError(
+        'You must pass the name of a supported reranking model in order to rerank' +
+          ' documents. See https://docs.pinecone.io/models for supported models.'
+      );
+    }
+
+    const {
+      topN = documents.length,
+      returnDocuments = true,
+      parameters = {},
+    } = options;
+
+    let { rankFields = ['text'] } = options;
+
+    // Validate and standardize documents to ensure they are in object format
+    const newDocuments = documents.map((doc) =>
+      typeof doc === 'string' ? { text: doc } : doc
+    );
+
+    if (!options.rankFields) {
+      if (!newDocuments.every((doc) => typeof doc === 'object' && doc.text)) {
+        throw new PineconeArgumentError(
+          'Documents must be a list of strings or objects containing the "text" field'
+        );
+      }
+    }
+
+    if (options.rankFields) {
+      rankFields = options.rankFields;
+    }
+
+    const req = {
+      rerankRequest: {
+        model: model,
+        query: query,
+        documents: newDocuments,
+        topN: topN,
+        returnDocuments: returnDocuments,
+        rankFields: rankFields,
+        parameters: parameters,
+      },
+    };
+
+    return await infApi.rerank(req);
+  };
+};

--- a/src/integration/assistant-data/uploadAndDeleteFile.test.ts
+++ b/src/integration/assistant-data/uploadAndDeleteFile.test.ts
@@ -3,7 +3,7 @@ import { Assistant } from '../../assistant';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { sleep } from '../test-helpers';
+import { assertWithRetries, sleep } from '../test-helpers';
 
 let pinecone: Pinecone;
 let assistant: Assistant;
@@ -82,10 +82,15 @@ describe('Upload file happy path', () => {
     expect(response.updatedOn).toBeDefined();
     expect(response.status).toBeDefined();
 
-    await sleep(30000);
+    await sleep(10000);
 
     // Delete file happy path test:
-    await assistant.deleteFile(response.id);
+    assertWithRetries(
+      () => assistant.deleteFile(response.id),
+      () => {
+        return;
+      }
+    );
   });
 
   test('Upload file with metadata', async () => {
@@ -109,10 +114,15 @@ describe('Upload file happy path', () => {
       expect(response.metadata['category']).toEqual('integration-test');
     }
 
-    await sleep(30000);
+    await sleep(10000);
 
     // Delete file happy path test:
-    await assistant.deleteFile(response.id);
+    assertWithRetries(
+      () => assistant.deleteFile(response.id),
+      () => {
+        return;
+      }
+    );
   });
 });
 

--- a/src/integration/inference/embed.test.ts
+++ b/src/integration/inference/embed.test.ts
@@ -18,7 +18,7 @@ describe('Integration Test: Pinecone Inference API embeddings endpoint', () => {
   });
 
   test('Confirm output types', async () => {
-    const response = await pinecone.inference.embed(model, inputs, params);
+    const response = await pinecone.inference.embed({ model, inputs, params });
     expect(response.model).toBeDefined();
     expect(response.data).toBeDefined();
     expect(response.usage).toBeDefined();

--- a/src/integration/inference/embed.test.ts
+++ b/src/integration/inference/embed.test.ts
@@ -18,7 +18,7 @@ describe('Integration Test: Pinecone Inference API embeddings endpoint', () => {
   });
 
   test('Confirm output types', async () => {
-    const response = await pinecone.inference.embed({ model, inputs, params });
+    const response = await pinecone.inference.embed(model, inputs, params);
     expect(response.model).toBeDefined();
     expect(response.data).toBeDefined();
     expect(response.usage).toBeDefined();

--- a/src/integration/inference/models.test.ts
+++ b/src/integration/inference/models.test.ts
@@ -1,0 +1,22 @@
+import { Pinecone } from '../../pinecone';
+
+describe('inference models', () => {
+  let pinecone: Pinecone;
+
+  beforeAll(() => {
+    const apiKey = process.env.PINECONE_API_KEY || '';
+    pinecone = new Pinecone({ apiKey });
+  });
+
+  test('get model', async () => {
+    const model = await pinecone.inference.getModel('multilingual-e5-large');
+    expect(model).toBeDefined();
+    expect(model.name).toEqual('multilingual-e5-large');
+  });
+
+  test('list models', async () => {
+    const modelList = await pinecone.inference.listModels();
+    expect(modelList).toBeDefined();
+    expect(modelList.models).toBeGreaterThan(0);
+  });
+});

--- a/src/integration/inference/models.test.ts
+++ b/src/integration/inference/models.test.ts
@@ -11,7 +11,7 @@ describe('inference models', () => {
   test('get model', async () => {
     const model = await pinecone.inference.getModel('multilingual-e5-large');
     expect(model).toBeDefined();
-    expect(model.name).toEqual('multilingual-e5-large');
+    expect(model.model).toEqual('multilingual-e5-large');
   });
 
   test('list models', async () => {

--- a/src/integration/inference/models.test.ts
+++ b/src/integration/inference/models.test.ts
@@ -17,6 +17,6 @@ describe('inference models', () => {
   test('list models', async () => {
     const modelList = await pinecone.inference.listModels();
     expect(modelList).toBeDefined();
-    expect(modelList.models).toBeGreaterThan(0);
+    expect(modelList.models?.length).toBeGreaterThan(0);
   });
 });

--- a/src/pinecone-generated-ts-fetch/db_control/apis/ManageIndexesApi.ts
+++ b/src/pinecone-generated-ts-fetch/db_control/apis/ManageIndexesApi.ts
@@ -264,7 +264,7 @@ export class ManageIndexesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Create a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.    For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/indexes/create-an-index#create-a-serverless-index). 
+     * Create a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.    For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/index-data/create-an-index). 
      * Create an index
      */
     async createIndexRaw(requestParameters: CreateIndexOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<IndexModel>> {
@@ -294,7 +294,7 @@ export class ManageIndexesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Create a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.    For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/indexes/create-an-index#create-a-serverless-index). 
+     * Create a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.    For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/index-data/create-an-index). 
      * Create an index
      */
     async createIndex(requestParameters: CreateIndexOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<IndexModel> {
@@ -303,7 +303,7 @@ export class ManageIndexesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Create an index with integrated embedding.  With this type of index, you provide source text, and Pinecone uses a [hosted embedding model](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models) to convert the text automatically during [upsert](https://docs.pinecone.io/reference/api/2025-01/data-plane/upsert_records) and [search](https://docs.pinecone.io/reference/api/2025-01/data-plane/search_records).  For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding).
+     * Create an index with integrated embedding.  With this type of index, you provide source text, and Pinecone uses a [hosted embedding model](https://docs.pinecone.io/guides/index-data/create-an-index#embedding-models) to convert the text automatically during [upsert](https://docs.pinecone.io/reference/api/2025-01/data-plane/upsert_records) and [search](https://docs.pinecone.io/reference/api/2025-01/data-plane/search_records).  For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/index-data/create-an-index#integrated-embedding).
      * Create an index with integrated embedding
      */
     async createIndexForModelRaw(requestParameters: CreateIndexForModelOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<IndexModel>> {
@@ -333,7 +333,7 @@ export class ManageIndexesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Create an index with integrated embedding.  With this type of index, you provide source text, and Pinecone uses a [hosted embedding model](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models) to convert the text automatically during [upsert](https://docs.pinecone.io/reference/api/2025-01/data-plane/upsert_records) and [search](https://docs.pinecone.io/reference/api/2025-01/data-plane/search_records).  For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding).
+     * Create an index with integrated embedding.  With this type of index, you provide source text, and Pinecone uses a [hosted embedding model](https://docs.pinecone.io/guides/index-data/create-an-index#embedding-models) to convert the text automatically during [upsert](https://docs.pinecone.io/reference/api/2025-01/data-plane/upsert_records) and [search](https://docs.pinecone.io/reference/api/2025-01/data-plane/search_records).  For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/index-data/create-an-index#integrated-embedding).
      * Create an index with integrated embedding
      */
     async createIndexForModel(requestParameters: CreateIndexForModelOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<IndexModel> {

--- a/src/pinecone-generated-ts-fetch/db_control/models/ConfigureIndexRequestEmbed.ts
+++ b/src/pinecone-generated-ts-fetch/db_control/models/ConfigureIndexRequestEmbed.ts
@@ -16,7 +16,7 @@ import { exists, mapValues } from '../runtime';
 /**
  * Configure the integrated inference embedding settings for this index.
  * 
- * You can convert an existing index to an integrated index by specifying the embedding model and field_map. The index vector type and dimension must match the model vector type and dimension, and the index similarity metric must be supported by the model. Refer to the [model guide](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models) for available models and model details.
+ * You can convert an existing index to an integrated index by specifying the embedding model and field_map. The index vector type and dimension must match the model vector type and dimension, and the index similarity metric must be supported by the model. Refer to the [model guide](https://docs.pinecone.io/guides/index-data/create-an-index#embedding-models) for available models and model details.
  * 
  * You can later change the embedding configuration to update the field map, read parameters, or write parameters. Once set, the model cannot be changed.
  * @export

--- a/src/pinecone-generated-ts-fetch/db_control/models/CreateIndexForModelRequestEmbed.ts
+++ b/src/pinecone-generated-ts-fetch/db_control/models/CreateIndexForModelRequestEmbed.ts
@@ -18,7 +18,7 @@ import { exists, mapValues } from '../runtime';
  * 
  * Once set the model cannot be changed, but you can later update the embedding configuration for an integrated inference index including field map, read parameters, or write parameters.
  * 
- * Refer to the [model guide](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models) for available models and model details.
+ * Refer to the [model guide](https://docs.pinecone.io/guides/index-data/create-an-index#embedding-models) for available models and model details.
  * @export
  * @interface CreateIndexForModelRequestEmbed
  */

--- a/src/pinecone-generated-ts-fetch/db_control/models/DeletionProtection.ts
+++ b/src/pinecone-generated-ts-fetch/db_control/models/DeletionProtection.ts
@@ -14,7 +14,7 @@
 
 
 /**
- * Whether [deletion protection](http://docs.pinecone.io/guides/indexes/manage-indexes#configure-deletion-protection) is enabled/disabled for the index.
+ * Whether [deletion protection](http://docs.pinecone.io/guides/manage-data/manage-indexes#configure-deletion-protection) is enabled/disabled for the index.
  * @export
  */
 export const DeletionProtection = {

--- a/src/pinecone-generated-ts-fetch/db_control/models/IndexSpec.ts
+++ b/src/pinecone-generated-ts-fetch/db_control/models/IndexSpec.ts
@@ -35,7 +35,7 @@ import {
 /**
  * The spec object defines how the index should be deployed.
  * 
- * For serverless indexes, you set only the [cloud and region](http://docs.pinecone.io/guides/indexes/understanding-indexes#cloud-regions) where the index should be hosted. For pod-based indexes, you set the [environment](http://docs.pinecone.io/guides/indexes/pods/understanding-pod-based-indexes#pod-environments) where the index should be hosted, the [pod type and size](http://docs.pinecone.io/guides/indexes/pods/understanding-pod-based-indexes#pod-types) to use, and other index characteristics. For [BYOC indexes](http://docs.pinecone.io/guides/operations/bring-your-own-cloud), you set the environment name provided to you during onboarding.
+ * For serverless indexes, you set only the [cloud and region](http://docs.pinecone.io/guides/index-data/create-an-index#cloud-regions) where the index should be hosted. For pod-based indexes, you set the [environment](http://docs.pinecone.io/guides/indexes/pods/understanding-pod-based-indexes#pod-environments) where the index should be hosted, the [pod type and size](http://docs.pinecone.io/guides/indexes/pods/understanding-pod-based-indexes#pod-types) to use, and other index characteristics. For [BYOC indexes](http://docs.pinecone.io/guides/production/bring-your-own-cloud), you set the environment name provided to you during onboarding.
  * @export
  * @interface IndexSpec
  */

--- a/src/pinecone-generated-ts-fetch/db_data/apis/BulkOperationsApi.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/apis/BulkOperationsApi.ts
@@ -57,7 +57,7 @@ export interface StartBulkImportRequest {
 export class BulkOperationsApi extends runtime.BaseAPI {
 
     /**
-     * Cancel an import operation if it is not yet finished. It has no effect if the operation is already finished.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * Cancel an import operation if it is not yet finished. It has no effect if the operation is already finished.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * Cancel an import
      */
     async cancelBulkImportRaw(requestParameters: CancelBulkImportRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<object>> {
@@ -84,7 +84,7 @@ export class BulkOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Cancel an import operation if it is not yet finished. It has no effect if the operation is already finished.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * Cancel an import operation if it is not yet finished. It has no effect if the operation is already finished.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * Cancel an import
      */
     async cancelBulkImport(requestParameters: CancelBulkImportRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<object> {
@@ -93,7 +93,7 @@ export class BulkOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Return details of a specific import operation.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * Return details of a specific import operation.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * Describe an import
      */
     async describeBulkImportRaw(requestParameters: DescribeBulkImportRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ImportModel>> {
@@ -120,7 +120,7 @@ export class BulkOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Return details of a specific import operation.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * Return details of a specific import operation.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * Describe an import
      */
     async describeBulkImport(requestParameters: DescribeBulkImportRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ImportModel> {
@@ -129,7 +129,7 @@ export class BulkOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * List all recent and ongoing import operations.  By default, `list_imports` returns up to 100 imports per page. If the `limit` parameter is set, `list` returns up to that number of imports instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of imports. When the response does not include a `pagination_token`, there are no more imports to return.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * List all recent and ongoing import operations.  By default, `list_imports` returns up to 100 imports per page. If the `limit` parameter is set, `list` returns up to that number of imports instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of imports. When the response does not include a `pagination_token`, there are no more imports to return.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * List imports
      */
     async listBulkImportsRaw(requestParameters: ListBulkImportsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ListImportsResponse>> {
@@ -160,7 +160,7 @@ export class BulkOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * List all recent and ongoing import operations.  By default, `list_imports` returns up to 100 imports per page. If the `limit` parameter is set, `list` returns up to that number of imports instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of imports. When the response does not include a `pagination_token`, there are no more imports to return.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * List all recent and ongoing import operations.  By default, `list_imports` returns up to 100 imports per page. If the `limit` parameter is set, `list` returns up to that number of imports instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of imports. When the response does not include a `pagination_token`, there are no more imports to return.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * List imports
      */
     async listBulkImports(requestParameters: ListBulkImportsRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListImportsResponse> {
@@ -169,7 +169,7 @@ export class BulkOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Start an asynchronous import of vectors from object storage into an index.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * Start an asynchronous import of vectors from object storage into an index.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * Start import
      */
     async startBulkImportRaw(requestParameters: StartBulkImportRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<StartImportResponse>> {
@@ -199,7 +199,7 @@ export class BulkOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Start an asynchronous import of vectors from object storage into an index.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/data/import-data).
+     * Start an asynchronous import of vectors from object storage into an index.  For guidance and examples, see [Import data](https://docs.pinecone.io/guides/index-data/import-data).
      * Start import
      */
     async startBulkImport(requestParameters: StartBulkImportRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<StartImportResponse> {

--- a/src/pinecone-generated-ts-fetch/db_data/apis/VectorOperationsApi.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/apis/VectorOperationsApi.ts
@@ -109,7 +109,7 @@ export interface UpsertVectorsRequest {
 export class VectorOperationsApi extends runtime.BaseAPI {
 
     /**
-     * Delete vectors by id from a single namespace.  For guidance and examples, see [Delete data](https://docs.pinecone.io/guides/data/delete-data).
+     * Delete vectors by id from a single namespace.  For guidance and examples, see [Delete data](https://docs.pinecone.io/guides/manage-data/delete-data).
      * Delete vectors
      */
     async deleteVectorsRaw(requestParameters: DeleteVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<object>> {
@@ -139,7 +139,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Delete vectors by id from a single namespace.  For guidance and examples, see [Delete data](https://docs.pinecone.io/guides/data/delete-data).
+     * Delete vectors by id from a single namespace.  For guidance and examples, see [Delete data](https://docs.pinecone.io/guides/manage-data/delete-data).
      * Delete vectors
      */
     async deleteVectors(requestParameters: DeleteVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<object> {
@@ -187,7 +187,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Look up and return vectors by ID from a single namespace. The returned vectors include the vector data and/or metadata.  For guidance and examples, see [Fetch data](https://docs.pinecone.io/guides/data/fetch-data).
+     * Look up and return vectors by ID from a single namespace. The returned vectors include the vector data and/or metadata.  For guidance and examples, see [Fetch data](https://docs.pinecone.io/guides/manage-data/fetch-data).
      * Fetch vectors
      */
     async fetchVectorsRaw(requestParameters: FetchVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FetchResponse>> {
@@ -222,7 +222,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Look up and return vectors by ID from a single namespace. The returned vectors include the vector data and/or metadata.  For guidance and examples, see [Fetch data](https://docs.pinecone.io/guides/data/fetch-data).
+     * Look up and return vectors by ID from a single namespace. The returned vectors include the vector data and/or metadata.  For guidance and examples, see [Fetch data](https://docs.pinecone.io/guides/manage-data/fetch-data).
      * Fetch vectors
      */
     async fetchVectors(requestParameters: FetchVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FetchResponse> {
@@ -231,7 +231,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * List the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.  Returns up to 100 IDs at a time by default in sorted order (bitwise \"C\" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.  For guidance and examples, see [List record IDs](https://docs.pinecone.io/guides/data/list-record-ids).  **Note:** `list` is supported only for serverless indexes.
+     * List the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.  Returns up to 100 IDs at a time by default in sorted order (bitwise \"C\" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.  For guidance and examples, see [List record IDs](https://docs.pinecone.io/guides/manage-data/list-record-ids).  **Note:** `list` is supported only for serverless indexes.
      * List vector IDs
      */
     async listVectorsRaw(requestParameters: ListVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ListResponse>> {
@@ -270,7 +270,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * List the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.  Returns up to 100 IDs at a time by default in sorted order (bitwise \"C\" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.  For guidance and examples, see [List record IDs](https://docs.pinecone.io/guides/data/list-record-ids).  **Note:** `list` is supported only for serverless indexes.
+     * List the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.  Returns up to 100 IDs at a time by default in sorted order (bitwise \"C\" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.  For guidance and examples, see [List record IDs](https://docs.pinecone.io/guides/manage-data/list-record-ids).  **Note:** `list` is supported only for serverless indexes.
      * List vector IDs
      */
     async listVectors(requestParameters: ListVectorsRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListResponse> {
@@ -279,7 +279,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance and examples, see [Query data](https://docs.pinecone.io/guides/data/query-data).
+     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
      * Search with a vector
      */
     async queryVectorsRaw(requestParameters: QueryVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<QueryResponse>> {
@@ -309,7 +309,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance and examples, see [Query data](https://docs.pinecone.io/guides/data/query-data).
+     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
      * Search with a vector
      */
     async queryVectors(requestParameters: QueryVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<QueryResponse> {
@@ -318,7 +318,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance and examples, see [Query data](https://docs.pinecone.io/guides/data/query-data).
+     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
      * Search with text
      */
     async searchRecordsNamespaceRaw(requestParameters: SearchRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SearchRecordsResponse>> {
@@ -352,7 +352,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance and examples, see [Query data](https://docs.pinecone.io/guides/data/query-data).
+     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
      * Search with text
      */
     async searchRecordsNamespace(requestParameters: SearchRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<SearchRecordsResponse> {
@@ -361,7 +361,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Update a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.  For guidance and examples, see [Update data](https://docs.pinecone.io/guides/data/update-data).
+     * Update a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.  For guidance and examples, see [Update data](https://docs.pinecone.io/guides/manage-data/update-data).
      * Update a vector
      */
     async updateVectorRaw(requestParameters: UpdateVectorRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<object>> {
@@ -391,7 +391,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Update a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.  For guidance and examples, see [Update data](https://docs.pinecone.io/guides/data/update-data).
+     * Update a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.  For guidance and examples, see [Update data](https://docs.pinecone.io/guides/manage-data/update-data).
      * Update a vector
      */
     async updateVector(requestParameters: UpdateVectorRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<object> {
@@ -400,7 +400,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/data/upsert-data#upsert-text).
+     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-text).
      * Upsert text
      */
     async upsertRecordsNamespaceRaw(requestParameters: UpsertRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
@@ -434,7 +434,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/data/upsert-data#upsert-text).
+     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-text).
      * Upsert text
      */
     async upsertRecordsNamespace(requestParameters: UpsertRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
@@ -442,7 +442,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/data/upsert-data#upsert-vectors).
+     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-vectors).
      * Upsert vectors
      */
     async upsertVectorsRaw(requestParameters: UpsertVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UpsertResponse>> {
@@ -472,7 +472,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/data/upsert-data#upsert-vectors).
+     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-vectors).
      * Upsert vectors
      */
     async upsertVectors(requestParameters: UpsertVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UpsertResponse> {

--- a/src/pinecone-generated-ts-fetch/db_data/models/DeleteRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/DeleteRequest.ts
@@ -38,7 +38,7 @@ export interface DeleteRequest {
      */
     namespace?: string;
     /**
-     * If specified, the metadata filter here will be used to select the vectors to delete. This is mutually exclusive with specifying ids to delete in the ids param or using delete_all=True. See [Understanding metadata](https://docs.pinecone.io/guides/data/understanding-metadata).
+     * If specified, the metadata filter here will be used to select the vectors to delete. This is mutually exclusive with specifying ids to delete in the ids param or using delete_all=True. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
      * Serverless indexes do not support delete by metadata. Instead, you can use the `list` operation to fetch the vector IDs based on their common ID prefix and then delete the records by ID.
      * @type {object}
      * @memberof DeleteRequest

--- a/src/pinecone-generated-ts-fetch/db_data/models/DescribeIndexStatsRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/DescribeIndexStatsRequest.ts
@@ -20,7 +20,7 @@ import { exists, mapValues } from '../runtime';
  */
 export interface DescribeIndexStatsRequest {
     /**
-     * If this parameter is present, the operation only returns statistics for vectors that satisfy the filter. See [Understanding metadata](https://docs.pinecone.io/guides/data/understanding-metadata).
+     * If this parameter is present, the operation only returns statistics for vectors that satisfy the filter. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
      * 
      * Serverless indexes do not support filtering `describe_index_stats` by metadata.
      * @type {object}

--- a/src/pinecone-generated-ts-fetch/db_data/models/QueryRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/QueryRequest.ts
@@ -45,7 +45,7 @@ export interface QueryRequest {
      */
     topK: number;
     /**
-     * The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/data/understanding-metadata). You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/data/understanding-metadata).
+     * The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata). You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
      * @type {object}
      * @memberof QueryRequest
      */

--- a/src/pinecone-generated-ts-fetch/db_data/models/SearchRecordsRequestQuery.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/SearchRecordsRequestQuery.ts
@@ -33,7 +33,7 @@ export interface SearchRecordsRequestQuery {
      */
     topK: number;
     /**
-     * The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/data/understanding-metadata).
+     * The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
      * @type {object}
      * @memberof SearchRecordsRequestQuery
      */

--- a/src/pinecone-generated-ts-fetch/db_data/models/SearchRecordsRequestRerank.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/SearchRecordsRequestRerank.ts
@@ -20,7 +20,7 @@ import { exists, mapValues } from '../runtime';
  */
 export interface SearchRecordsRequestRerank {
     /**
-     * The name of the [reranking model](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models) to use.
+     * The name of the [reranking model](https://docs.pinecone.io/guides/search/rerank-results#reranking-models) to use.
      * @type {string}
      * @memberof SearchRecordsRequestRerank
      */
@@ -28,7 +28,7 @@ export interface SearchRecordsRequestRerank {
     /**
      * The field(s) to consider for reranking. If not provided, the default is `["text"]`.
      * 
-     * The number of fields supported is [model-specific](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models).
+     * The number of fields supported is [model-specific](https://docs.pinecone.io/guides/search/rerank-results#reranking-models).
      * @type {Array<string>}
      * @memberof SearchRecordsRequestRerank
      */
@@ -40,7 +40,7 @@ export interface SearchRecordsRequestRerank {
      */
     topN?: number;
     /**
-     * Additional model-specific parameters. Refer to the [model guide](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models) for available model parameters.
+     * Additional model-specific parameters. Refer to the [model guide](https://docs.pinecone.io/guides/search/rerank-results#reranking-models) for available model parameters.
      * @type {{ [key: string]: any; }}
      * @memberof SearchRecordsRequestRerank
      */

--- a/src/pinecone-generated-ts-fetch/db_data/models/StartImportRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/StartImportRequest.ts
@@ -33,7 +33,7 @@ export interface StartImportRequest {
      */
     integrationId?: string;
     /**
-     * The [URI prefix](https://docs.pinecone.io/guides/data/understanding-imports#directory-structure) under which the data to import is available. All data within this prefix will be listed then imported into the target index. Currently only `s3://` URIs are supported.
+     * The [URI prefix](https://docs.pinecone.io/guides/index-data/import-data#prepare-your-data) under which the data to import is available. All data within this prefix will be listed then imported into the target index. Currently only `s3://` URIs are supported.
      * @type {string}
      * @memberof StartImportRequest
      */

--- a/src/pinecone-generated-ts-fetch/inference/apis/InferenceApi.ts
+++ b/src/pinecone-generated-ts-fetch/inference/apis/InferenceApi.ts
@@ -63,7 +63,7 @@ export interface RerankOperationRequest {
 export class InferenceApi extends runtime.BaseAPI {
 
     /**
-     * Generate vector embeddings for input data. This endpoint uses [Pinecone Inference](https://docs.pinecone.io/guides/inference/understanding-inference).  For guidance and examples, see [Embed data](https://docs.pinecone.io/guides/inference/generate-embeddings).
+     * Generate vector embeddings for input data. This endpoint uses [Pinecone Inference](https://docs.pinecone.io/guides/index-data/indexing-overview#vector-embedding).
      * Generate vectors
      */
     async embedRaw(requestParameters: EmbedOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<EmbeddingsList>> {
@@ -89,7 +89,7 @@ export class InferenceApi extends runtime.BaseAPI {
     }
 
     /**
-     * Generate vector embeddings for input data. This endpoint uses [Pinecone Inference](https://docs.pinecone.io/guides/inference/understanding-inference).  For guidance and examples, see [Embed data](https://docs.pinecone.io/guides/inference/generate-embeddings).
+     * Generate vector embeddings for input data. This endpoint uses [Pinecone Inference](https://docs.pinecone.io/guides/index-data/indexing-overview#vector-embedding).
      * Generate vectors
      */
     async embed(requestParameters: EmbedOperationRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<EmbeddingsList> {
@@ -174,7 +174,7 @@ export class InferenceApi extends runtime.BaseAPI {
     }
 
     /**
-     * Rerank documents according to their relevance to a query.  For guidance and examples, see [Rerank documents](https://docs.pinecone.io/guides/inference/rerank).
+     * Rerank documents according to their relevance to a query.  For guidance and examples, see [Rerank results](https://docs.pinecone.io/guides/search/rerank-results).
      * Rerank documents
      */
     async rerankRaw(requestParameters: RerankOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<RerankResult>> {
@@ -200,7 +200,7 @@ export class InferenceApi extends runtime.BaseAPI {
     }
 
     /**
-     * Rerank documents according to their relevance to a query.  For guidance and examples, see [Rerank documents](https://docs.pinecone.io/guides/inference/rerank).
+     * Rerank documents according to their relevance to a query.  For guidance and examples, see [Rerank results](https://docs.pinecone.io/guides/search/rerank-results).
      * Rerank documents
      */
     async rerank(requestParameters: RerankOperationRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<RerankResult> {

--- a/src/pinecone-generated-ts-fetch/inference/models/EmbedRequest.ts
+++ b/src/pinecone-generated-ts-fetch/inference/models/EmbedRequest.ts
@@ -27,13 +27,13 @@ import {
  */
 export interface EmbedRequest {
     /**
-     * The [model](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models) to use for embedding generation.
+     * The [model](https://docs.pinecone.io/guides/index-data/create-an-index#embedding-models) to use for embedding generation.
      * @type {string}
      * @memberof EmbedRequest
      */
     model: string;
     /**
-     * Additional model-specific parameters. Refer to the [model guide](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models) for available model parameters.
+     * Additional model-specific parameters. Refer to the [model guide](https://docs.pinecone.io/guides/index-data/create-an-index#embedding-models) for available model parameters.
      * @type {{ [key: string]: any; }}
      * @memberof EmbedRequest
      */

--- a/src/pinecone-generated-ts-fetch/inference/models/ModelInfo.ts
+++ b/src/pinecone-generated-ts-fetch/inference/models/ModelInfo.ts
@@ -37,7 +37,7 @@ export interface ModelInfo {
      * @type {string}
      * @memberof ModelInfo
      */
-    name: string;
+    model: string;
     /**
      * A summary of the model.
      * @type {string}
@@ -131,7 +131,7 @@ export type ModelInfoVectorTypeEnum = typeof ModelInfoVectorTypeEnum[keyof typeo
  */
 export function instanceOfModelInfo(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "name" in value;
+    isInstance = isInstance && "model" in value;
     isInstance = isInstance && "shortDescription" in value;
     isInstance = isInstance && "type" in value;
     isInstance = isInstance && "supportedParameters" in value;
@@ -149,7 +149,7 @@ export function ModelInfoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     }
     return {
         
-        'name': json['name'],
+        'model': json['model'],
         'shortDescription': json['short_description'],
         'type': json['type'],
         'vectorType': !exists(json, 'vector_type') ? undefined : json['vector_type'],
@@ -173,7 +173,7 @@ export function ModelInfoToJSON(value?: ModelInfo | null): any {
     }
     return {
         
-        'name': value.name,
+        'model': value.model,
         'short_description': value.shortDescription,
         'type': value.type,
         'vector_type': value.vectorType,

--- a/src/pinecone-generated-ts-fetch/inference/models/RerankRequest.ts
+++ b/src/pinecone-generated-ts-fetch/inference/models/RerankRequest.ts
@@ -20,7 +20,7 @@ import { exists, mapValues } from '../runtime';
  */
 export interface RerankRequest {
     /**
-     * The [model](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models) to use for reranking.
+     * The [model](https://docs.pinecone.io/guides/search/rerank-results#reranking-models) to use for reranking.
      * @type {string}
      * @memberof RerankRequest
      */
@@ -46,7 +46,7 @@ export interface RerankRequest {
     /**
      * The field(s) to consider for reranking. If not provided, the default is `["text"]`.
      * 
-     * The number of fields supported is [model-specific](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models).
+     * The number of fields supported is [model-specific](https://docs.pinecone.io/guides/search/rerank-results#reranking-models).
      * @type {Array<string>}
      * @memberof RerankRequest
      */
@@ -58,7 +58,7 @@ export interface RerankRequest {
      */
     documents: Array<{ [key: string]: any; }>;
     /**
-     * Additional model-specific parameters. Refer to the [model guide](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models) for available model parameters.
+     * Additional model-specific parameters. Refer to the [model guide](https://docs.pinecone.io/guides/search/rerank-results#reranking-models) for available model parameters.
      * @type {{ [key: string]: any; }}
      * @memberof RerankRequest
      */

--- a/src/pinecone.ts
+++ b/src/pinecone.ts
@@ -52,7 +52,6 @@ import {
 import { Index } from './data';
 import type { PineconeConfiguration, RecordMetadata } from './data';
 import { Inference } from './inference';
-import { inferenceOperationsBuilder } from './inference/inferenceOperationsBuilder';
 import { isBrowser } from './utils/environment';
 import { ValidateObjectProperties } from './utils/validateObjectProperties';
 import { PineconeConfigurationProperties } from './data/vectors/types';
@@ -180,7 +179,6 @@ export class Pinecone {
     this._checkForBrowser();
 
     const api = indexOperationsBuilder(this.config);
-    const infApi = inferenceOperationsBuilder(this.config);
     const asstControlApi = asstControlOperationsBuilder(this.config);
 
     this._configureIndex = configureIndex(api);
@@ -208,7 +206,7 @@ export class Pinecone {
     this._listBackups = listBackups(api);
     this._listRestoreJobs = listRestoreJobs(api);
 
-    this.inference = new Inference(infApi);
+    this.inference = new Inference(this.config);
   }
 
   /**


### PR DESCRIPTION
## Problem
Inference has new APIs which were made available in `2025-04`. These allow for listing and describing available models hosted by Pinecone.

## Solution

- I took the liberty to refactor the `Inference` class to better align with other classes used in a similar way such as `Index` and `Pinecone`. I broke out all inference actions into individual files / functions: `embed.ts` and `rerank.ts`. I think a lot of this was implemented rather quickly initially, so I've done a bunch of cleanup while I was in here adding new methods.
- Add new `getModel.ts` and `listModels.ts` files/functions. These are called and documented inside `Inference`.
- Rework unit tests for `embed` and `rerank`. Basically just standardized to how we do mocking / testing elsewhere. They were a bit awkward.
- Add unit tests for `getModel`, `listModels`, along with an integration test file.
- Update README to add examples working with models.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - external test, unit tests, integration tests

To test this you can pull this branch down, and run the repl locally:

from `pinecone-ts-client` root:
```
export PINECONE_API_KEY=<here>
npm run repl
await init()

await client.inference.listModels()
await client.inference.getModel('multilingual-e5-large')
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209828518477622