### PR TITLE
chore(deps): combine Dependabot minor/patch bumps (#403, #406, #407, #413, #414)

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
       - name: Setup

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
       - name: Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     environment: npm-publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 

--- a/.github/workflows/testing-cleanup.yml
+++ b/.github/workflows/testing-cleanup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup
         uses: ./.github/actions/setup
       - name: Cleanup

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
       fixturesJson: ${{ steps.setup.outputs.FIXTURES_JSON }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: Setup bun
         if: matrix.config.bun_version
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ matrix.config.bun_version }}
 
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
@@ -169,11 +169,11 @@ jobs:
           ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
@@ -213,12 +213,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pinecone-ts-client
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
           path: pinecone-ts-client
       - name: Checkout semantic-search-example
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: pinecone-io/semantic-search-example
           ref: main
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
       "version": "8.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@edge-runtime/jest-environment": "^2.3.10",
-        "@edge-runtime/types": "^2.2.9",
+        "@edge-runtime/jest-environment": "^4.0.0",
+        "@edge-runtime/types": "^4.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "22.19.7",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
-        "dotenv": "^16.6.1",
+        "dotenv": "^17.4.2",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.32.0",
         "jest": "29.7",
         "jest-progress-bar-reporter": "^1.0.25",
         "prettier": "^3.4.2",
         "ts-jest": "^29.4.6",
-        "tsx": "^4.21.0",
-        "typedoc": "^0.27.9",
+        "tsx": "^4.23.1",
+        "typedoc": "^0.28.20",
         "typescript": "~5.6.3"
       },
       "engines": {
@@ -547,56 +547,56 @@
       "license": "MIT"
     },
     "node_modules/@edge-runtime/jest-environment": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/jest-environment/-/jest-environment-2.3.10.tgz",
-      "integrity": "sha512-wms2hveQV18DnWkiqzpjzIJ4SoD3+dXzuQ3/GAsklQDCGd4ClkREu5zCy0TFha0mR4I9tqi0DB8nD5Ldd/r1Pg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/jest-environment/-/jest-environment-4.0.0.tgz",
+      "integrity": "sha512-75bTOg+coJO0YRfwzlSzCxdNi7KRKcRBeCYSmnKrvYiS++iF2kif0TLL8oKu6Z70pcFO3ugC6AjOloLe0WxOzw==",
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "dependencies": {
-        "@edge-runtime/vm": "3.2.0",
+        "@edge-runtime/vm": "5.0.0",
         "@jest/environment": "29.5.0",
         "@jest/fake-timers": "29.5.0",
         "jest-mock": "29.5.0",
         "jest-util": "29.5.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@edge-runtime/primitives": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
-      "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-6.0.0.tgz",
+      "integrity": "sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==",
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@edge-runtime/types": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/types/-/types-2.2.9.tgz",
-      "integrity": "sha512-xhPxUwqnaro7YiHMu9ScI0GqSjEGY1tkAaP2nC+CsdKY+V9VsoaInSqOyz6kcnabNkR601/+SIwjKqG5r0RbJg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/types/-/types-4.0.0.tgz",
+      "integrity": "sha512-6HiX1oSir5R+X74IzM08fCQkR5mTcOxgfFVdn335jz/CckIHVFphh7hNkIcI+XsMYhAfWOJ5b8TfBU/Hbx1EIQ==",
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "dependencies": {
-        "@edge-runtime/primitives": "4.1.0"
+        "@edge-runtime/primitives": "6.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@edge-runtime/vm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
-      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-5.0.0.tgz",
+      "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "dependencies": {
-        "@edge-runtime/primitives": "4.1.0"
+        "@edge-runtime/primitives": "6.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1129,15 +1129,17 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
-      "integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^1.27.2",
-        "@shikijs/types": "^1.27.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1846,24 +1848,44 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
@@ -3209,9 +3231,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -8035,9 +8057,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8168,26 +8190,66 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.27.9",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.9.tgz",
-      "integrity": "sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==",
+      "version": "0.28.20",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.20.tgz",
+      "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^1.24.0",
+        "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
-        "markdown-it": "^14.1.0",
-        "minimatch": "^9.0.5",
-        "yaml": "^2.6.1"
+        "markdown-it": "^14.3.0",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18",
+        "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -38,21 +38,21 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@edge-runtime/jest-environment": "^2.3.10",
-    "@edge-runtime/types": "^2.2.9",
+    "@edge-runtime/jest-environment": "^4.0.0",
+    "@edge-runtime/types": "^4.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "22.19.7",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.4.2",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.32.0",
     "jest": "29.7",
     "jest-progress-bar-reporter": "^1.0.25",
     "prettier": "^3.4.2",
     "ts-jest": "^29.4.6",
-    "tsx": "^4.21.0",
-    "typedoc": "^0.27.9",
+    "tsx": "^4.23.1",
+    "typedoc": "^0.28.20",
     "typescript": "~5.6.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Combines five Dependabot PRs whose CI only failed because `PINECONE_API_KEY` is not exposed to Dependabot-triggered workflow runs (lint/build/unit/smoke were all green on each). Reopening them on a maintainer-authored branch lets the secret-gated jobs (TS compile, external-app, example app, integration) run and pass.

Supersedes and closes: #403, #406, #407, #413, #414.

### npm bumps
| Package | From → To | Supersedes |
|---------|-----------|------------|
| @edge-runtime/jest-environment | ^2.3.10 → ^4.0.0 | #413 |
| @edge-runtime/types | ^2.2.9 → ^4.0.0 | #407 |
| dotenv | ^16.6.1 → ^17.4.2 | #406 |
| tsx | ^4.21.0 → ^4.23.1 | #414 |
| typedoc | ^0.27.9 → ^0.28.20 | #414 |

(transitively: `@edge-runtime/vm` 3→5, `@edge-runtime/primitives` 4.1→6.0)

### GitHub Actions bumps (#403)
- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v7
- `oven-sh/setup-bun` v1 → v2

## Local verification
- ✅ `npm run build` (tsc) compiles
- ✅ `npm run lint` clean
- ✅ `npm run test:unit` — 574 passing
- ✅ `npm run docs:build` (typedoc 0.28) — 0 errors
- ✅ prettier — unchanged

## Not included
The remaining Dependabot PRs have genuine breakages and are intentionally left out: `typescript@7` (#408, blocked by ts-jest peer), `eslint@10` (#409), `@types/node@26` (#410, URLPattern conflict), `@typescript-eslint@8` parser/plugin (#411/#412, must be paired), and `jest`/`@types/jest` (#405, needs `toThrowError`→`toThrow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to devDependencies and GitHub Actions versions; the published package surface is unchanged.
> 
> **Overview**
> Bundles several safe Dependabot updates into one maintainer branch so secret-gated CI can run.
> 
> **CI:** All workflow checkouts move from `actions/checkout@v4` to **v7**; the TypeScript compile matrix uses `actions/setup-node@v7`; Bun integration legs use `oven-sh/setup-bun@v2` instead of v1.
> 
> **Dev dependencies:** `@edge-runtime/jest-environment` and `@edge-runtime/types` jump to **^4.0.0** (with newer `@edge-runtime/vm` / primitives for edge Jest runs). `dotenv` **^17.4.2**, `tsx` **^4.23.1**, and `typedoc` **^0.28.20** are bumped in `package.json` with matching `package-lock.json` changes—docs and integration tooling only, not the published SDK runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e7eb318100910b3b5a089fe8ea5e497d591fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->