### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# Auto-requests review from the owners below on every pull request.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @pinecone-io/sdk


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so pull requests automatically request review from the appropriate owners.

Owners: `@pinecone-io/sdk`

Part of an org-wide rollout to ensure every public repo has code owners configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository governance only; no application, security, or deployment logic is modified.
> 
> **Overview**
> Adds **`.github/CODEOWNERS`** so GitHub automatically requests review from **`@pinecone-io/sdk`** on every pull request via the `*` path rule.
> 
> This is part of an org-wide rollout to ensure public repos have code owners configured; it does not change application code or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d1f7974f1805eea23c0fa80afa00d35da6cb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->