### PR TITLE
Expose `includeUrl` in `Assistant.describeFile`, add `sourceCollection` for serverless

### DIFF
--- a/src/assistant/data/describeFile.ts
+++ b/src/assistant/data/describeFile.ts
@@ -42,7 +42,10 @@ export const describeFile = (
   assistantName: string,
   apiProvider: AsstDataOperationsProvider
 ) => {
-  return async (fileId: string): Promise<AssistantFileModel> => {
+  return async (
+    fileId: string,
+    includeUrl: boolean
+  ): Promise<AssistantFileModel> => {
     if (!fileId) {
       throw new PineconeArgumentError(
         'You must pass the fileId of a file to describe.'
@@ -52,7 +55,7 @@ export const describeFile = (
     const request = {
       assistantName: assistantName,
       assistantFileId: fileId,
-      includeUrl: 'true',
+      includeUrl: includeUrl.toString(),
     } as DescribeFileRequest;
     return await api.describeFile(request);
   };

--- a/src/assistant/index.ts
+++ b/src/assistant/index.ts
@@ -335,11 +335,12 @@ export class Assistant {
    * // }
    * ```
    *
-   * @param options - A {@link DescribeFile} object containing the file ID to describe.
+   * @param fileId - The ID of the file to describe.
+   * @param includeUrl - Whether to include the signed URL in the response. Defaults to true.
    * @returns A promise that resolves to a {@link AssistantFileModel} object containing the file details.
    */
-  describeFile(fileId: string) {
-    return this._describeFile(fileId);
+  describeFile(fileId: string, includeUrl: boolean = true) {
+    return this._describeFile(fileId, includeUrl);
   }
 
   /**

--- a/src/control/createIndex.ts
+++ b/src/control/createIndex.ts
@@ -69,6 +69,9 @@ export interface CreateIndexServerlessSpec {
 
   /** The region where you would like your index to be created. */
   region: string;
+
+  /** The name of the collection to be used as the source for the index. NOTE: Collections can only be created from pods-based indexes. */
+  sourceCollection?: string;
 }
 
 // Properties for validation to ensure no unknown/invalid properties are passed
@@ -76,6 +79,7 @@ type CreateIndexServerlessSpecType = keyof CreateIndexServerlessSpec;
 const CreateIndexServerlessSpecProperties: CreateIndexServerlessSpecType[] = [
   'cloud',
   'region',
+  'sourceCollection',
 ];
 
 /**

--- a/src/pinecone-generated-ts-fetch/assistant_data/models/AssistantFileModel.ts
+++ b/src/pinecone-generated-ts-fetch/assistant_data/models/AssistantFileModel.ts
@@ -62,7 +62,7 @@ export interface AssistantFileModel {
      */
     percentDone?: number | null;
     /**
-     * A signed url that gives you access to the underlying file
+     * A [signed URL](https://cloud.google.com/storage/docs/access-control/signed-urls) that provides temporary, read-only access to the underlying file. Anyone with the link can access the file, so treat it as sensitive data. Expires after a short time.
      * @type {string}
      * @memberof AssistantFileModel
      */

--- a/src/pinecone-generated-ts-fetch/db_control/models/ServerlessSpec.ts
+++ b/src/pinecone-generated-ts-fetch/db_control/models/ServerlessSpec.ts
@@ -31,6 +31,12 @@ export interface ServerlessSpec {
      * @memberof ServerlessSpec
      */
     region: string;
+    /**
+     * The name of the collection to be used as the source for the index.
+     * @type {string}
+     * @memberof ServerlessSpec
+     */
+    sourceCollection?: string;
 }
 
 
@@ -68,6 +74,7 @@ export function ServerlessSpecFromJSONTyped(json: any, ignoreDiscriminator: bool
         
         'cloud': json['cloud'],
         'region': json['region'],
+        'sourceCollection': !exists(json, 'source_collection') ? undefined : json['source_collection'],
     };
 }
 
@@ -82,6 +89,7 @@ export function ServerlessSpecToJSON(value?: ServerlessSpec | null): any {
         
         'cloud': value.cloud,
         'region': value.region,
+        'source_collection': value.sourceCollection,
     };
 }
 

--- a/src/pinecone-generated-ts-fetch/db_data/apis/NamespaceOperationsApi.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/apis/NamespaceOperationsApi.ts
@@ -47,7 +47,7 @@ export interface ListNamespacesOperationRequest {
 export class NamespaceOperationsApi extends runtime.BaseAPI {
 
     /**
-     * Delete a namespace from an index.
+     * Delete a namespace from a serverless index. Deleting a namespace is irreversible; all data in the namespace is permanently deleted.  For guidance and examples, see [Manage namespaces](https://docs.pinecone.io/guides/manage-data/manage-namespaces).  **Note:** This operation is not supported for pod-based indexes.
      * Delete a namespace
      */
     async deleteNamespaceRaw(requestParameters: DeleteNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<object>> {
@@ -74,7 +74,7 @@ export class NamespaceOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Delete a namespace from an index.
+     * Delete a namespace from a serverless index. Deleting a namespace is irreversible; all data in the namespace is permanently deleted.  For guidance and examples, see [Manage namespaces](https://docs.pinecone.io/guides/manage-data/manage-namespaces).  **Note:** This operation is not supported for pod-based indexes.
      * Delete a namespace
      */
     async deleteNamespace(requestParameters: DeleteNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<object> {
@@ -83,7 +83,7 @@ export class NamespaceOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Describe a [namespace](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index, including the total number of vectors in the namespace.
+     * Describe a namespace in a serverless index, including the total number of vectors in the namespace.  For guidance and examples, see [Manage namespaces](https://docs.pinecone.io/guides/manage-data/manage-namespaces).  **Note:** This operation is not supported for pod-based indexes.
      * Describe a namespace
      */
     async describeNamespaceRaw(requestParameters: DescribeNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<NamespaceDescription>> {
@@ -110,7 +110,7 @@ export class NamespaceOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Describe a [namespace](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index, including the total number of vectors in the namespace.
+     * Describe a namespace in a serverless index, including the total number of vectors in the namespace.  For guidance and examples, see [Manage namespaces](https://docs.pinecone.io/guides/manage-data/manage-namespaces).  **Note:** This operation is not supported for pod-based indexes.
      * Describe a namespace
      */
     async describeNamespace(requestParameters: DescribeNamespaceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<NamespaceDescription> {
@@ -119,7 +119,7 @@ export class NamespaceOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Get a list of all [namespaces](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index.  Up to 100 namespaces are returned at a time by default, in sorted order (bitwise “C” collation). If the `limit` parameter is set, up to that number of namespaces are returned instead. Whenever there are additional namespaces to return, the response also includes a `pagination_token` that you can use to get the next batch of namespaces. When the response does not include a `pagination_token`, there are no more namespaces to return.
+     * List all namespaces in a serverless index.  Up to 100 namespaces are returned at a time by default, in sorted order (bitwise “C” collation). If the `limit` parameter is set, up to that number of namespaces are returned instead. Whenever there are additional namespaces to return, the response also includes a `pagination_token` that you can use to get the next batch of namespaces. When the response does not include a `pagination_token`, there are no more namespaces to return.  For guidance and examples, see [Manage namespaces](https://docs.pinecone.io/guides/manage-data/manage-namespaces).  **Note:** This operation is not supported for pod-based indexes.
      * List namespaces
      */
     async listNamespacesOperationRaw(requestParameters: ListNamespacesOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ListNamespacesResponse>> {
@@ -150,7 +150,7 @@ export class NamespaceOperationsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Get a list of all [namespaces](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index.  Up to 100 namespaces are returned at a time by default, in sorted order (bitwise “C” collation). If the `limit` parameter is set, up to that number of namespaces are returned instead. Whenever there are additional namespaces to return, the response also includes a `pagination_token` that you can use to get the next batch of namespaces. When the response does not include a `pagination_token`, there are no more namespaces to return.
+     * List all namespaces in a serverless index.  Up to 100 namespaces are returned at a time by default, in sorted order (bitwise “C” collation). If the `limit` parameter is set, up to that number of namespaces are returned instead. Whenever there are additional namespaces to return, the response also includes a `pagination_token` that you can use to get the next batch of namespaces. When the response does not include a `pagination_token`, there are no more namespaces to return.  For guidance and examples, see [Manage namespaces](https://docs.pinecone.io/guides/manage-data/manage-namespaces).  **Note:** This operation is not supported for pod-based indexes.
      * List namespaces
      */
     async listNamespacesOperation(requestParameters: ListNamespacesOperationRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ListNamespacesResponse> {

--- a/src/pinecone-generated-ts-fetch/db_data/models/StartImportRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/StartImportRequest.ts
@@ -33,7 +33,7 @@ export interface StartImportRequest {
      */
     integrationId?: string;
     /**
-     * The [URI prefix](https://docs.pinecone.io/guides/index-data/import-data#prepare-your-data) under which the data to import is available. All data within this prefix will be listed then imported into the target index. Currently only `s3://` URIs are supported.
+     * The URI of the bucket and import directory containing the namespaces and Parquet files you want to import, for example, `s3://BUCKET_NAME/IMPORT_DIR` for Amazong S3 or `gs://BUCKET_NAME/IMPORT_DIR` for Google Cloud Storage. For more information, see [Import directory structure](https://docs.pinecone.io/guides/index-data/import-data#directory-structure).
      * @type {string}
      * @memberof StartImportRequest
      */


### PR DESCRIPTION
## Problem
We got feedback that currently, the `Assistant.describeFile` method does not allow passing `includeUrl` along with `fileId`. It's currently hard-coded to `true`.

`2025-04` also supports `sourceCollection` as a field for `ServerlessSpec` as a means of migrating from pods-based to serverless indexes.

## Solution
- Regenerate core from latest `2025-04` spec.
- Update `CreateIndexServerlessSpec` to include `sourceCollection`. Other types are exported from generated code, and already include the field.
- Update `Assistant.describeFile` method to allow `includeUrl` as an optional argument. Currently, I've left it defaulting to `true` as that was the hard-coded behavior previously, and I don't want to break anyone who was relying on this.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit, integration, and external app tests
