### PR TITLE
Regenerate core, expose `privateHost` and `temperature`

### DIFF
--- a/src/assistant/data/types.ts
+++ b/src/assistant/data/types.ts
@@ -132,6 +132,12 @@ export interface ChatOptions {
    */
   model?: string;
   /**
+   * Controls the randomness of the model's output: lower values make responses more deterministic,
+   * while higher values increase creativity and variability. If the model does not support a temperature parameter, the parameter will be ignored.
+   */
+  temperature?: number;
+
+  /**
    * A filter against which documents can be retrieved.
    */
   filter?: object;
@@ -160,6 +166,7 @@ type ChatOptionsType = keyof ChatOptions;
 export const ChatOptionsType: ChatOptionsType[] = [
   'messages',
   'model',
+  'temperature',
   'filter',
   'jsonResponse',
   'includeHighlights',
@@ -182,6 +189,11 @@ export interface ChatCompletionOptions {
    */
   model?: string;
   /**
+   * Controls the randomness of the model's output: lower values make responses more deterministic,
+   * while higher values increase creativity and variability. If the model does not support a temperature parameter, the parameter will be ignored.
+   */
+  temperature?: number;
+  /**
    * A filter against which documents can be retrieved.
    */
   filter?: object;
@@ -192,6 +204,7 @@ type ChatCompletionOptionsType = keyof ChatCompletionOptions;
 export const ChatCompletionOptionsType: ChatCompletionOptionsType[] = [
   'messages',
   'model',
+  'temperature',
   'filter',
 ];
 

--- a/src/pinecone-generated-ts-fetch/assistant_data/models/Chat.ts
+++ b/src/pinecone-generated-ts-fetch/assistant_data/models/Chat.ts
@@ -51,6 +51,12 @@ export interface Chat {
      */
     model?: ChatModelEnum;
     /**
+     * Controls the randomness of the model's output: lower values make responses more deterministic, while higher values increase creativity and variability. If the model does not support a temperature parameter, the parameter will be ignored.
+     * @type {number}
+     * @memberof Chat
+     */
+    temperature?: number;
+    /**
      * Optionally filter which documents can be retrieved using the following metadata fields.
      * @type {object}
      * @memberof Chat
@@ -82,7 +88,11 @@ export interface Chat {
  */
 export const ChatModelEnum = {
     Gpt4o: 'gpt-4o',
-    Claude35Sonnet: 'claude-3-5-sonnet'
+    Gpt41: 'gpt-4.1',
+    O4Mini: 'o4-mini',
+    Claude35Sonnet: 'claude-3-5-sonnet',
+    Claude37Sonnet: 'claude-3-7-sonnet',
+    Gemini25Pro: 'gemini-2.5-pro'
 } as const;
 export type ChatModelEnum = typeof ChatModelEnum[keyof typeof ChatModelEnum];
 
@@ -110,6 +120,7 @@ export function ChatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Chat
         'messages': ((json['messages'] as Array<any>).map(MessageModelFromJSON)),
         'stream': !exists(json, 'stream') ? undefined : json['stream'],
         'model': !exists(json, 'model') ? undefined : json['model'],
+        'temperature': !exists(json, 'temperature') ? undefined : json['temperature'],
         'filter': !exists(json, 'filter') ? undefined : json['filter'],
         'jsonResponse': !exists(json, 'json_response') ? undefined : json['json_response'],
         'includeHighlights': !exists(json, 'include_highlights') ? undefined : json['include_highlights'],
@@ -129,6 +140,7 @@ export function ChatToJSON(value?: Chat | null): any {
         'messages': ((value.messages as Array<any>).map(MessageModelToJSON)),
         'stream': value.stream,
         'model': value.model,
+        'temperature': value.temperature,
         'filter': value.filter,
         'json_response': value.jsonResponse,
         'include_highlights': value.includeHighlights,

--- a/src/pinecone-generated-ts-fetch/assistant_data/models/SearchCompletions.ts
+++ b/src/pinecone-generated-ts-fetch/assistant_data/models/SearchCompletions.ts
@@ -45,6 +45,12 @@ export interface SearchCompletions {
      */
     model?: SearchCompletionsModelEnum;
     /**
+     * Controls the randomness of the model's output: lower values make responses more deterministic, while higher values increase creativity and variability. If the model does not support a temperature parameter, the parameter will be ignored.
+     * @type {number}
+     * @memberof SearchCompletions
+     */
+    temperature?: number;
+    /**
      * Optionally filter which documents can be retrieved using the following metadata fields.
      * @type {object}
      * @memberof SearchCompletions
@@ -58,7 +64,11 @@ export interface SearchCompletions {
  */
 export const SearchCompletionsModelEnum = {
     Gpt4o: 'gpt-4o',
-    Claude35Sonnet: 'claude-3-5-sonnet'
+    Gpt41: 'gpt-4.1',
+    O4Mini: 'o4-mini',
+    Claude35Sonnet: 'claude-3-5-sonnet',
+    Claude37Sonnet: 'claude-3-7-sonnet',
+    Gemini25Pro: 'gemini-2.5-pro'
 } as const;
 export type SearchCompletionsModelEnum = typeof SearchCompletionsModelEnum[keyof typeof SearchCompletionsModelEnum];
 
@@ -86,6 +96,7 @@ export function SearchCompletionsFromJSONTyped(json: any, ignoreDiscriminator: b
         'messages': ((json['messages'] as Array<any>).map(MessageModelFromJSON)),
         'stream': !exists(json, 'stream') ? undefined : json['stream'],
         'model': !exists(json, 'model') ? undefined : json['model'],
+        'temperature': !exists(json, 'temperature') ? undefined : json['temperature'],
         'filter': !exists(json, 'filter') ? undefined : json['filter'],
     };
 }
@@ -102,6 +113,7 @@ export function SearchCompletionsToJSON(value?: SearchCompletions | null): any {
         'messages': ((value.messages as Array<any>).map(MessageModelToJSON)),
         'stream': value.stream,
         'model': value.model,
+        'temperature': value.temperature,
         'filter': value.filter,
     };
 }

--- a/src/pinecone-generated-ts-fetch/db_control/models/IndexModel.ts
+++ b/src/pinecone-generated-ts-fetch/db_control/models/IndexModel.ts
@@ -69,6 +69,12 @@ export interface IndexModel {
      */
     host: string;
     /**
+     * The private endpoint URL of an index.
+     * @type {string}
+     * @memberof IndexModel
+     */
+    privateHost?: string;
+    /**
      * 
      * @type {DeletionProtection}
      * @memberof IndexModel
@@ -147,6 +153,7 @@ export function IndexModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'dimension': !exists(json, 'dimension') ? undefined : json['dimension'],
         'metric': json['metric'],
         'host': json['host'],
+        'privateHost': !exists(json, 'private_host') ? undefined : json['private_host'],
         'deletionProtection': !exists(json, 'deletion_protection') ? undefined : DeletionProtectionFromJSON(json['deletion_protection']),
         'tags': !exists(json, 'tags') ? undefined : json['tags'],
         'embed': !exists(json, 'embed') ? undefined : ModelIndexEmbedFromJSON(json['embed']),
@@ -169,6 +176,7 @@ export function IndexModelToJSON(value?: IndexModel | null): any {
         'dimension': value.dimension,
         'metric': value.metric,
         'host': value.host,
+        'private_host': value.privateHost,
         'deletion_protection': DeletionProtectionToJSON(value.deletionProtection),
         'tags': value.tags,
         'embed': ModelIndexEmbedToJSON(value.embed),

--- a/src/pinecone-generated-ts-fetch/db_data/apis/VectorOperationsApi.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/apis/VectorOperationsApi.ts
@@ -279,7 +279,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
+     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance, examples, and limits, see [Search](https://docs.pinecone.io/guides/search/search-overview).
      * Search with a vector
      */
     async queryVectorsRaw(requestParameters: QueryVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<QueryResponse>> {
@@ -309,7 +309,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
+     * Search a namespace using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.  For guidance, examples, and limits, see [Search](https://docs.pinecone.io/guides/search/search-overview).
      * Search with a vector
      */
     async queryVectors(requestParameters: QueryVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<QueryResponse> {
@@ -318,7 +318,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
+     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance, examples, and limits, see [Search](https://docs.pinecone.io/guides/search/search-overview).
      * Search with text
      */
     async searchRecordsNamespaceRaw(requestParameters: SearchRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SearchRecordsResponse>> {
@@ -352,7 +352,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
+     * Search a namespace with a query text, query vector, or record ID and return the most similar records, along with their similarity scores. Optionally, rerank the initial results based on their relevance to the query.   Searching with text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/guides/indexes/create-an-index#integrated-embedding). Searching with a query vector or record ID is supported for all indexes.   For guidance, examples, and limits, see [Search](https://docs.pinecone.io/guides/search/search-overview).
      * Search with text
      */
     async searchRecordsNamespace(requestParameters: SearchRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<SearchRecordsResponse> {
@@ -400,7 +400,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-text).
+     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance, examples, and limits, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data).
      * Upsert text
      */
     async upsertRecordsNamespaceRaw(requestParameters: UpsertRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
@@ -434,7 +434,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-text).
+     * Upsert text into a namespace. Pinecone converts the text to vectors automatically using the hosted embedding model associated with the index.  Upserting text is supported only for [indexes with integrated embedding](https://docs.pinecone.io/reference/api/2025-01/control-plane/create_for_model).  For guidance, examples, and limits, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data).
      * Upsert text
      */
     async upsertRecordsNamespace(requestParameters: UpsertRecordsNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
@@ -442,7 +442,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-vectors).
+     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance, examples, and limits, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data).
      * Upsert vectors
      */
     async upsertVectorsRaw(requestParameters: UpsertVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UpsertResponse>> {
@@ -472,7 +472,7 @@ export class VectorOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-vectors).
+     * Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.  For guidance, examples, and limits, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data).
      * Upsert vectors
      */
     async upsertVectors(requestParameters: UpsertVectorsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UpsertResponse> {

--- a/src/pinecone-generated-ts-fetch/db_data/models/DeleteRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/DeleteRequest.ts
@@ -38,8 +38,7 @@ export interface DeleteRequest {
      */
     namespace?: string;
     /**
-     * If specified, the metadata filter here will be used to select the vectors to delete. This is mutually exclusive with specifying ids to delete in the ids param or using delete_all=True. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
-     * Serverless indexes do not support delete by metadata. Instead, you can use the `list` operation to fetch the vector IDs based on their common ID prefix and then delete the records by ID.
+     * If specified, the metadata filter here will be used to select the vectors to delete. This is mutually exclusive with specifying ids to delete in the ids param or using delete_all=True. See [Delete data](https://docs.pinecone.io/guides/manage-data/delete-data#delete-records-by-metadata).
      * @type {object}
      * @memberof DeleteRequest
      */

--- a/src/pinecone-generated-ts-fetch/db_data/models/UpsertRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/UpsertRequest.ts
@@ -27,7 +27,7 @@ import {
  */
 export interface UpsertRequest {
     /**
-     * An array containing the vectors to upsert. Recommended batch limit is 100 vectors.
+     * An array containing the vectors to upsert. Recommended batch limit is up to 1000 vectors.
      * @type {Array<Vector>}
      * @memberof UpsertRequest
      */


### PR DESCRIPTION
## Problem
There are a few new fields which were ported to the `2025-04` spec:
- `temperature` (Assistant chat / chatCompletion`
- `privateHost` (IndexModel)

## Solution
- Regenerate 2025-04, exposing privateHost, new assistant model enum values, and `temperature`.
- Add temperature to both `ChatOptions` and `ChatCompletionOptions`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - external app tests, unit tests, integration tests
