### PR TITLE
chore(deps): bump @types/node to 26.1.1 (#410)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edge-runtime/jest-environment": "^4.0.0",
         "@edge-runtime/types": "^4.0.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "22.19.7",
+        "@types/node": "26.1.1",
         "@typescript-eslint/eslint-plugin": "^8.64.0",
         "@typescript-eslint/parser": "^8.64.0",
         "dotenv": "^17.4.2",
@@ -2919,13 +2919,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -10617,9 +10617,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@edge-runtime/jest-environment": "^4.0.0",
     "@edge-runtime/types": "^4.0.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "22.19.7",
+    "@types/node": "26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.64.0",
     "@typescript-eslint/parser": "^8.64.0",
     "dotenv": "^17.4.2",

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,3 +1,9 @@
+// `EdgeRuntime` is a global injected by the Vercel Edge Runtime. We declare it
+// locally rather than loading @edge-runtime/types into the global `types`,
+// because that package declares a `URLPattern` global that collides with the
+// one @types/node ships (TS2451).
+declare const EdgeRuntime: string | undefined;
+
 export const isEdge = () => {
   // This is the recommended way to detect
   // running in the Edge Runtime according

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node", "jest", "@edge-runtime/types"],
+    "types": ["node", "jest"],
     "noImplicitAny": false,
     "resolveJsonModule": true
   },


### PR DESCRIPTION
## Summary

Bumps `@types/node` `22.19.7` → `26.1.1` (major, but dev-only).

Supersedes and closes: #410.

## The fix

`@types/node@26` added a global `URLPattern` declaration that collides (`TS2451: Cannot redeclare block-scoped variable 'URLPattern'`) with the one `@edge-runtime/types` declares — and the main `src` build was loading `@edge-runtime/types` globally via tsconfig's `types` array.

`src/` only ever referenced **one** edge global (`EdgeRuntime`, in `src/utils/environment.ts`), so rather than suppressing the conflict with `skipLibCheck`, this removes the root cause:
- drop `@edge-runtime/types` from `tsconfig.json`'s `types` array
- declare `EdgeRuntime` locally in `environment.ts` (build-time ambient; verified it does **not** leak into the emitted `.d.ts`)

## Consumer impact: none

Dev-dependency only. The published `.d.ts` references stable Node symbols (`Buffer`, `Readable`, `NodeJS.ReadableStream`) that the consumer resolves against their own `@types/node`, and the bump doesn't change those references. Ships in a **minor/patch**.

## Local verification
- ✅ `npm run build` — URLPattern error resolved
- ✅ `npm run lint` — clean
- ✅ `npm run test:unit` — 574 passing
- ✅ smoke (mocked) — 2 passing
- ✅ edge integration suite still compiles & runs (removing edge types from tsconfig didn't break the edge lane)

## Note

`@edge-runtime/types` is now an unused direct devDependency; left in scope here, reasonable to drop in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f54d51c1b419bb668101dba861d53d6a74954f2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->