### PR TITLE
Add `ChatContextOptions` to `ChatOptions`

### DIFF
--- a/src/assistant/data/chat.ts
+++ b/src/assistant/data/chat.ts
@@ -30,6 +30,7 @@ export const chat = (
         filter: options.filter,
         jsonResponse: options.jsonResponse,
         includeHighlights: options.includeHighlights,
+        contextOptions: options.contextOptions,
       },
     };
 

--- a/src/assistant/data/chat.ts
+++ b/src/assistant/data/chat.ts
@@ -21,6 +21,7 @@ export const chat = (
     const api = await apiProvider.provideData();
     const messages = messagesValidation(options) as MessageModel[];
     const model = modelValidation(options);
+
     const request: ChatAssistantRequest = {
       assistantName: assistantName,
       chat: {
@@ -30,7 +31,11 @@ export const chat = (
         filter: options.filter,
         jsonResponse: options.jsonResponse,
         includeHighlights: options.includeHighlights,
-        contextOptions: options.contextOptions,
+        contextOptions: {
+          // use topK from contextOptions if provided, otherwise use topK from options
+          topK: options.contextOptions?.topK || options.topK,
+          snippetSize: options.contextOptions?.snippetSize,
+        },
       },
     };
 

--- a/src/assistant/data/chatStream.ts
+++ b/src/assistant/data/chatStream.ts
@@ -43,8 +43,12 @@ export const chatStream = (
     let contextOptions: object | void = undefined;
     if (options.contextOptions?.topK || options.contextOptions?.snippetSize) {
       contextOptions = {
-        top_k: options.contextOptions.topK,
-        snippet_size: options.contextOptions.snippetSize,
+        top_k: options.contextOptions?.topK || options.topK,
+        snippet_size: options.contextOptions?.snippetSize,
+      };
+    } else if (options.topK) {
+      contextOptions = {
+        top_k: options.topK,
       };
     }
 

--- a/src/assistant/data/chatStream.ts
+++ b/src/assistant/data/chatStream.ts
@@ -5,7 +5,11 @@ import {
 import type { PineconeConfiguration } from '../../data';
 import { buildUserAgent, getFetch, ChatStream } from '../../utils';
 import { AsstDataOperationsProvider } from './asstDataOperationsProvider';
-import type { ChatOptions, StreamedChatResponse } from './types';
+import type {
+  ChatOptions,
+  ContextOptions,
+  StreamedChatResponse,
+} from './types';
 import { handleApiError } from '../../errors';
 import { ReadableStream } from 'node:stream/web';
 import { Readable } from 'node:stream';
@@ -35,6 +39,16 @@ export const chatStream = (
       'X-Pinecone-Api-Version': X_PINECONE_API_VERSION,
     };
 
+    // format context options
+    let contextOptions: object | void = undefined;
+    if (options.contextOptions?.topK || options.contextOptions?.snippetSize) {
+      contextOptions = {
+        top_k: options.contextOptions.topK,
+        snippet_size: options.contextOptions.snippetSize,
+      };
+    }
+
+    // we call the API directly via fetch, so we need to snake_case the keys (normally generated code handles this)
     const response = await fetch(chatUrl, {
       method: 'POST',
       headers: requestHeaders,
@@ -43,7 +57,9 @@ export const chatStream = (
         stream: true,
         model: modelValidation(options),
         filter: options.filter,
-        includeHighlights: options.includeHighlights,
+        json_response: options.jsonResponse,
+        include_highlights: options.includeHighlights,
+        context_options: contextOptions,
       }),
     });
 

--- a/src/assistant/data/context.ts
+++ b/src/assistant/data/context.ts
@@ -50,6 +50,9 @@ export const context = (
       contextRequest: {
         query: options.query,
         filter: options.filter,
+        messages: options.messages,
+        topK: options.topK,
+        snippetSize: options.snippetSize,
       },
     } as ContextAssistantRequest;
     return await api.contextAssistant(request);

--- a/src/assistant/data/types.ts
+++ b/src/assistant/data/types.ts
@@ -163,6 +163,7 @@ export const ChatOptionsType: ChatOptionsType[] = [
   'filter',
   'jsonResponse',
   'includeHighlights',
+  'topK',
   'contextOptions',
 ];
 

--- a/src/assistant/data/types.ts
+++ b/src/assistant/data/types.ts
@@ -143,7 +143,15 @@ export interface ChatOptions {
    * If true, the assistant will be instructed to return highlights from the referenced documents that support its response.
    */
   includeHighlights?: boolean;
-
+  /**
+   * The maximum number of context snippets to use. Default is 16. Maximum is 64.
+   * `topK` can also be passed through `contextOptions`. If both are passed, `contextOptions.topK` will be used.
+   * @deprecated Use `contextOptions.topK` instead.
+   */
+  topK?: number;
+  /**
+   * Controls the context snippets sent to the LLM.
+   */
   contextOptions?: ChatContextOptions;
 }
 

--- a/src/assistant/data/types.ts
+++ b/src/assistant/data/types.ts
@@ -104,6 +104,20 @@ export interface MessageModel {
 export type MessagesModel = string[] | MessageModel[];
 
 /**
+ * Controls the context snippets sent to the LLM.
+ */
+export interface ChatContextOptions {
+  /**
+   * The maximum number of context snippets to use. Default is 16. Maximum is 64.
+   */
+  topK?: number;
+  /**
+   * The maximum context snippet size. Default is 2048 tokens. Minimum is 512 tokens. Maximum is 8192 tokens.
+   */
+  snippetSize?: number;
+}
+
+/**
  * Describes the request format for sending a `chat` or `chatStream` request to an assistant.
  */
 export interface ChatOptions {
@@ -129,6 +143,8 @@ export interface ChatOptions {
    * If true, the assistant will be instructed to return highlights from the referenced documents that support its response.
    */
   includeHighlights?: boolean;
+
+  contextOptions?: ChatContextOptions;
 }
 
 // Properties for validation to ensure no unkonwn/invalid properties are passed.
@@ -139,6 +155,7 @@ export const ChatOptionsType: ChatOptionsType[] = [
   'filter',
   'jsonResponse',
   'includeHighlights',
+  'contextOptions',
 ];
 
 /**
@@ -186,9 +203,13 @@ export interface ContextOptions {
    */
   filter?: Record<string, string>;
   /**
-   * The number of context snippets to return. Default is 15.
+   * The maximum number of context snippets to return. Default is 16. Maximum is 64.
    */
   topK?: number;
+  /**
+   * The maximum context snippet size. Default is 2048 tokens. Minimum is 512 tokens. Maximum is 8192 tokens.
+   */
+  snippetSize?: number;
 }
 
 type ContextOptionsType = keyof ContextOptions;

--- a/src/assistant/index.ts
+++ b/src/assistant/index.ts
@@ -27,6 +27,7 @@ export type {
 } from './control/types';
 export type {
   ChatOptions,
+  ChatContextOptions,
   ChatCompletionOptions,
   ChatModelEnum,
   ChoiceModel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export type {
   AssistantModel,
   AssistantStatusEnum,
   ChatOptions,
+  ChatContextOptions,
   ChatCompletionOptions,
   ChatModelEnum,
   ChoiceModel,


### PR DESCRIPTION
## Problem
There was a change made to the Assistant chat interface in the last release that were not captured in the TypeScript client - `topK` and `snippetSize` have been moved into a `context_options` value: https://docs.pinecone.io/reference/api/2025-04/assistant/chat_assistant#body-context-options. The client currently has `topK` at the top level of the `ChatOptions` payload.

While cleaning this up I also noticed a few inconsistencies with how some things are being passed to the Assistant API which I've also addressed here. There's some added complexity in the TypeScript implementation for Assistant as the generated code did not fully cover implementation for streaming and file upload, so `chatStream`, `chatCompletionStream`,  and `uploadFile` all use `fetch` directly rather than plumbing through generated code.

This looks to address this community post: https://community.pinecone.io/t/pinecone-assistant-chatstream-topk-and-snippet-size/8065/1

## Solution

- Add and export `ChatContextOptions` as a new type which wraps `topK` and `snippetSize`. To keep this somewhat non-breaking, I've left the `topK` field at the top of the `ChatOptions` interface as well. There's a bit of logic to use this if present, and otherwise use `contextOptions.topK`. I wanted to keep things non-breaking so we could release this as a minor upgrade.
- In the `chatStream`, `chatCompletionStream` functions we need to manually convert the keys of the passed objects to snake case. The API is expecting snakecase, and normally the generated OpenAPI types handle this for us. Since we're not using those directly in these cases, we need to handle this ourselves. I had missed this previously, although I did handle converting responses from snake to camel where necessary. I know this is a bit confusing - apologies.
- The `context` function wasn't passing `messages`, `topK`, or `snippetSize` properly. This was just a miss on my part.

We need better testing coverage in general for assistant operations. The implementation was a bit rushed on my part earlier this year.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - external app tests, unit tests, integration tests

Manually tested using the assistant interface via repl. You can pull this branch down yourself and play around using `npm run repl` locally:
```bash
npm run repl
await init()

await client.createAssistant({ name: 'test-assistant' })

# you'll need to use a local path
await client.Assistant('test-assistant').uploadFile({ path: '/Users/austin/Downloads/A_Primer_on_Memory_Consistency_and_Cache_Coherence-2nd-Edition.pdf', metadata: { genre: 'classical', meat: 'cute' }})

# wait for file to process, etc

# non-streaming chat, contextOptions
await client.assistant('test-assistant').chat({ messages: [{ role: 'user', content: 'tell me a few basics about caching'}], model: 'claude-3-5-sonnet', filter: { genre: 'classical'}, jsonResponse: true, includeHighlights: true, contextOptions: {topK:20, snippetSize: 584 }})

# non-streaming chat, topK only
await client.assistant('test-assistant').chat({ messages: [{ role: 'user', content: 'tell me a few basics about caching'}], model: 'claude-3-5-sonnet', filter: { genre: 'classical'}, jsonResponse: true, includeHighlights: true, topK: 20})

# streaming chat, contextOptions
const chatStream = await client.assistant('test-assistant').chatStream({ messages: [{ role: 'user', content: 'tell me a few basics about caching'}], model: 'claude-3-5-sonnet', filter: { genre: 'classical'}, includeHighlights: true, contextOptions: {topK:20, snippetSize: 584 }})
for await (const chunk of chatStream) { console.log(chunk) }

# streaming chat, contextOptions
const chatStream = await client.assistant('test-assistant').chatStream({ messages: [{ role: 'user', content: 'tell me a few basics about caching'}], model: 'claude-3-5-sonnet', filter: { genre: 'classical'}, includeHighlights: true, topK: 20})
for await (const chunk of chatStream) { console.log(chunk) }
```

Here are some examples with PINECONE_DEBUG output from my local runs:
```
> await client.assistant('test-assistant').chat({ messages: [{ role: 'user', content: 'tell me a few basics about caching'}], model: 'claude-3-5-sonnet', filter: { genre: 'classical'}, jsonResponse: true, includeHighlights: true, contextOptions: {topK:20, snippetSize: 584 }})
>>> Request: GET https://api.pinecone.io/assistant/assistants/test-assistant
>>> Headers: {"User-Agent":"@pinecone-database/pinecone v6.0.1; lang=typescript; node v18.17.1","X-Pinecone-Api-Version":"2025-04","Api-Key":"***REDACTED***"}

<<< Status: 200
<<< Body: {"name":"test-assistant","instructions":null,"metadata":null,"status":"Ready","host":"https://prod-1-data.ke.pinecone.io","created_at":"2025-05-30T16:51:21.987343597Z","updated_at":"2025-05-30T16:51:22.374927670Z"}

curl -X GET https://api.pinecone.io/assistant/assistants/test-assistant -H "Api-Key: ****REDACTED***" 

>>> Request: POST https://prod-1-data.ke.pinecone.io/assistant/chat/test-assistant
>>> Headers: {"User-Agent":"@pinecone-database/pinecone v6.0.1; lang=typescript; node v18.17.1","X-Pinecone-Api-Version":"2025-04","Content-Type":"application/json","Api-Key":"***REDACTED***"}
>>> Body: {"messages":[{"role":"user","content":"tell me a few basics about caching"}],"stream":false,"model":"claude-3-5-sonnet","filter":{"genre":"classical"},"json_response":true,"include_highlights":true,"context_options":{"top_k":20,"snippet_size":584}}

<<< Status: 200
<<< Body: {"finish_reason":"stop","message":{"role":"assistant","content":"{\n  \"basics\": [\n ... ETC }

curl -X POST https://prod-1-data.ke.pinecone.io/assistant/chat/test-assistant -H "Api-Key: ***REDACTED***" -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"tell me a few basics about caching"}],"stream":false,"model":"claude-3-5-sonnet","filter":{"genre":"classical"},"json_response":true,"include_highlights":true,"context_options":{"top_k":20,"snippet_size":584}}'

{
  id: '00000000000000005ec73ab3e9e573ad',
  finishReason: 'stop',
  message: {
    role: 'assistant',
    content: '{\n' +
      '  "basics": [\n' +
      '    "Caches are used to reduce average latencies to access storage structures.",\n' +
      '    "A typical system model includes a multicore processor chip with private data caches for each core and a shared last-level cache (LLC).",\n' +
      '    "Cache coherence is needed to maintain consistency between multiple cached copies of data.",\n' +
      '    "The granularity of coherence is usually maintained at the level of cache blocks, rather than individual bytes.",\n' +
      '    "Common cache states include Modified (M), Shared (S), and Invalid (I), which are part of the MSI protocol."\n' +
      '  ]\n' +
      '}'
  },
  model: 'arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0',
  citations: [
    { position: 93, references: [Array] },
    { position: 235, references: [Array] },
    { position: 332, references: [Array] },
    { position: 450, references: [Array] },
    { position: 564, references: [Array] }
  ],
  usage: { promptTokens: 13795, completionTokens: 189, totalTokens: 13984 }
}
```

```
>  await client.assistant('test-assistant').chat({ messages: [{ role: 'user', content: 'tell me a few basics about caching'}], model: 'claude-3-5-sonnet', filter: { genre: 'classical'}, jsonResponse: true, includeHighlights: true, topK: 20})
>>> Request: GET https://api.pinecone.io/assistant/assistants/test-assistant
>>> Headers: {"User-Agent":"@pinecone-database/pinecone v6.0.1; lang=typescript; node v18.17.1","X-Pinecone-Api-Version":"2025-04","Api-Key":"***REDACTED***"}

<<< Status: 200
<<< Body: {"name":"test-assistant","instructions":null,"metadata":null,"status":"Ready","host":"https://prod-1-data.ke.pinecone.io","created_at":"2025-05-30T16:51:21.987343597Z","updated_at":"2025-05-30T16:51:22.374927670Z"}

curl -X GET https://api.pinecone.io/assistant/assistants/test-assistant -H "Api-Key: ***REDACTED***" 

>>> Request: POST https://prod-1-data.ke.pinecone.io/assistant/chat/test-assistant
>>> Headers: {"User-Agent":"@pinecone-database/pinecone v6.0.1; lang=typescript; node v18.17.1","X-Pinecone-Api-Version":"2025-04","Content-Type":"application/json","Api-Key":"***REDACTED***"}
>>> Body: {"messages":[{"role":"user","content":"tell me a few basics about caching"}],"stream":false,"model":"claude-3-5-sonnet","filter":{"genre":"classical"},"json_response":true,"include_highlights":true,"context_options":{"top_k":20}}

<<< Status: 200
<<< Body: {"finish_reason":"stop","message":{"role":"assistant","content":"{\n  \"basics\":...ETC}

curl -X POST https://prod-1-data.ke.pinecone.io/assistant/chat/test-assistant -H "Api-Key: ***REDACTED***" -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"tell me a few basics about caching"}],"stream":false,"model":"claude-3-5-sonnet","filter":{"genre":"classical"},"json_response":true,"include_highlights":true,"context_options":{"top_k":20}}'

{
  id: '00000000000000004e4877c14db3faa7',
  finishReason: 'stop',
  message: {
    role: 'assistant',
    content: '{\n' +
      '  "basics": [\n' +
      '    "Caches are used to store recently accessed data for faster retrieval, reducing the need to access slower main memory. A cache contains copies of data from frequently used main memory locations.",\n' +
      '    "There are typically multiple levels of caches in a system, including private level-one (L1) caches for each processor core and a shared last-level cache (LLC).",\n' +
      '    "Caches can be virtually addressed or physically addressed. Most modern systems use physically addressed caches, where the cache is accessed using physical memory addresses.",\n' +
      '    "Cache coherence is needed to ensure that multiple copies of data in different caches remain consistent. Coherence protocols define rules for maintaining consistency between caches.",\n' +
      '    "Two main types of coherence protocols are snooping protocols, which broadcast requests to all caches, and directory protocols, which use a centralized directory to track which caches have copies of data."\n' +
      '  ]\n' +
      '}'
  },
  model: 'arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0',
  citations: [
    { position: 137, references: [Array] },
    { position: 380, references: [Array] },
    { position: 446, references: [Array] },
    { position: 560, references: [Array] },
    { position: 671, references: [Array] },
    { position: 748, references: [Array] },
    { position: 959, references: [Array] }
  ],
  usage: { promptTokens: 46851, completionTokens: 286, totalTokens: 47137 }
}
```
