### PR TITLE
ci: pin @types/node to matching TS version in compile matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -173,7 +173,17 @@ jobs:
           cp -r pinecone-ts-client/ts-compilation-test ts-compilation-test
           cd ts-compilation-test
           npm install typescript@${{ matrix.tsVersion }} --no-cache
-          npm install @types/node --no-cache
+          # Install a @types/node build compatible with this TypeScript version.
+          # DefinitelyTyped publishes per-TS dist-tags (e.g. ts5.2); the unpinned
+          # 'latest' requires TS >= 5.6 and breaks the older matrix entries with
+          # errors like "Cannot find name 'IteratorObject'". Derive the tag from
+          # the matrix TS version, falling back to latest for newer/unknown tags.
+          TS_MINOR=$(echo "${{ matrix.tsVersion }}" | grep -oE '[0-9]+\.[0-9]+' || true)
+          if [ -n "$TS_MINOR" ] && npm install "@types/node@ts${TS_MINOR}" --no-cache; then
+            echo "Installed @types/node@ts${TS_MINOR}"
+          else
+            npm install @types/node --no-cache
+          fi
           npm install '../pinecone-ts-client' --no-cache
           cat package.json
           cat package-lock.json


### PR DESCRIPTION
## Problem

The `TS compile` matrix job (`ts-compilation-test`) runs `npm install @types/node` with **no version pin**, so it always installs the latest `@types/node`. Recent `@types/node` (>= 22.7) references lib types introduced in TypeScript 5.6 — `IteratorObject`, `AsyncIteratorObject`, `BuiltinIteratorReturn` — so `tsc` fails under the `~5.2.0`–`~5.5.0` matrix entries with errors such as:

```
node_modules/@types/node/globals.d.ts(136,69): error TS2304: Cannot find name 'IteratorObject'.
node_modules/@types/node/url.d.ts(549,69): error TS2304: Cannot find name 'BuiltinIteratorReturn'.
```

This is environmental — it fails on **every** open PR (e.g. #393, #394, #395) regardless of the PR's own changes, and only on TS < 5.6 (5.6/5.7/5.8/latest pass).

## Fix

Install the DefinitelyTyped per-TS dist-tag (e.g. `@types/node@ts5.5`) matching the matrix TypeScript version, falling back to `latest` for newer/unknown tags.

## Verification

Reproduced locally in `ts-compilation-test`:

| Setup | `@types/node` | `error TS` count |
|---|---|---|
| TS `~5.5.0` + unpinned (before) | 26.1.1 | **8** |
| TS `~5.5.0` + `@types/node@ts5.5` (after) | 25.9.3 | **0** |

(The only residual error in the sandbox was the un-installed local client, which real CI installs.)

Unblocks the TS compile checks on #393, #394, #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; no runtime or library code is modified.
> 
> **Overview**
> Fixes **TS compile** matrix failures on TypeScript **&lt; 5.6** caused by unpinned `@types/node` pulling typings that need newer compiler libs (`IteratorObject`, etc.).
> 
> The `typescript-compilation-tests` sample-app step now derives the matrix TS minor (e.g. `5.5` from `~5.5.0`), installs `@types/node@ts{minor}` when that dist-tag exists, and **falls back** to unpinned `@types/node` for `latest` or unknown tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60c38072f501d721df7c0e3b37e942854411975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->