### PR TITLE
Enable Dependabot version updates (PIN-4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     open-pull-requests-limit: 10
     groups:
       npm-minor-and-patch:
         update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+          - 'minor'
+          - 'patch'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       github-actions:
         patterns:
-          - "*"
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` enabling **weekly, grouped Dependabot version updates**.

Ecosystems covered: npm, github-actions.

## Why
Part of standing up the security fast-patch process (**PIN-4**). Keeping dependencies close to their latest patched release shrinks the diff and time needed to ship a fix when a security advisory lands. Dependabot **security updates** (auto patch PRs on advisories) and **vulnerability alerts** are already enabled on this repo; this adds the routine version-update cadence.

Minor/patch updates are grouped into a single PR per ecosystem to keep review noise low; majors come as individual PRs.

## Review notes
Config only — no code changes. First run may open a batch of update PRs; that is expected. Adjust `open-pull-requests-limit` or `schedule` if the cadence is too noisy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with no runtime or auth impact; main effect is automated dependency PR volume.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so Dependabot runs **weekly version updates** for **npm** (repo root) and **github-actions**, alongside existing security alerts/advisory PRs.
> 
> npm **minor and patch** bumps are **grouped** into one PR (`npm-minor-and-patch`); **major** npm updates stay separate. GitHub Actions updates are grouped under `github-actions` (`patterns: '*'`). npm is capped at **10 open** Dependabot PRs at once.
> 
> No application code changes—CI/dependency maintenance config only. Expect an initial batch of update PRs on first run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef96f9a5257307b88c784b8614b516a18111ce5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->