### PR TITLE
Implement `scan_factor` and `max_candidates` 

### DIFF
--- a/src/pinecone-generated-ts-fetch/db_data/models/QueryRequest.ts
+++ b/src/pinecone-generated-ts-fetch/db_data/models/QueryRequest.ts
@@ -87,6 +87,20 @@ export interface QueryRequest {
      * @memberof QueryRequest
      */
     id?: string;
+    /**
+     * An optimization parameter for IVF dense indexes in dedicated read node indexes. It adjusts how much of the index is scanned to find vector candidates. Range: 0.5 – 4 (default).
+     * Keep the default (4.0) for the best search results. If query latency is too high, try lowering this value incrementally (minimum 0.5) to speed up the search at the cost of slightly lower accuracy. This parameter is only supported for dedicated (DRN) dense indexes. 
+     * @type {number}
+     * @memberof QueryRequest
+     */
+    scanFactor?: number;
+    /**
+     * An optimization parameter that controls the maximum number of candidate dense vectors to rerank. Reranking computes exact distances to improve recall but increases query latency. Range: top_k – 100000.
+     * Keep the default for a balance of recall and latency. Increase this value if recall is too low, or decrease it to reduce latency at the cost of accuracy. This parameter is only supported for dedicated (DRN) dense indexes.
+     * @type {number}
+     * @memberof QueryRequest
+     */
+    maxCandidates?: number;
 }
 
 /**
@@ -118,6 +132,8 @@ export function QueryRequestFromJSONTyped(json: any, ignoreDiscriminator: boolea
         'vector': !exists(json, 'vector') ? undefined : json['vector'],
         'sparseVector': !exists(json, 'sparseVector') ? undefined : SparseValuesFromJSON(json['sparseVector']),
         'id': !exists(json, 'id') ? undefined : json['id'],
+        'scanFactor': !exists(json, 'scanFactor') ? undefined : json['scanFactor'],
+        'maxCandidates': !exists(json, 'maxCandidates') ? undefined : json['maxCandidates'],
     };
 }
 
@@ -139,6 +155,8 @@ export function QueryRequestToJSON(value?: QueryRequest | null): any {
         'vector': value.vector,
         'sparseVector': SparseValuesToJSON(value.sparseVector),
         'id': value.id,
+        'scanFactor': value.scanFactor,
+        'maxCandidates': value.maxCandidates,
     };
 }
 


### PR DESCRIPTION
## Problem
There are new parameters available on `query` for indexes with dedicated read nodes:
- `scan_factor`
- `max_candidates`

These were pulled into the `2025-10` API release and need to be added to the clients.

## Solution
- Regenerate core off `2025-10` to pull in `scan_factor` and `max_candidates`.
- Add `maxCandidates` and `scanFactor` to `QueryShared` - wire through for query operation.
- Add unit tests.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit, integration, and external tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional query parameters with straightforward bounds validation and tests; minimal impact on existing query behavior unless callers opt in.
> 
> **Overview**
> Adds support for the new query tuning parameters `scanFactor` and `maxCandidates` and passes them through to the underlying `queryVectors` request.
> 
> Adds client-side validation for `scanFactor` (must be `0.5`–`4`) and `maxCandidates` (must be `>= topK` and `<= 100000`), plus unit tests covering passthrough and invalid-argument cases. Updates the generated `QueryRequest` model to serialize/deserialize the new fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dffae35d8cdcc9b4d61507a2775bf1536606fe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->