### PR TITLE
feat(assistant): support Buffer, Blob, and ReadableStream inputs for uploadFile

### DIFF
--- a/src/assistant/data/__tests__/uploadFile.test.ts
+++ b/src/assistant/data/__tests__/uploadFile.test.ts
@@ -334,6 +334,25 @@ describe('ReadableStream input', () => {
     );
   });
 
+  test('escapes special characters in fileName for Content-Disposition header', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const stream = Readable.from([Buffer.from('pdf content')]);
+    await upload({ file: stream, fileName: 'file "name"\r\n.pdf' });
+
+    const [, init] = mockNonRetryingFetch.mock.calls[0];
+    const body: ReadableStream<Uint8Array> = init.body;
+    const reader = body.getReader();
+    let raw = '';
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      raw += new TextDecoder().decode(value);
+    }
+    // Unescaped chars would break the header line; verify they are encoded
+    expect(raw).toContain('filename="file %22name%22%0D%0A.pdf"');
+    expect(raw).not.toContain('"name"');
+  });
+
   test('builds URL with metadata', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
     const stream = Readable.from(['data']);

--- a/src/assistant/data/__tests__/uploadFile.test.ts
+++ b/src/assistant/data/__tests__/uploadFile.test.ts
@@ -1,157 +1,185 @@
 import { uploadFile } from '../uploadFile';
 import fs from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
 import { AsstDataOperationsProvider } from '../asstDataOperationsProvider';
 
-const mockFetch = jest.fn();
-jest.mock('fs');
+const mockRetryingFetch = jest.fn();
+const mockNonRetryingFetch = jest.fn();
+
+jest.mock('fs', () => ({
+  promises: {
+    readFile: jest.fn(),
+  },
+}));
 jest.mock('path');
 jest.mock('../../../utils', () => {
   const actual = jest.requireActual('../../../utils');
   return {
     ...actual,
-    getFetch: () => mockFetch,
+    getFetch: () => mockRetryingFetch,
+    getNonRetryingFetch: () => mockNonRetryingFetch,
     buildUserAgent: () => 'TestUserAgent',
   };
 });
 
 const buildMockFetchResponse = (
+  mock: jest.Mock,
   isSuccess: boolean,
   status: number,
   body: string,
 ) =>
-  mockFetch.mockResolvedValue({
-    ok: isSuccess ? true : false,
+  mock.mockResolvedValue({
+    ok: isSuccess,
     status: status,
     json: async () => JSON.parse(body),
   });
 
-describe('uploadFileInternal', () => {
-  const mockConfig = {
-    apiKey: 'test-api-key',
-    additionalHeaders: {
-      'Custom-Header': 'test',
-    },
-  };
-  const mockAssistantName = 'test-assistant';
-  const mockFileContent = Buffer.from('test file content');
-  const mockResponse = {
-    data: {
-      name: 'test.txt',
-      id: 'test-id',
-      createdOn: new Date().toISOString(),
-      updatedOn: new Date().toISOString(),
-      status: 'ready',
-    },
-  };
-  const mockApiProvider = {
-    provideHostUrl: async () => 'https://prod-1-data.ke.pinecone.io/assistant',
-  } as AsstDataOperationsProvider;
+const mockResponse = {
+  data: {
+    name: 'test.txt',
+    id: 'test-id',
+    createdOn: new Date().toISOString(),
+    updatedOn: new Date().toISOString(),
+    status: 'ready',
+  },
+};
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.resetAllMocks();
-    (fs.readFileSync as jest.Mock).mockResolvedValue(mockFileContent);
-    (path.basename as jest.Mock).mockReturnValue('test.txt');
-  });
+const mockConfig = {
+  apiKey: 'test-api-key',
+  additionalHeaders: {
+    'Custom-Header': 'test',
+  },
+};
 
-  test('throws error when file path is not provided', async () => {
+const mockAssistantName = 'test-assistant';
+
+const mockApiProvider = {
+  provideHostUrl: async () => 'https://prod-1-data.ke.pinecone.io/assistant',
+} as AsstDataOperationsProvider;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe('validation', () => {
+  test('throws when called with no options', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
-    await expect(upload({ path: '' })).rejects.toThrow(
-      'You must pass an object with required properties (`path`) to upload a file.',
+    await expect(upload(undefined as any)).rejects.toThrow(
+      'You must pass an object with required properties',
     );
   });
 
-  test('correctly builds URL without metadata', async () => {
-    buildMockFetchResponse(true, 200, JSON.stringify(mockResponse));
+  test('throws when path is empty string', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await expect(upload({ path: '' })).rejects.toThrow(
+      'You must pass an object with required properties',
+    );
+  });
+
+  test('throws when file is provided without fileName', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await expect(
+      upload({ file: Buffer.from('data'), fileName: '' } as any),
+    ).rejects.toThrow('`fileName` is required when uploading via `file`.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// path input — uses retrying fetch
+// ---------------------------------------------------------------------------
+
+describe('path input', () => {
+  const mockFileContent = Buffer.from('test file content');
+
+  beforeEach(() => {
+    (fs.promises.readFile as jest.Mock).mockResolvedValue(mockFileContent);
+    (path.basename as jest.Mock).mockReturnValue('test.txt');
+    buildMockFetchResponse(
+      mockRetryingFetch,
+      true,
+      200,
+      JSON.stringify(mockResponse),
+    );
+  });
+
+  test('reads file asynchronously from path', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
     await upload({ path: 'test.txt' });
+    expect(fs.promises.readFile).toHaveBeenCalledWith('test.txt');
+  });
 
-    expect(mockFetch).toHaveBeenCalledWith(
+  test('uses retrying fetch', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await upload({ path: 'test.txt' });
+    expect(mockRetryingFetch).toHaveBeenCalled();
+    expect(mockNonRetryingFetch).not.toHaveBeenCalled();
+  });
+
+  test('sends FormData body', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await upload({ path: 'test.txt' });
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
       'https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant',
       expect.objectContaining({
         method: 'POST',
         body: expect.any(FormData),
-        headers: expect.objectContaining({
-          'Api-Key': 'test-api-key',
-          'User-Agent': 'TestUserAgent',
-          'X-Pinecone-Api-Version': expect.any(String),
-        }),
       }),
     );
   });
 
-  test('correctly builds URL with metadata', async () => {
-    buildMockFetchResponse(true, 200, JSON.stringify(mockResponse));
-    const metadata = { key: 'value' };
+  test('builds URL with metadata', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const metadata = { key: 'value' };
     await upload({ path: 'test.txt', metadata });
 
     const encodedMetadata = encodeURIComponent(JSON.stringify(metadata));
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
       `https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant?metadata=${encodedMetadata}`,
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.any(FormData),
-        headers: expect.objectContaining({
-          'Api-Key': 'test-api-key',
-          'User-Agent': 'TestUserAgent',
-          'X-Pinecone-Api-Version': expect.any(String),
-        }),
-      }),
+      expect.anything(),
     );
   });
 
-  test('correctly builds URL with multimodal flag set to true', async () => {
-    buildMockFetchResponse(true, 200, JSON.stringify(mockResponse));
+  test('builds URL with multimodal=true', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
     await upload({ path: 'test.txt', multimodal: true });
-
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
       'https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant?multimodal=true',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.any(FormData),
-        headers: expect.objectContaining({
-          'Api-Key': 'test-api-key',
-          'User-Agent': 'TestUserAgent',
-          'X-Pinecone-Api-Version': expect.any(String),
-        }),
-      }),
+      expect.anything(),
     );
   });
 
-  test('correctly builds URL with multimodal flag set to false', async () => {
-    buildMockFetchResponse(true, 200, JSON.stringify(mockResponse));
+  test('builds URL with multimodal=false', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
     await upload({ path: 'test.txt', multimodal: false });
-
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
       'https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant?multimodal=false',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.any(FormData),
-        headers: expect.objectContaining({
-          'Api-Key': 'test-api-key',
-          'User-Agent': 'TestUserAgent',
-          'X-Pinecone-Api-Version': expect.any(String),
-        }),
-      }),
+      expect.anything(),
     );
   });
 
-  test('correctly builds URL with both metadata and multimodal', async () => {
-    buildMockFetchResponse(true, 200, JSON.stringify(mockResponse));
+  test('builds URL with both metadata and multimodal', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
     const metadata = { key: 'value' };
-    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
     await upload({ path: 'test.txt', metadata, multimodal: true });
-
     const encodedMetadata = encodeURIComponent(JSON.stringify(metadata));
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
       `https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant?metadata=${encodedMetadata}&multimodal=true`,
+      expect.anything(),
+    );
+  });
+
+  test('includes required headers', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await upload({ path: 'test.txt' });
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
-        method: 'POST',
-        body: expect.any(FormData),
         headers: expect.objectContaining({
           'Api-Key': 'test-api-key',
           'User-Agent': 'TestUserAgent',
@@ -160,31 +188,147 @@ describe('uploadFileInternal', () => {
       }),
     );
   });
+});
 
-  test('includes correct headers in request', async () => {
-    buildMockFetchResponse(true, 200, JSON.stringify(mockResponse));
+// ---------------------------------------------------------------------------
+// Buffer input — uses retrying fetch
+// ---------------------------------------------------------------------------
+
+describe('Buffer input', () => {
+  beforeEach(() => {
+    buildMockFetchResponse(
+      mockRetryingFetch,
+      true,
+      200,
+      JSON.stringify(mockResponse),
+    );
+  });
+
+  test('uses retrying fetch', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
-    await upload({ path: 'test.txt' });
+    await upload({ file: Buffer.from('pdf content'), fileName: 'doc.pdf' });
+    expect(mockRetryingFetch).toHaveBeenCalled();
+    expect(mockNonRetryingFetch).not.toHaveBeenCalled();
+  });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant',
+  test('sends FormData body', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await upload({ file: Buffer.from('pdf content'), fileName: 'doc.pdf' });
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         method: 'POST',
         body: expect.any(FormData),
-        headers: expect.objectContaining({
-          'Api-Key': 'test-api-key',
-          'User-Agent': 'TestUserAgent',
-          'X-Pinecone-Api-Version': expect.any(String),
-        }),
       }),
     );
   });
 
-  test('creates form data with file stream', async () => {
-    buildMockFetchResponse(true, 200, JSON.stringify(mockResponse));
+  test('builds URL with metadata', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
-    await upload({ path: 'test.txt' });
+    const metadata = { source: 'upload' };
+    await upload({
+      file: Buffer.from('data'),
+      fileName: 'doc.txt',
+      metadata,
+    });
+    const encodedMetadata = encodeURIComponent(JSON.stringify(metadata));
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
+      `https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant?metadata=${encodedMetadata}`,
+      expect.anything(),
+    );
+  });
+});
 
-    expect(fs.readFileSync).toHaveBeenCalledWith('test.txt');
+// ---------------------------------------------------------------------------
+// Blob input — uses retrying fetch
+// ---------------------------------------------------------------------------
+
+describe('Blob input', () => {
+  beforeEach(() => {
+    buildMockFetchResponse(
+      mockRetryingFetch,
+      true,
+      200,
+      JSON.stringify(mockResponse),
+    );
+  });
+
+  test('uses retrying fetch', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const blob = new Blob(['pdf content'], { type: 'application/pdf' });
+    await upload({ file: blob, fileName: 'doc.pdf' });
+    expect(mockRetryingFetch).toHaveBeenCalled();
+    expect(mockNonRetryingFetch).not.toHaveBeenCalled();
+  });
+
+  test('sends FormData body', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const blob = new Blob(['pdf content'], { type: 'application/pdf' });
+    await upload({ file: blob, fileName: 'doc.pdf' });
+    expect(mockRetryingFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ReadableStream input — uses non-retrying fetch
+// ---------------------------------------------------------------------------
+
+describe('ReadableStream input', () => {
+  beforeEach(() => {
+    buildMockFetchResponse(
+      mockNonRetryingFetch,
+      true,
+      200,
+      JSON.stringify(mockResponse),
+    );
+  });
+
+  test('uses non-retrying fetch', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const stream = Readable.from(['pdf content']);
+    await upload({ file: stream, fileName: 'doc.pdf' });
+    expect(mockNonRetryingFetch).toHaveBeenCalled();
+    expect(mockRetryingFetch).not.toHaveBeenCalled();
+  });
+
+  test('sends a ReadableStream body (not FormData)', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const stream = Readable.from(['pdf content']);
+    await upload({ file: stream, fileName: 'doc.pdf' });
+    expect(mockNonRetryingFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(ReadableStream),
+      }),
+    );
+  });
+
+  test('sets multipart Content-Type header with boundary', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const stream = Readable.from(['pdf content']);
+    await upload({ file: stream, fileName: 'doc.pdf' });
+    const [, init] = mockNonRetryingFetch.mock.calls[0];
+    expect(init.headers['Content-Type']).toMatch(
+      /^multipart\/form-data; boundary=/,
+    );
+  });
+
+  test('builds URL with metadata', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    const stream = Readable.from(['data']);
+    const metadata = { source: 'stream' };
+    await upload({ file: stream, fileName: 'doc.txt', metadata });
+    const encodedMetadata = encodeURIComponent(JSON.stringify(metadata));
+    expect(mockNonRetryingFetch).toHaveBeenCalledWith(
+      `https://prod-1-data.ke.pinecone.io/assistant/files/test-assistant?metadata=${encodedMetadata}`,
+      expect.anything(),
+    );
   });
 });

--- a/src/assistant/data/__tests__/uploadFile.test.ts
+++ b/src/assistant/data/__tests__/uploadFile.test.ts
@@ -75,6 +75,20 @@ describe('validation', () => {
     );
   });
 
+  test('throws when neither path nor file is provided', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await expect(upload({} as any)).rejects.toThrow(
+      'You must pass an object with required properties',
+    );
+  });
+
+  test('throws when only metadata is provided', async () => {
+    const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
+    await expect(upload({ metadata: { key: 'value' } } as any)).rejects.toThrow(
+      'You must pass an object with required properties',
+    );
+  });
+
   test('throws when path is empty string', async () => {
     const upload = uploadFile(mockAssistantName, mockApiProvider, mockConfig);
     await expect(upload({ path: '' })).rejects.toThrow(

--- a/src/assistant/data/types.ts
+++ b/src/assistant/data/types.ts
@@ -175,13 +175,25 @@ export interface ContextOptions {
 }
 
 /**
- * Options for uploading a file to an assistant.
+ * An uploadable file value. Can be a Node.js `Buffer`, a `Blob`, or a Node.js
+ * `ReadableStream`. Pass a `ReadableStream` to avoid loading the file into
+ * memory — for example, when forwarding an incoming HTTP upload directly to
+ * the assistant without buffering on disk.
+ *
+ * Note: `ReadableStream` inputs are sent in a single attempt. Automatic
+ * retries are not supported because the stream is consumed after the first
+ * read and cannot be replayed.
  */
-export interface UploadFileOptions {
-  /**
-   * The (local) path to the file to upload.
-   */
-  path: string;
+export type Uploadable = Buffer | Blob | NodeJS.ReadableStream;
+
+/**
+ * Options for uploading a file to an assistant.
+ *
+ * Provide either `path` (a local file path) or `file` + `fileName` (an
+ * in-memory buffer, blob, or readable stream). The two forms are mutually
+ * exclusive.
+ */
+export type UploadFileOptions = {
   /**
    * Metadata to attach to the file.
    */
@@ -190,7 +202,30 @@ export interface UploadFileOptions {
    * Whether to process the file as multimodal (enabling image extraction). Defaults to false.
    */
   multimodal?: boolean;
-}
+} & (
+  | {
+      /**
+       * The local path to the file to upload. The file is read asynchronously.
+       */
+      path: string;
+      file?: never;
+      fileName?: never;
+    }
+  | {
+      /**
+       * The file data to upload. Accepts a `Buffer`, `Blob`, or Node.js
+       * `ReadableStream`. When passing a stream, `fileName` is required so
+       * the server receives a meaningful filename.
+       */
+      file: Uploadable;
+      /**
+       * The filename to use in the multipart upload (e.g. `"report.pdf"`).
+       * Required when using `file`.
+       */
+      fileName: string;
+      path?: never;
+    }
+);
 
 /**
  * Indicates why the chat response generation stopped. This signals the end of the response.

--- a/src/assistant/data/uploadFile.ts
+++ b/src/assistant/data/uploadFile.ts
@@ -247,6 +247,11 @@ const validateUploadFileOptions = (options: UploadFileOptions) => {
       'You must pass an object with required properties (`path` or `file` + `fileName`) to upload a file.',
     );
   }
+  if (!('path' in options) && !('file' in options)) {
+    throw new PineconeArgumentError(
+      'You must pass an object with required properties (`path` or `file` + `fileName`) to upload a file.',
+    );
+  }
   if ('path' in options && !options.path) {
     throw new PineconeArgumentError(
       'You must pass an object with required properties (`path` or `file` + `fileName`) to upload a file.',

--- a/src/assistant/data/uploadFile.ts
+++ b/src/assistant/data/uploadFile.ts
@@ -8,10 +8,11 @@ import {
 import { AsstDataOperationsProvider } from './asstDataOperationsProvider';
 import { handleApiError, PineconeArgumentError } from '../../errors';
 import type { PineconeConfiguration } from '../../data';
-import { buildUserAgent, getFetch } from '../../utils';
-import type { UploadFileOptions } from './types';
+import { buildUserAgent, getFetch, getNonRetryingFetch } from '../../utils';
+import type { UploadFileOptions, Uploadable } from './types';
 import fs from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
 
 export const uploadFile = (
   assistantName: string,
@@ -19,69 +20,245 @@ export const uploadFile = (
   config: PineconeConfiguration,
 ) => {
   return async (options: UploadFileOptions): Promise<AssistantFileModel> => {
-    const fetch = getFetch(config);
     validateUploadFileOptions(options);
 
-    const fileBuffer = fs.readFileSync(options.path);
-    const fileName = path.basename(options.path);
-    const mimeType = getMimeType(fileName);
-    const fileBlob = new Blob([new Uint8Array(fileBuffer)], { type: mimeType });
-    const formData = new FormData();
-    formData.append('file', fileBlob, fileName);
     const hostUrl = await apiProvider.provideHostUrl();
-    let filesUrl = `${hostUrl}/files/${assistantName}`;
+    const filesUrl = buildFilesUrl(hostUrl, assistantName, options);
+    const requestHeaders = buildRequestHeaders(config);
 
-    const requestHeaders = {
-      'Api-Key': config.apiKey,
-      'User-Agent': buildUserAgent(config),
-      'X-Pinecone-Api-Version': X_PINECONE_API_VERSION,
-    };
-
-    if (options.metadata) {
-      const encodedMetadata = encodeURIComponent(
-        JSON.stringify(options.metadata),
-      );
-      filesUrl += `?metadata=${encodedMetadata}`;
-    }
-
-    if (options.multimodal !== undefined) {
-      const separator = filesUrl.includes('?') ? '&' : '?';
-      filesUrl += `${separator}multimodal=${options.multimodal}`;
-    }
-
-    // Note: This operation uses direct fetch() with FormData for file uploads,
-    const response = await fetch(filesUrl, {
-      method: 'POST',
-      headers: requestHeaders,
-      body: formData,
-    });
-
-    if (response.ok) {
-      return await new JSONApiResponse(response, (jsonValue) =>
-        AssistantFileModelFromJSON(jsonValue),
-      ).value();
+    if ('path' in options && options.path) {
+      return uploadFromPath(options.path, filesUrl, requestHeaders, config);
     } else {
-      const err = await handleApiError(
-        new ResponseError(response, 'Response returned an error'),
-        undefined,
+      return uploadFromFile(
+        options.file!,
+        options.fileName!,
         filesUrl,
+        requestHeaders,
+        config,
       );
-      throw err;
     }
   };
 };
 
-const validateUploadFileOptions = (options: UploadFileOptions) => {
-  if (!options || !options.path) {
-    throw new PineconeArgumentError(
-      'You must pass an object with required properties (`path`) to upload a file.',
+// --- Path-based upload (async read → Blob → FormData, retries supported) ---
+
+async function uploadFromPath(
+  filePath: string,
+  filesUrl: string,
+  requestHeaders: Record<string, string>,
+  config: PineconeConfiguration,
+): Promise<AssistantFileModel> {
+  const fetch = getFetch(config);
+  const fileBuffer = await fs.promises.readFile(filePath);
+  const fileName = path.basename(filePath);
+  const mimeType = getMimeType(fileName);
+  const fileBlob = new Blob([fileBuffer], { type: mimeType });
+  const formData = new FormData();
+  formData.append('file', fileBlob, fileName);
+
+  return executeUpload(fetch, filesUrl, requestHeaders, formData);
+}
+
+// --- File/stream/buffer upload ---
+
+async function uploadFromFile(
+  file: Uploadable,
+  fileName: string,
+  filesUrl: string,
+  requestHeaders: Record<string, string>,
+  config: PineconeConfiguration,
+): Promise<AssistantFileModel> {
+  const mimeType = getMimeType(fileName);
+
+  if (file instanceof Blob) {
+    // Blob is replayable — retries are safe
+    const fetch = getFetch(config);
+    const formData = new FormData();
+    formData.append('file', file, fileName);
+    return executeUpload(fetch, filesUrl, requestHeaders, formData);
+  }
+
+  if (Buffer.isBuffer(file)) {
+    // Buffer is replayable — wrap in Blob and use retrying fetch
+    const fetch = getFetch(config);
+    const fileBlob = new Blob([file], { type: mimeType });
+    const formData = new FormData();
+    formData.append('file', fileBlob, fileName);
+    return executeUpload(fetch, filesUrl, requestHeaders, formData);
+  }
+
+  // Node.js ReadableStream — stream is consumed on first read, no retries
+  const fetch = getNonRetryingFetch(config);
+  const { body, contentType } = buildMultipartBody(file, fileName, mimeType);
+  return executeStreamUpload(fetch, filesUrl, requestHeaders, body, contentType);
+}
+
+// --- Shared response handling ---
+
+async function executeUpload(
+  fetch: ReturnType<typeof getFetch>,
+  filesUrl: string,
+  requestHeaders: Record<string, string>,
+  body: FormData,
+): Promise<AssistantFileModel> {
+  const response = await fetch(filesUrl, {
+    method: 'POST',
+    headers: requestHeaders,
+    body,
+  });
+  return parseResponse(response, filesUrl);
+}
+
+async function executeStreamUpload(
+  fetch: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>,
+  filesUrl: string,
+  requestHeaders: Record<string, string>,
+  body: ReadableStream<Uint8Array>,
+  contentType: string,
+): Promise<AssistantFileModel> {
+  const response = await fetch(filesUrl, {
+    method: 'POST',
+    headers: { ...requestHeaders, 'Content-Type': contentType },
+    body,
+    // undici (Node.js built-in fetch) requires duplex: 'half' for streaming
+    // request bodies. The RequestInit type doesn't include this field yet.
+    ...(({ duplex: 'half' } as unknown) as RequestInit),
+  });
+  return parseResponse(response, filesUrl);
+}
+
+async function parseResponse(
+  response: Response,
+  filesUrl: string,
+): Promise<AssistantFileModel> {
+  if (response.ok) {
+    return await new JSONApiResponse(response, (jsonValue) =>
+      AssistantFileModelFromJSON(jsonValue),
+    ).value();
+  } else {
+    const err = await handleApiError(
+      new ResponseError(response, 'Response returned an error'),
+      undefined,
+      filesUrl,
     );
+    throw err;
+  }
+}
+
+// --- Streaming multipart body construction ---
+
+/**
+ * Builds a multipart/form-data body as a streaming ReadableStream without
+ * buffering the file content. The returned body and contentType header should
+ * be passed directly to fetch().
+ */
+function buildMultipartBody(
+  stream: NodeJS.ReadableStream,
+  fileName: string,
+  mimeType: string,
+): { body: ReadableStream<Uint8Array>; contentType: string } {
+  const boundary = `----PineconeBoundary${Math.random().toString(36).slice(2)}`;
+  const encoder = new TextEncoder();
+
+  const header = encoder.encode(
+    `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${fileName}"\r\n` +
+      `Content-Type: ${mimeType}\r\n` +
+      `\r\n`,
+  );
+  const footer = encoder.encode(`\r\n--${boundary}--\r\n`);
+
+  // Convert Node.js ReadableStream to Web ReadableStream
+  const webStream = Readable.toWeb(
+    stream instanceof Readable ? stream : Readable.from(stream),
+  ) as ReadableStream<Uint8Array>;
+
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      controller.enqueue(header);
+
+      const reader = webStream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(value);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      controller.enqueue(footer);
+      controller.close();
+    },
+  });
+
+  return { body, contentType: `multipart/form-data; boundary=${boundary}` };
+}
+
+// --- Helpers ---
+
+function buildFilesUrl(
+  hostUrl: string,
+  assistantName: string,
+  options: UploadFileOptions,
+): string {
+  let filesUrl = `${hostUrl}/files/${assistantName}`;
+
+  if (options.metadata) {
+    const encodedMetadata = encodeURIComponent(JSON.stringify(options.metadata));
+    filesUrl += `?metadata=${encodedMetadata}`;
+  }
+
+  if (options.multimodal !== undefined) {
+    const separator = filesUrl.includes('?') ? '&' : '?';
+    filesUrl += `${separator}multimodal=${options.multimodal}`;
+  }
+
+  return filesUrl;
+}
+
+function buildRequestHeaders(
+  config: PineconeConfiguration,
+): Record<string, string> {
+  return {
+    'Api-Key': config.apiKey,
+    'User-Agent': buildUserAgent(config),
+    'X-Pinecone-Api-Version': X_PINECONE_API_VERSION,
+  };
+}
+
+const validateUploadFileOptions = (options: UploadFileOptions) => {
+  if (!options) {
+    throw new PineconeArgumentError(
+      'You must pass an object with required properties (`path` or `file` + `fileName`) to upload a file.',
+    );
+  }
+  if ('path' in options && !options.path) {
+    throw new PineconeArgumentError(
+      'You must pass an object with required properties (`path` or `file` + `fileName`) to upload a file.',
+    );
+  }
+  if ('file' in options) {
+    if (!options.file) {
+      throw new PineconeArgumentError(
+        'You must pass an object with required properties (`path` or `file` + `fileName`) to upload a file.',
+      );
+    }
+    if (!options.fileName) {
+      throw new PineconeArgumentError(
+        '`fileName` is required when uploading via `file`.',
+      );
+    }
   }
 };
 
 // get mime types for accepted file types
 function getMimeType(filePath: string) {
-  const extensionToMimeType = {
+  const extensionToMimeType: Record<string, string> = {
     pdf: 'application/pdf',
     json: 'application/json',
     txt: 'text/plain',
@@ -89,14 +266,12 @@ function getMimeType(filePath: string) {
     docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   };
 
-  // Extract file extension and ensure it's lowercase
   const parts = filePath.split('.');
   if (parts.length < 2) {
-    return 'application/octet-stream'; // Default for files without extensions
+    return 'application/octet-stream';
   }
   const ext = parts.pop();
   const extension = ext ? ext.toLowerCase() : '';
 
-  // Return the MIME type or a default value for unsupported types
-  return extensionToMimeType[extension];
+  return extensionToMimeType[extension] ?? 'application/octet-stream';
 }

--- a/src/assistant/data/uploadFile.ts
+++ b/src/assistant/data/uploadFile.ts
@@ -84,7 +84,12 @@ async function uploadFromFile(
     // ArrayBufferView<ArrayBuffer> constraint (Buffer uses ArrayBufferLike).
     const fetch = getFetch(config);
     const fileBlob = new Blob(
-      [file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength) as ArrayBuffer],
+      [
+        file.buffer.slice(
+          file.byteOffset,
+          file.byteOffset + file.byteLength,
+        ) as ArrayBuffer,
+      ],
       { type: mimeType },
     );
     const formData = new FormData();
@@ -173,7 +178,7 @@ function buildMultipartBody(
 
   const header = encoder.encode(
     `--${boundary}\r\n` +
-      `Content-Disposition: form-data; name="file"; filename="${fileName}"\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${escapeFilename(fileName)}"\r\n` +
       `Content-Type: ${mimeType}\r\n` +
       `\r\n`,
   );
@@ -278,6 +283,16 @@ const validateUploadFileOptions = (options: UploadFileOptions) => {
     }
   }
 };
+
+// Per RFC 7578 §2 (https://www.rfc-editor.org/rfc/rfc7578#section-2),
+// double quotes, carriage returns, and newlines must be percent-encoded
+// in the filename parameter of a Content-Disposition header.
+function escapeFilename(fileName: string): string {
+  return fileName
+    .replace(/"/g, '%22')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A');
+}
 
 // get mime types for accepted file types
 function getMimeType(filePath: string) {

--- a/src/assistant/data/uploadFile.ts
+++ b/src/assistant/data/uploadFile.ts
@@ -90,7 +90,13 @@ async function uploadFromFile(
   // Node.js ReadableStream — stream is consumed on first read, no retries
   const fetch = getNonRetryingFetch(config);
   const { body, contentType } = buildMultipartBody(file, fileName, mimeType);
-  return executeStreamUpload(fetch, filesUrl, requestHeaders, body, contentType);
+  return executeStreamUpload(
+    fetch,
+    filesUrl,
+    requestHeaders,
+    body,
+    contentType,
+  );
 }
 
 // --- Shared response handling ---
@@ -110,10 +116,7 @@ async function executeUpload(
 }
 
 async function executeStreamUpload(
-  fetch: (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ) => Promise<Response>,
+  fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   filesUrl: string,
   requestHeaders: Record<string, string>,
   body: ReadableStream<Uint8Array>,
@@ -125,7 +128,7 @@ async function executeStreamUpload(
     body,
     // undici (Node.js built-in fetch) requires duplex: 'half' for streaming
     // request bodies. The RequestInit type doesn't include this field yet.
-    ...(({ duplex: 'half' } as unknown) as RequestInit),
+    ...({ duplex: 'half' } as unknown as RequestInit),
   });
   return parseResponse(response, filesUrl);
 }
@@ -209,7 +212,9 @@ function buildFilesUrl(
   let filesUrl = `${hostUrl}/files/${assistantName}`;
 
   if (options.metadata) {
-    const encodedMetadata = encodeURIComponent(JSON.stringify(options.metadata));
+    const encodedMetadata = encodeURIComponent(
+      JSON.stringify(options.metadata),
+    );
     filesUrl += `?metadata=${encodedMetadata}`;
   }
 

--- a/src/assistant/data/uploadFile.ts
+++ b/src/assistant/data/uploadFile.ts
@@ -184,23 +184,31 @@ function buildMultipartBody(
     stream instanceof Readable ? stream : Readable.from(stream),
   ) as ReadableStream<Uint8Array>;
 
-  const body = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      controller.enqueue(header);
+  const reader = webStream.getReader();
+  let phase: 'header' | 'body' | 'done' = 'header';
 
-      const reader = webStream.getReader();
-      try {
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          controller.enqueue(value);
-        }
-      } finally {
-        reader.releaseLock();
+  // Use pull (not start) so chunks are read on demand as fetch consumes the
+  // body. start runs eagerly and enqueue() ignores backpressure, which would
+  // buffer the entire stream in the internal queue before upload begins.
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (phase === 'header') {
+        controller.enqueue(header);
+        phase = 'body';
+        return;
       }
 
-      controller.enqueue(footer);
-      controller.close();
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.enqueue(footer);
+        controller.close();
+        phase = 'done';
+      } else {
+        controller.enqueue(value);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
     },
   });
 

--- a/src/assistant/data/uploadFile.ts
+++ b/src/assistant/data/uploadFile.ts
@@ -79,9 +79,14 @@ async function uploadFromFile(
   }
 
   if (Buffer.isBuffer(file)) {
-    // Buffer is replayable — wrap in Blob and use retrying fetch
+    // Buffer is replayable — wrap in Blob and use retrying fetch.
+    // Extract the exact ArrayBuffer slice to satisfy BlobPart's
+    // ArrayBufferView<ArrayBuffer> constraint (Buffer uses ArrayBufferLike).
     const fetch = getFetch(config);
-    const fileBlob = new Blob([file], { type: mimeType });
+    const fileBlob = new Blob(
+      [file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength)],
+      { type: mimeType },
+    );
     const formData = new FormData();
     formData.append('file', fileBlob, fileName);
     return executeUpload(fetch, filesUrl, requestHeaders, formData);
@@ -185,7 +190,7 @@ function buildMultipartBody(
 
       const reader = webStream.getReader();
       try {
-        while (true) {
+        for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
           controller.enqueue(value);

--- a/src/assistant/data/uploadFile.ts
+++ b/src/assistant/data/uploadFile.ts
@@ -84,7 +84,7 @@ async function uploadFromFile(
     // ArrayBufferView<ArrayBuffer> constraint (Buffer uses ArrayBufferLike).
     const fetch = getFetch(config);
     const fileBlob = new Blob(
-      [file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength)],
+      [file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength) as ArrayBuffer],
       { type: mimeType },
     );
     const formData = new FormData();

--- a/src/assistant/index.ts
+++ b/src/assistant/index.ts
@@ -37,6 +37,7 @@ export type {
   ContextOptions,
   ListFilesOptions,
   UploadFileOptions,
+  Uploadable,
   AssistantFilesList,
   MessagesModel,
   MessageModel,
@@ -384,40 +385,58 @@ export class Assistant {
   /**
    * Uploads a file to an assistant.
    *
+   * Accepts either a local file path or an in-memory `Buffer`, `Blob`, or
+   * Node.js `ReadableStream`. Use the `file` + `fileName` form to forward an
+   * incoming HTTP upload stream directly to the assistant without writing it
+   * to disk or buffering the entire file in memory.
+   *
    * Note: This method does *not* use the generated code from the OpenAPI spec.
    *
    * @example
+   * Upload from a local path:
    * ```typescript
    * import { Pinecone } from '@pinecone-database/pinecone';
    * const pc = new Pinecone();
-   * const assistantName = 'test1';
-   * const assistant = pc.assistant({ name: assistantName });
-   * await assistant.uploadFile({path: "test-file.txt", metadata: {"test-key": "test-value"}})
-   * // {
-   * //  name: 'test-file.txt',
-   * //  id: '921ad74c-2421-413a-8c86-fca81ceabc5c',
-   * //  metadata: { 'test-key': 'test-value' },
-   * //  createdOn: Invalid Date,  // Note: these dates resolve in seconds
-   * //  updatedOn: Invalid Date,
-   * //  status: 'Processing',
-   * //  percentDone: null,
-   * //  signedUrl: null,
-   * //  errorMessage: null
-   * // }
+   * const assistant = pc.Assistant({ name: 'my-assistant' });
+   * await assistant.uploadFile({ path: 'report.pdf', metadata: { category: 'reports' } });
+   * ```
+   *
+   * @example
+   * Upload from a Buffer (e.g. from multer memory storage):
+   * ```typescript
+   * // req.file.buffer is a Buffer provided by multer
+   * await assistant.uploadFile({
+   *   file: req.file.buffer,
+   *   fileName: req.file.originalname,
+   * });
+   * ```
+   *
+   * @example
+   * Upload from a ReadableStream (zero server-side buffering):
+   * ```typescript
+   * // Forward an incoming upload stream directly — no disk write, no memory spike.
+   * // Note: automatic retries are disabled for stream inputs because the stream
+   * // is consumed after the first read and cannot be replayed.
+   * await assistant.uploadFile({
+   *   file: req.file.stream,   // e.g. from busboy / @fastify/multipart
+   *   fileName: req.file.filename,
+   * });
    * ```
    *
    * @example
    * Upload a file with multimodal processing enabled:
    * ```typescript
    * await assistant.uploadFile({
-   *   path: "document-with-images.pdf",
-   *   metadata: {"category": "reports"},
-   *   multimodal: true
+   *   path: 'document-with-images.pdf',
+   *   metadata: { category: 'reports' },
+   *   multimodal: true,
    * });
    * ```
    *
-   * @param options - A {@link UploadFileOptions} object containing the file path, optional metadata, and optional multimodal flag.
-   * @returns A promise that resolves to a {@link AssistantFileModel} object containing the file details.
+   * @param options - A {@link UploadFileOptions} object. Provide either
+   *   `path` (local file path) or `file` ({@link Uploadable}) + `fileName`,
+   *   along with optional `metadata` and `multimodal` flags.
+   * @returns A promise that resolves to an {@link AssistantFileModel} object containing the file details.
    */
   uploadFile(options: UploadFileOptions) {
     return this._uploadFile(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export type {
   ContextOptions,
   ListFilesOptions,
   UploadFileOptions,
+  Uploadable,
   AssistantFilesList,
   MessagesModel,
   MessageModel,

--- a/src/integration/assistant-data/uploadAndDeleteFile.test.ts
+++ b/src/integration/assistant-data/uploadAndDeleteFile.test.ts
@@ -12,10 +12,10 @@ import { getTestContext } from '../test-context';
 let pinecone: Pinecone;
 let assistant: Assistant;
 let assistantName: string;
-let tempFile: string;
 let tempFilePath: string;
-let tempFileWithMetadata: string;
+let tempFile: string;
 let tempFileWithMetadataPath: string;
+let tempFileWithMetadata: string;
 
 beforeAll(async () => {
   const fixtures = await getTestContext();
@@ -23,9 +23,9 @@ beforeAll(async () => {
   assistantName = fixtures.assistant.name;
   assistant = pinecone.Assistant({ name: assistantName });
 
-  // Create two temporary test files
   const content = 'This is test content for file upload';
-  // 1: file without metadata
+
+  // file without metadata
   tempFile = `test-upload-${Date.now()}.txt`;
   tempFilePath = path.join(os.tmpdir(), tempFile);
   try {
@@ -35,10 +35,9 @@ beforeAll(async () => {
     console.error('Error writing file:', err);
   }
 
-  // 2: file with metadata
+  // file with metadata
   tempFileWithMetadata = `test-upload-metadata-${Date.now()}.txt`;
   tempFileWithMetadataPath = path.join(os.tmpdir(), tempFileWithMetadata);
-
   try {
     fs.writeFileSync(tempFileWithMetadataPath, content);
     console.log('File written:', tempFileWithMetadataPath);
@@ -57,14 +56,14 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  // Cleanup: remove temporary test files
-  if (fs.existsSync(tempFilePath)) {
-    fs.unlinkSync(tempFilePath);
-  }
-  if (fs.existsSync(tempFileWithMetadataPath)) {
+  if (fs.existsSync(tempFilePath)) fs.unlinkSync(tempFilePath);
+  if (fs.existsSync(tempFileWithMetadataPath))
     fs.unlinkSync(tempFileWithMetadataPath);
-  }
 });
+
+// ---------------------------------------------------------------------------
+// path input (existing behaviour)
+// ---------------------------------------------------------------------------
 
 describe('Upload file happy path', () => {
   test('Upload file without metadata', async () => {
@@ -79,10 +78,7 @@ describe('Upload file happy path', () => {
     expect(response.updatedOn).toBeDefined();
     expect(response.status).toBeDefined();
 
-    // Wait for file to be ready before attempting delete
     await waitUntilAssistantFileReady(assistantName, response.id);
-
-    // Delete file happy path test:
     assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
@@ -112,10 +108,7 @@ describe('Upload file happy path', () => {
       expect(response.metadata['category']).toEqual('integration-test');
     }
 
-    // Wait for file to be ready before attempting delete
     await waitUntilAssistantFileReady(assistantName, response.id);
-
-    // Delete file happy path test:
     assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
@@ -124,6 +117,116 @@ describe('Upload file happy path', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Buffer input
+// ---------------------------------------------------------------------------
+
+describe('Upload via Buffer', () => {
+  test('Upload Buffer without metadata', async () => {
+    const buffer = fs.readFileSync(tempFilePath);
+    const fileName = `buffer-upload-${Date.now()}.txt`;
+
+    const response = await assistant.uploadFile({
+      file: buffer,
+      fileName,
+    });
+
+    expect(response).toBeDefined();
+    expect(response.name).toEqual(fileName);
+    expect(response.id).toBeDefined();
+    expect(response.status).toBeDefined();
+
+    await waitUntilAssistantFileReady(assistantName, response.id);
+    assertWithRetries(
+      () => assistant.deleteFile(response.id),
+      () => {
+        return;
+      },
+    );
+  });
+
+  test('Upload Buffer with metadata', async () => {
+    const buffer = fs.readFileSync(tempFilePath);
+    const fileName = `buffer-upload-meta-${Date.now()}.txt`;
+
+    const response = await assistant.uploadFile({
+      file: buffer,
+      fileName,
+      metadata: { source: 'buffer' },
+    });
+
+    expect(response).toBeDefined();
+    expect(response.name).toEqual(fileName);
+    if (response.metadata) {
+      expect(response.metadata['source']).toEqual('buffer');
+    }
+
+    await waitUntilAssistantFileReady(assistantName, response.id);
+    assertWithRetries(
+      () => assistant.deleteFile(response.id),
+      () => {
+        return;
+      },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ReadableStream input
+// ---------------------------------------------------------------------------
+
+describe('Upload via ReadableStream', () => {
+  test('Upload ReadableStream without metadata', async () => {
+    const fileName = `stream-upload-${Date.now()}.txt`;
+
+    const response = await assistant.uploadFile({
+      file: fs.createReadStream(tempFilePath),
+      fileName,
+    });
+
+    expect(response).toBeDefined();
+    expect(response.name).toEqual(fileName);
+    expect(response.id).toBeDefined();
+    expect(response.status).toBeDefined();
+
+    await waitUntilAssistantFileReady(assistantName, response.id);
+    assertWithRetries(
+      () => assistant.deleteFile(response.id),
+      () => {
+        return;
+      },
+    );
+  });
+
+  test('Upload ReadableStream with metadata', async () => {
+    const fileName = `stream-upload-meta-${Date.now()}.txt`;
+
+    const response = await assistant.uploadFile({
+      file: fs.createReadStream(tempFilePath),
+      fileName,
+      metadata: { source: 'stream' },
+    });
+
+    expect(response).toBeDefined();
+    expect(response.name).toEqual(fileName);
+    if (response.metadata) {
+      expect(response.metadata['source']).toEqual('stream');
+    }
+
+    await waitUntilAssistantFileReady(assistantName, response.id);
+    assertWithRetries(
+      () => assistant.deleteFile(response.id),
+      () => {
+        return;
+      },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
 
 describe('Upload file error paths', () => {
   test('Upload with nonexistent file path', async () => {
@@ -148,7 +251,7 @@ describe('Upload file error paths', () => {
         path: '',
       }),
     ).rejects.toThrow(
-      'You must pass an object with required properties (`path`) to upload a file.',
+      'You must pass an object with required properties (`path` or `file` + `fileName`) to upload a file.',
     );
   });
 });

--- a/src/integration/assistant-data/uploadAndDeleteFile.test.ts
+++ b/src/integration/assistant-data/uploadAndDeleteFile.test.ts
@@ -79,7 +79,7 @@ describe('Upload file happy path', () => {
     expect(response.status).toBeDefined();
 
     await waitUntilAssistantFileReady(assistantName, response.id);
-    assertWithRetries(
+    await assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
         return;
@@ -109,7 +109,7 @@ describe('Upload file happy path', () => {
     }
 
     await waitUntilAssistantFileReady(assistantName, response.id);
-    assertWithRetries(
+    await assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
         return;
@@ -138,7 +138,7 @@ describe('Upload via Buffer', () => {
     expect(response.status).toBeDefined();
 
     await waitUntilAssistantFileReady(assistantName, response.id);
-    assertWithRetries(
+    await assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
         return;
@@ -163,7 +163,7 @@ describe('Upload via Buffer', () => {
     }
 
     await waitUntilAssistantFileReady(assistantName, response.id);
-    assertWithRetries(
+    await assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
         return;
@@ -191,7 +191,7 @@ describe('Upload via ReadableStream', () => {
     expect(response.status).toBeDefined();
 
     await waitUntilAssistantFileReady(assistantName, response.id);
-    assertWithRetries(
+    await assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
         return;
@@ -215,7 +215,7 @@ describe('Upload via ReadableStream', () => {
     }
 
     await waitUntilAssistantFileReady(assistantName, response.id);
-    assertWithRetries(
+    await assertWithRetries(
       () => assistant.deleteFile(response.id),
       () => {
         return;

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -145,6 +145,17 @@ export const getFetch = (config: PineconeConfiguration) => {
 
 /**
  * Gets the base fetch implementation without retry wrapping.
+ *
+ * Use this for operations where the request body cannot be replayed on retry,
+ * such as streaming uploads where the ReadableStream is consumed after the
+ * first read.
+ */
+export const getNonRetryingFetch = (config: PineconeConfiguration) => {
+  return getBaseFetch(config);
+};
+
+/**
+ * Gets the base fetch implementation without retry wrapping.
  */
 function getBaseFetch(
   config: PineconeConfiguration,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,7 @@ import { debugLog } from './debugLog';
 import { normalizeUrl } from './normalizeUrl';
 import { queryParamsStringify } from './queryParamsStringify';
 import { buildUserAgent } from './user-agent';
-import { getFetch } from './fetch';
+import { getFetch, getNonRetryingFetch } from './fetch';
 import { ChatStream } from '../assistant/chatStream';
 import { convertKeysToCamelCase } from './convertKeys';
 
@@ -12,6 +12,7 @@ export {
   queryParamsStringify,
   buildUserAgent,
   getFetch,
+  getNonRetryingFetch,
   convertKeysToCamelCase,
   ChatStream,
 };

--- a/ts-compilation-test/tsconfig.json
+++ b/ts-compilation-test/tsconfig.json
@@ -4,6 +4,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "lib",
+    "rootDir": "src",
     "sourceMap": true,
     "strict": true,
     "target": "es2022"

--- a/ts-compilation-test/tsconfig.json
+++ b/ts-compilation-test/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": "src",
     "sourceMap": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2022",
+    "types": ["node"]
   },
   "compileOnSave": true,
   "include": ["src"]


### PR DESCRIPTION
## Problem
The file upload path for Assistant currently loads the entire file into memory before uploading, and doesn't support streaming inputs generally. This is a big issue for users who are trying to send concurrent requests, especially on lower power machines using to host backend applications.

We've had direct feedback that this is an issue:


> the customer is using the Node.js Pinecone SDK to ingest user-uploaded PDFs into the Assistant, but the SDK loads the entire file into memory before ingestion, causing out-of-memory errors when multiple documents are uploaded concurrently. The backend only has 1GB of RAM, so they've had to cap the app at 4 concurrent ingestion requests across all users, which won't scale. They couldn't find a streaming upload option in the SDK and is looking for guidance on whether one exists or how to handle this more efficiently.


The root cause is in `uploadFile.ts`:

```typescript
// Entire file read synchronously into JS heap — twice
const fileBuffer = fs.readFileSync(options.path);
const fileBlob = new Blob([new Uint8Array(fileBuffer)], { type: mimeType });
```

For a 10 MB PDF with 4 concurrent uploads, this is potentially 80+ MB of heap pressure from file data alone, before accounting for any other process overhead.

## Solution
UploadFileOptions is extended to a discriminated union, accepting either the existing path form or a new file + fileName form:

```typescript
type Uploadable = Buffer | Blob | NodeJS.ReadableStream;

type UploadFileOptions = {
  metadata?: Record<string, string | number>;
  multimodal?: boolean;
} & (
  | { path: string }
  | { file: Uploadable; fileName: string }
);
```

Each input type is handled appropriately:
|Input|Transport|Retries|
|----|----|----|
|`pathj`|`fs.promises.readFile() -> Blob -> FormData`|Yes|
|`Buffer`|`Blob -> FormData`|Yes|
|`Blob`|`FormData` directly|Yes|
|`ReadableStream`|Manual multipart body (streamed, no buffer)|No|

For ReadableStream inputs, the multipart body is constructed manually as a concatenated Web `ReadableStream` (boundary header + file chunks + footer) and passed directly to fetch with duplex: 'half'. The file is never fully materialized in memory. Because a stream is consumed after the first read and cannot be replayed, retries are disabled for this input type — a `getNonRetryingFetch` helper is added for this purpose.

The path case moves from `readFileSync` to `fs.promises.readFile`, which is non-blocking. No new runtime dependencies are introduced.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Unit tests cover all four input shapes and verify the correct fetch implementation (retrying vs. non-retrying) is used for each:

```typescript
// path — uses retrying fetch, sends FormData
await upload({ path: 'doc.pdf' });

// Buffer — uses retrying fetch, sends FormData
await upload({ file: Buffer.from('...'), fileName: 'doc.pdf' });

// Blob — uses retrying fetch, sends FormData
await upload({ file: new Blob(['...']), fileName: 'doc.pdf' });

// ReadableStream — uses non-retrying fetch, sends ReadableStream body
// with a multipart/form-data; boundary=... Content-Type header
await upload({ file: Readable.from(['...']), fileName: 'doc.pdf' });

Integration tests extend the existing path-based happy path and error cases
with end-to-end coverage for Buffer and ReadableStream inputs:

// Buffer upload
const buffer = fs.readFileSync(tempFilePath);
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the assistant file-upload path and introduces manual streaming multipart construction plus a new non-retrying fetch path; mistakes here could cause failed uploads or subtle retry/compatibility issues across Node runtimes.
> 
> **Overview**
> **Adds streaming and in-memory upload support to `assistant.uploadFile()`.** `UploadFileOptions` is now a discriminated union that accepts either `{ path }` (now read via `fs.promises.readFile`) or `{ file, fileName }` where `file` can be `Buffer`, `Blob`, or Node `ReadableStream` (`Uploadable`, newly exported).
> 
> **Implements a new streaming upload path for `ReadableStream` inputs** by building a multipart `ReadableStream` body (with RFC-compliant filename escaping) and sending it via a new `getNonRetryingFetch()` helper since streams can’t be replayed; path/Buffer/Blob uploads continue to use retrying `getFetch()` with `FormData`.
> 
> Updates unit + integration tests to cover validation, URL query construction (`metadata`, `multimodal`), retrying vs non-retrying fetch selection, and end-to-end uploads for `Buffer`/`ReadableStream`, and adjusts `ts-compilation-test` to include Node types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f9774494314faaf2d7c685496f70f9377d8a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->