### PR TITLE
Pinecone connection error retries

### DIFF
--- a/src/utils/retries.ts
+++ b/src/utils/retries.ts
@@ -70,9 +70,11 @@ export class RetryOnServerFailure<T, A extends any[]> {
     if (response) {
       if (
         response.name &&
-        ['PineconeUnavailableError', 'PineconeInternalServerError', 'PineconeConnectionError'].includes(
-          response.name
-        )
+        [
+          'PineconeUnavailableError',
+          'PineconeInternalServerError',
+          'PineconeConnectionError',
+        ].includes(response.name)
       ) {
         return true;
       }

--- a/src/utils/retries.ts
+++ b/src/utils/retries.ts
@@ -70,7 +70,7 @@ export class RetryOnServerFailure<T, A extends any[]> {
     if (response) {
       if (
         response.name &&
-        ['PineconeUnavailableError', 'PineconeInternalServerError'].includes(
+        ['PineconeUnavailableError', 'PineconeInternalServerError', 'PineconeConnectionError'].includes(
           response.name
         )
       ) {
@@ -127,7 +127,8 @@ export class RetryOnServerFailure<T, A extends any[]> {
     if (error.name) {
       return (
         error.name !== 'PineconeUnavailableError' &&
-        error.name !== 'PineconeInternalServerError'
+        error.name !== 'PineconeInternalServerError' &&
+        error.name !== 'PineconeConnectionError'
       );
     }
     return true;


### PR DESCRIPTION
Make `PineconeConnectionError` retryable to handle transient connection failures in CPU-constrained environments.

---
Linear Issue: [PIN-38](https://linear.app/pinecone-io/issue/PIN-38/github-354-pinecone-throwing-pineconeconnectionerrors-when-hitting-cpu)

<a href="https://cursor.com/background-agent?bcId=bc-2f40bc10-1467-46eb-8d35-d78e15f7af0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f40bc10-1467-46eb-8d35-d78e15f7af0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates retry logic to include `PineconeConnectionError` as retryable alongside existing server/unavailable errors.
> 
> - Extends `isRetryError` and `shouldStopRetrying` in `src/utils/retries.ts` to handle `PineconeConnectionError`
> - Adds tests in `src/utils/__tests__/retries.test.ts` for max-retry throw, successful retry after connection error, and recognition of retryable error names/status codes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 877fc4eb4ec1d65817d98327be9c693dc3c18520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->