### PR TITLE
fix(deps): bump minimatch from 3.1.2 to 3.1.5 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,7 +6197,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "typedoc": "^0.27.9",
     "typescript": "~5.6.3"
   },
+  "overrides": {
+    "minimatch": "3.1.5"
+  },
   "types": "dist/index.d.ts",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -55,10 +55,18 @@
     "typescript": "~5.6.3"
   },
   "overrides": {
-    "eslint": { "minimatch": "3.1.5" },
-    "eslint-plugin-import": { "minimatch": "3.1.5" },
-    "jest": { "minimatch": "3.1.5" },
-    "ts-jest": { "minimatch": "3.1.5" }
+    "eslint": {
+      "minimatch": "3.1.5"
+    },
+    "eslint-plugin-import": {
+      "minimatch": "3.1.5"
+    },
+    "jest": {
+      "minimatch": "3.1.5"
+    },
+    "ts-jest": {
+      "minimatch": "3.1.5"
+    }
   },
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "typescript": "~5.6.3"
   },
   "overrides": {
-    "minimatch": "3.1.5"
+    "eslint": { "minimatch": "3.1.5" },
+    "eslint-plugin-import": { "minimatch": "3.1.5" },
+    "jest": { "minimatch": "3.1.5" },
+    "ts-jest": { "minimatch": "3.1.5" }
   },
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Problem
https://github.com/pinecone-io/pinecone-ts-client/pull/380

## Solution
Use `overrides` in `package.json` to pin minimatch (transitive dependency).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only transitive dependency pin with no changes to runtime or published `dist` code.
> 
> **Overview**
> Pins the transitive **`minimatch`** dependency from **3.1.2** to **3.1.5** using npm **`overrides`** in `package.json`, scoped to dev-tool trees (`eslint`, `eslint-plugin-import`, `jest`, `ts-jest`). The lockfile is updated to reflect the resolved **3.1.5** tarball.
> 
> This is an infrastructure-only dependency alignment (per linked PR #380); it does not change application or published library code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20e85c399f05d69c3d8cb7d24e9602abab68f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->