### PR TITLE
fix(ci): pin @types/node@20 in ts-compilation-test so TS 5.2-5.5 legs compile

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -173,7 +173,13 @@ jobs:
           cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
           cd ts-compilation-test
           npm install typescript@${{ matrix.tsVersion }} --no-cache
-          npm install @types/node --no-cache
+          # Pin @types/node to the major that matches this job's Node runtime
+          # (node-version: 20.x above). The unpinned "@types/node" pulled the
+          # latest major, whose iterator-helper types (IteratorObject,
+          # BuiltinIteratorReturn, ...) require TypeScript >= 5.6 and broke the
+          # TS 5.2-5.5 matrix legs. Pinning aligns the type defs with the Node
+          # version actually under test. See PIN-93 / pinecone-io#<tracking>.
+          npm install @types/node@20 --no-cache
           npm install '../pinecone-ts-client' --no-cache
           cat package.json
           cat package-lock.json

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -178,7 +178,7 @@ jobs:
           # latest major, whose iterator-helper types (IteratorObject,
           # BuiltinIteratorReturn, ...) require TypeScript >= 5.6 and broke the
           # TS 5.2-5.5 matrix legs. Pinning aligns the type defs with the Node
-          # version actually under test. See PIN-93 / pinecone-io#<tracking>.
+          # version actually under test. See #396.
           npm install @types/node@20 --no-cache
           npm install '../pinecone-ts-client' --no-cache
           cat package.json


### PR DESCRIPTION
Closes #396.

## Problem

The `TS compile` matrix in `.github/workflows/testing.yml` fails on the `~5.2.0`, `~5.3.0`, `~5.4.0`, and `~5.5.0` legs while passing on `~5.6.0`+/`latest`. This is currently red on open PRs #394 and #395 (and affects the matrix on any PR branched from `main`).

## Root cause

The `ts-compilation-test` step installs `@types/node` **unpinned**:

```yaml
npm install @types/node --no-cache
```

so it resolves to the latest major (currently 26.x). Recent `@types/node` ships iterator-helper types (`IteratorObject`, `AsyncIteratorObject`, `BuiltinIteratorReturn`) that require **TypeScript >= 5.6**. Under TS 5.2–5.5 the compiler can't resolve those names, so `tsc` errors out **inside `node_modules/@types/node`** — not in the Pinecone client code:

```
node_modules/@types/node/globals.d.ts: error TS2304: Cannot find name 'IteratorObject'.
node_modules/@types/node/url.d.ts:    error TS2304: Cannot find name 'BuiltinIteratorReturn'.
```

It's time-based: the leg went red only once `@types/node` published a major requiring newer TS, which is why older green runs exist alongside newer red ones.

## Fix

Pin `@types/node` to the major matching this job's Node runtime (the job runs `node-version: 20.x`):

```yaml
npm install @types/node@20 --no-cache
```

This aligns the ambient type definitions with the Node version actually under test and restores the older-TS compatibility guarantee for consumers. Older type defs compile cleanly under newer TS, so the 5.6+/`latest` legs stay green.

## Verification

Reproduced locally against this repo's `ts-compilation-test`:

| @types/node | TypeScript | `tsc` result |
|---|---|---|
| 26.1.1 (unpinned) | 5.2.2 | ❌ fails in `@types/node/*.d.ts` |
| 20.19.43 (pinned) | 5.2.2 | ✅ exit 0 |

Full CI matrix will confirm across all eight TS legs on this PR.

## Scope

CI-only change; no runtime/library code touched, non-breaking. Surfaced by the PR Feedback Autofix agent (PIN-93) while triaging failing checks on #394/#395.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no application or published package behavior is modified.
> 
> **Overview**
> The **TS compile** matrix job in `testing.yml` now installs **`@types/node@20`** instead of an unpinned `@types/node`, with inline comments explaining why.
> 
> Unpinned installs were resolving to a newer major whose iterator-helper typings require **TypeScript ≥ 5.6**, which caused `tsc` to fail inside `node_modules/@types/node` on the **5.2–5.5** matrix legs while **5.6+** stayed green. Pinning matches the job’s **Node 20.x** runtime and restores those older TypeScript legs without changing library code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bade787695bee0413526b44be3e3adf97d890a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Closes #396.