### PR TITLE
ci: fix ts-compilation-test failure on TS ~5.2–~5.5 (skipLibCheck)

### DIFF
--- a/ts-compilation-test/tsconfig.json
+++ b/ts-compilation-test/tsconfig.json
@@ -5,6 +5,7 @@
     "noUnusedLocals": true,
     "outDir": "lib",
     "rootDir": "src",
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "target": "es2022",


### PR DESCRIPTION
Closes #396.

## Problem

The **TS compile** matrix (`testing.yml` → *install, compile, and run sample app*) fails on the `~5.2.0`, `~5.3.0`, `~5.4.0`, and `~5.5.0` legs on every PR. This is a pre-existing CI infrastructure failure, not caused by any feature PR.

Root cause: the step runs `npm install @types/node --no-cache`, which pulls the **latest** `@types/node` unconditionally. Recent `@types/node` releases ship declaration types (`IteratorObject`, `AsyncIteratorObject`, `BuiltinIteratorReturn`) that only exist in the TypeScript **5.6+** standard lib. Compiling the sample app under older TS therefore fails lib-check inside `node_modules/@types/node/*.d.ts`:

```
node_modules/@types/node/globals.d.ts: error TS2304: Cannot find name 'IteratorObject'.
node_modules/@types/node/url.d.ts:    error TS2304: Cannot find name 'BuiltinIteratorReturn'.
node_modules/@types/node/fs.d.ts:     error TS2416: Property '[Symbol.asyncIterator]' ... not assignable ...
```

The `~5.6.0`/`~5.7.0`/`~5.8.0`/`latest` legs pass, which confirms the sample app's own `src` is clean — the errors are exclusively in `@types/node`'s declaration files.

## Fix

Add `"skipLibCheck": true` to `ts-compilation-test/tsconfig.json`. This skips type-checking of `.d.ts` files (the standard remedy for cross-version `@types` mismatches) while still compiling and running the sample app's `src`. It is version-robust — no need to pin `@types/node` and chase it over time — and brings the older-TS legs in line with the behavior the 5.6+/latest legs already have.

## Verification

Reproduced in an isolated project with `typescript@5.2.2` + `@types/node@26.1.1` and the same tsconfig options:

- **without** `skipLibCheck`: same TS2304/TS2416 errors as CI, non-zero exit
- **with** `skipLibCheck`: exit 0

## Impact

Unblocks the TS-compile checks on all open ts-client PRs (#393, #394, #395) once they rebase onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI/sample-project compiler option; no runtime or library behavior change for the published client.
> 
> **Overview**
> **Enables the TS compile matrix** for older TypeScript legs (`~5.2`–`~5.5`) by turning on **`skipLibCheck`** in `ts-compilation-test/tsconfig.json`.
> 
> CI installs the latest `@types/node`, whose declarations assume TS 5.6+ lib types; without this flag, `tsc` fails inside `node_modules/@types/node` while the sample `src` is unchanged. Skipping `.d.ts` checking keeps full compile/typecheck of the app source across the version matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6e31683a37287d3d2fc42c988065cf51641b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->