### PR TITLE
ci: skipLibCheck in ts-compilation-test to fix TS matrix compile

### DIFF
--- a/ts-compilation-test/tsconfig.json
+++ b/ts-compilation-test/tsconfig.json
@@ -5,6 +5,7 @@
     "noUnusedLocals": true,
     "outDir": "lib",
     "rootDir": "src",
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "target": "es2022",


### PR DESCRIPTION
## Problem

The `testing / TS compile (~5.2.0 … ~5.5.0)` matrix jobs are red on **every** open PR — including config-only PRs like #393 (which touches only `.github/dependabot.yml`). That is the tell that the failure is not PR-specific but a shared breakage on `main`.

Root cause: the `install, compile, and run sample app` step in `.github/workflows/testing.yml` installs an **unpinned** `@types/node` (currently `26.x`). Its bundled lib definitions (`IteratorObject`, `BuiltinIteratorReturn`, updated `AsyncIterator` signatures) require **TS ≥ 5.6**, so `tsc` fails inside `node_modules/@types/node/*.d.ts` on the 5.2–5.5 matrix before the sample app's own code is ever checked.

Reproduced locally: `@types/node@26.1.1` + `typescript@5.2` → 8 errors in `@types/node` d.ts; adding `skipLibCheck` → exit 0.

## Fix

Enable `skipLibCheck` in `ts-compilation-test/tsconfig.json`. This skips type-checking of third-party `.d.ts` files while still fully type-checking the sample app against the client's published types — which is the actual purpose of this gate.

## Impact

Unblocks the TS-compile matrix on all currently-red PRs (#393, #394, #395, …). Rebase those onto `main` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only TypeScript config tweak with no runtime or library behavior change.
> 
> **Overview**
> Adds **`skipLibCheck: true`** to `ts-compilation-test/tsconfig.json` so the CI **TypeScript 5.2–5.5 compile matrix** no longer fails on errors inside **`node_modules/@types/node`** (unpinned installs can pull typings that need TS ≥ 5.6).
> 
> The gate still type-checks the sample app under `src` against the published client types; only third-party declaration files are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068c49143c338cfe4b91038132bb3a6ad7946df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->