### PR TITLE
docs(assistant): file management idempotency - file identifiers, upsert

### DIFF
--- a/guides/assistant/file-management.md
+++ b/guides/assistant/file-management.md
@@ -4,6 +4,13 @@ This guide covers operations for managing files within a Pinecone Assistant, inc
 
 For more information, see [Manage files](https://docs.pinecone.io/guides/assistant/manage-files).
 
+### File identifiers
+
+Each file in an assistant has a unique identifier. File IDs can be:
+
+- **System-generated**: When you upload a file using `uploadFile`, the system assigns a UUID as the file ID.
+- **User-provided**: When you [upsert a file](#upsert-a-file-create-or-replace-by-id) using `upsertFile`, you provide a custom file ID. User-provided IDs must be 1–128 characters long and can contain alphanumeric characters, hyphens, and underscores.
+
 ## Upload a file
 
 Upload a local file to an Assistant. You can attach metadata to the file for organization and filtering purposes.
@@ -31,9 +38,7 @@ console.log(uploadResponse);
 //   createdOn: '2025-01-06T19:14:21.969Z',
 //   updatedOn: '2025-01-06T19:14:21.969Z',
 //   status: 'Processing',
-//   percentDone: null,
-//   signedUrl: null,
-//   errorMessage: null
+//   signedUrl: null
 // }
 ```
 
@@ -68,6 +73,21 @@ When `multimodal: true`, the assistant will:
 - Enable the assistant to answer questions about visual elements
 - Allow you to retrieve image-related context snippets
 
+## Upsert a file (create or replace by ID)
+
+Create or replace a file by providing a custom file ID. If a file with the given ID already exists, it is replaced; otherwise a new file is created. Use this for idempotent uploads (for example, pipelines that re-run).
+
+```typescript
+const upsertResponse = await assistant.upsertFile({
+  fileId: 'my-custom-file-id',
+  path: 'product-catalog.txt',
+  metadata: { source: 'catalog', version: '2025-01' },
+});
+
+console.log(upsertResponse);
+// Returns an operation. See [Track file operations](#track-file-operations).
+```
+
 ## File processing states
 
 After uploading, files go through several states:
@@ -75,6 +95,8 @@ After uploading, files go through several states:
 - `Processing` - File is being processed
 - `Available` - File is ready to be used in chats
 - `Failed` - File processing failed
+
+For progress and failure details, see [Track file operations](#track-file-operations).
 
 ## List files
 
@@ -97,8 +119,7 @@ console.log(allFiles);
 //       metadata: { source: 'catalog', version: '2025-01' },
 //       createdOn: '2025-01-06T19:14:21.969Z',
 //       updatedOn: '2025-01-06T19:14:36.925Z',
-//       status: 'Available',
-//       percentDone: 1
+//       status: 'Available'
 //     },
 //     // ... more files
 //   ]
@@ -132,15 +153,31 @@ console.log(fileInfo);
 //   createdOn: '2025-01-06T19:14:21.969Z',
 //   updatedOn: '2025-01-06T19:14:36.925Z',
 //   status: 'Available',
-//   percentDone: 1,
-//   signedUrl: undefined,
-//   errorMessage: undefined
+//   signedUrl: undefined
 // }
 ```
 
+## Track file operations
+
+Upload, upsert, and delete are asynchronous and return an **operation** object. Use list and describe operation to poll for status and progress.
+
+```typescript
+// List operations for the assistant
+const { operations } = await assistant.listOperations();
+// operations: { id, operation_type, file_id, status, percent_complete, error_message?, ... }
+
+// Describe a specific operation
+const op = await assistant.describeOperation({ operationId: 'op-1234-abcd' });
+console.log(op.status);   // 'Processing' | 'Completed' | 'Failed'
+console.log(op.percent_complete);
+if (op.status === 'Failed') console.log(op.error_message);
+```
+
+Operation status values: **Processing** (in progress; use `percent_complete`), **Completed**, **Failed** (check `error_message` on the operation). Progress and errors for file processing are on the operation, not on the file model.
+
 ## Delete a file
 
-Delete a file from an Assistant by ID:
+Delete a file from an Assistant by ID. Deletion is **asynchronous** and returns an operation. See [Track file operations](#track-file-operations).
 
 > **Warning:** Deleting files is a PERMANENT operation. Deleted files cannot be recovered.
 
@@ -243,7 +280,7 @@ For file size limits and additional restrictions, see [Pinecone Assistant limits
 
 1. **Descriptive metadata**: Add meaningful metadata to files for easy filtering and organization
 2. **Check status**: Always verify files are `Available` before chatting
-3. **Handle errors**: Check for `errorMessage` when file status is `Failed`
+3. **Handle errors**: Use list/describe operation to track progress and check `error_message` on the operation when status is `Failed`
 4. **Clean up**: Delete obsolete files to manage storage
 5. **Organize by source**: Use metadata to track file sources and versions
 

--- a/guides/assistant/getting-started.md
+++ b/guides/assistant/getting-started.md
@@ -53,9 +53,9 @@ await assistant.uploadFile({
 //   metadata: { source: 'catalog', version: '2025-01' },
 //   createdOn: '2025-01-06T19:14:21.969Z',
 //   updatedOn: '2025-01-06T19:14:21.969Z',
-//   status: 'Processing',
-//   percentDone: null
+//   status: 'Processing'
 // }
+// Upload returns an operation; use listOperations / describeOperation to track progress.
 ```
 
 ## Chat with an Assistant


### PR DESCRIPTION

## Problem

Describe the purpose of this change. What problem is being solved and why?

SDK docs for Pinecone Assistant file management were out of date with the new idempotency behavior: no explanation of file identifiers (system vs user-provided), no upsert-by-ID, no async operations (upload/upsert/delete return operations to poll), and examples still showed deprecated file fields (percentDone, errorMessage). That made it unclear how to use custom file IDs, track progress, or handle errors.

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

File identifiers: Added a short subsection describing system-generated IDs (upload) vs user-provided IDs (upsert, 1–128 chars) and linked to the upsert section.
Upsert: Documented upsertFile({ fileId, path, metadata }) for create/replace by ID and idempotent usage, with a note that the response is an operation and a link to Track file operations.
Track file operations: New section for listOperations and describeOperation, operation status (Processing / Completed / Failed), percent_complete and error_message on the operation, and that progress/errors live on the operation, not on the file.
File model: Removed percentDone and error_message from all file response examples in the guide; kept a single explanation in Track file operations.
Delete: Clarified that delete is asynchronous and returns an operation; added a short link to Track file operations (and tightened repeated “use Track file operations to poll” wording elsewhere).
Best practices: Updated the error-handling bullet to use list/describe operation and error_message on the operation when status is Failed.
getting-started.md: Dropped percentDone from the upload example comment and added a one-line note that upload returns an operation and to use listOperations/describeOperation.
Aligned with the idempotent file management design and with Removing scope (no update-metadata or crc32c_hash in docs). Repetition in the new copy was reduced (one “progress/errors on the operation” explanation, shorter “see Track file operations” links).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan


Describe specific steps for validating this change.

Open the built or rendered SDK docs (e.g. from the repo’s docs build or sdk.pinecone.io after publish) and confirm: File identifiers appears and describes system vs user-provided IDs and links to the upsert section; Upsert a file section shows upsertFile with fileId and the comment points to Track file operations; Track file operations shows listOperations / describeOperation, status values, and that progress/errors are on the operation; Upload / List / Describe examples no longer show percentDone or errorMessage on file objects; Delete says it’s async and links to Track file operations; Best practices error bullet refers to list/describe operation and error_message on the operation.

In getting-started.md, confirm the upload example comment has no percentDone and includes the one-line note about operations.

Spot-check that links to “Track file operations” and “Upsert a file” resolve correctly in the built docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates, but they change the guidance for how users track upload/delete progress and handle failures, so incorrect wording could mislead integrations.
> 
> **Overview**
> Updates Assistant file-management docs to reflect **idempotent file handling** by documenting *system vs user-provided* file identifiers and adding an `upsertFile` (create/replace by ID) workflow.
> 
> Clarifies that upload/upsert/delete are **asynchronous operations** and adds a new section showing `listOperations`/`describeOperation` polling, with progress/errors reported on the operation (not the file). Examples and best practices are updated to remove deprecated file fields like `percentDone`/`errorMessage` and to reference operation `percent_complete`/`error_message`, and the quickstart upload snippet now notes the operation-based tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 197a8899bfbde627f460eb71abb90b471245b79e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->