### PR TITLE
docs(assistant): document the metadata filter shape for listFiles

### DIFF
--- a/src/assistant/data/listFiles.ts
+++ b/src/assistant/data/listFiles.ts
@@ -11,7 +11,9 @@ import type { ListFilesOptions, AssistantFilesList } from './types';
  * const pc = new Pinecone();
  * const assistantName = 'test1';
  * const assistant = pc.assistant({ name: assistantName });
- * const files = await assistant.listFiles({filter: {key: 'value'}});
+ * // Metadata fields are referenced at the top level — not wrapped in a `metadata` key.
+ * // See https://docs.pinecone.io/guides/data/filter-with-metadata for operators ($eq, $ne, $gt, $lt, $in).
+ * const files = await assistant.listFiles({ filter: { version: { $eq: 'v1' } } });
  * console.log(files);
  * // {
  * //  files: [

--- a/src/assistant/data/types.ts
+++ b/src/assistant/data/types.ts
@@ -8,7 +8,31 @@ import type {
  */
 export interface ListFilesOptions {
   /**
-   * Optionally filter which files can be retrieved using the following metadata fields.
+   * Optionally filter files by metadata. Uses Pinecone's metadata filter language:
+   * fields are referenced at the top level (not wrapped in a `metadata` key), and
+   * may be combined with operators like `$eq`, `$ne`, `$gt`, `$lt`, `$in`.
+   *
+   * @example Direct value match:
+   * ```typescript
+   * filter: { version: 'v1' }
+   * ```
+   *
+   * @example Operator filter:
+   * ```typescript
+   * filter: { version: { $eq: 'v1' } }
+   * ```
+   *
+   * @example Combined fields:
+   * ```typescript
+   * filter: { version: 'v1', tier: { $in: ['gold', 'silver'] } }
+   * ```
+   *
+   * @see {@link https://docs.pinecone.io/guides/data/filter-with-metadata Metadata filter language}
+   *
+   * Filters that don't match Pinecone's expected shape (e.g. wrapping fields
+   * in a top-level `metadata` key like `{ metadata: { version: 'v1' } }`) are
+   * silently ignored server-side and return the unfiltered file list. See
+   * {@link https://github.com/pinecone-io/pinecone-ts-client/issues/335 issue #335}.
    */
   filter?: object;
 }

--- a/src/assistant/index.ts
+++ b/src/assistant/index.ts
@@ -314,7 +314,9 @@ export class Assistant {
    * const pc = new Pinecone();
    * const assistantName = 'test1';
    * const assistant = pc.assistant({ name: assistantName });
-   * const files = await assistant.listFiles({filter: {key: 'value'}});
+   * // Metadata fields are referenced at the top level — not wrapped in a `metadata` key.
+   * // See https://docs.pinecone.io/guides/data/filter-with-metadata for operators ($eq, $ne, $gt, $lt, $in).
+   * const files = await assistant.listFiles({ filter: { version: { $eq: 'v1' } } });
    * console.log(files);
    * // {
    * //  files: [


### PR DESCRIPTION
Closes #335.

The `filter` example in `Assistant#listFiles` (and the underlying `listFiles` factory + `ListFilesOptions` type doc) read `{ key: 'value' }`, which is vague enough that users reach for shapes like `{ metadata: { version: 'v1' } }` thinking they're targeting the metadata object on each file. The Pinecone API silently ignores filters that don't match its metadata-filter language and returns the unfiltered list, so the mismatch surfaces as "filtering doesn't work" with no error to root-cause from — exactly the symptom in #335.

This PR spells out the contract in the JSDoc:

- Fields are referenced at the top level (no `metadata` wrapper).
- Direct value match (`{ version: 'v1' }`) and operator forms (`{ version: { $eq: 'v1' } }`, `$ne`, `$gt`, `$lt`, `$in`) are supported.
- Link to Pinecone's metadata-filter docs and to issue #335 so a user searching for "listFiles filter not working" lands on the contract.

Docs-only; no runtime change. If a tighter `filter` type (e.g. a discriminated union over the operator set, matching the data-plane filter shape) would be welcome, happy to do that as a follow-up — kept this focused on the doc clarity that closes out the reported symptom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc and example-only changes with no runtime, API, or type behavior changes.
> 
> **Overview**
> **Documentation-only** update for Assistant `listFiles` filtering (closes #335). No runtime or type changes beyond JSDoc.
> 
> JSDoc for `ListFilesOptions.filter`, `listFiles`, and `Assistant#listFiles` now documents Pinecone’s metadata filter shape: fields at the **top level** (not under a `metadata` wrapper), with examples for direct match, operators (`$eq`, `$ne`, `$gt`, `$lt`, `$in`), and combined filters. It links to Pinecone’s metadata-filter guide and notes that malformed filters (e.g. `{ metadata: { version: 'v1' } }`) are **silently ignored** server-side and return the full file list.
> 
> The public `@example` blocks replace the vague `{ key: 'value' }` snippet with `{ filter: { version: { $eq: 'v1' } } }` and inline comments pointing to the docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e439f1132179ee738d3e8181e7dd15f507e7c8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->